### PR TITLE
test: redefine AppBio Quantstudio get_model test to take into account calculated document references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Changed
 - Typing ignore tags are removed from the construction of AppBio Quantstudio structure
+- Redefinition of AppBio Quantstudio get model test to take into account calculated documents references
 
 ### Deprecated
 ### Removed

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_data.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_data.py
@@ -748,7 +748,7 @@ def get_model() -> Model:
             calculated_data_aggregate_document=TCalculatedDataAggregateDocument(
                 calculated_data_document=[
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="3bd75f5b-d108-485f-b658-4241b2799f11",
+                        calculated_data_identifier="d006e7e7-fbe4-47cf-821b-904e85202803",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
@@ -768,7 +768,7 @@ def get_model() -> Model:
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="c97a989a-464e-4776-8c50-cc42d7ecd01e",
+                        calculated_data_identifier="f4fee39c-5861-4203-afcf-94ee755ac0b4",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
@@ -788,7 +788,7 @@ def get_model() -> Model:
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="b41977c9-8da0-4dc7-891a-2834576a0823",
+                        calculated_data_identifier="e6707b0c-4494-412f-8a8e-ef51d01f25b3",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
@@ -808,7 +808,7 @@ def get_model() -> Model:
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="bd5f29a3-ad92-4e5c-8db9-9fdb6dec0f68",
+                        calculated_data_identifier="da78a225-2c34-40b3-b487-97893bfe491a",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_parser_test.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_parser_test.py
@@ -26,23 +26,6 @@ output_files = (
 VENDOR_TYPE = Vendor.APPBIO_QUANTSTUDIO
 
 
-def rm_measurement_identifier(model: Model) -> Model:
-    if model.qPCR_aggregate_document:
-        for qpcr_doc in model.qPCR_aggregate_document.qPCR_document:
-            for (
-                measurement_doc
-            ) in qpcr_doc.measurement_aggregate_document.measurement_document:
-                measurement_doc.measurement_identifier = ""
-
-        if model.qPCR_aggregate_document.calculated_data_aggregate_document:
-            for calc_doc in (
-                model.qPCR_aggregate_document.calculated_data_aggregate_document.calculated_data_document
-                or []
-            ):
-                calc_doc.calculated_data_identifier = ""
-    return model
-
-
 @pytest.mark.parametrize("output_file", output_files)
 def test_parse_appbio_quantstudio_to_asm_schema(output_file: str) -> None:
     test_filepath = f"tests/parsers/appbio_quantstudio/testdata/{output_file}.txt"
@@ -75,4 +58,4 @@ def test_parse_appbio_quantstudio_to_asm_contents(output_file: str) -> None:
 def test_get_model(file_name: str, data: Data, model: Model) -> None:
     parser = AppBioQuantStudioParser(TimestampParser())
     generated = parser._get_model(data, file_name)
-    assert rm_measurement_identifier(generated) == rm_measurement_identifier(model)
+    assert generated == model


### PR DESCRIPTION
- Redefine AppBio Quantstudio get_model test to take into account calculated document references