### PR TITLE
fix: handle unexpected section and comma as thousand separator in Appbio Quantstudio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calculated documents are introduced in the AppBio Quantstudio parser
 - Genotyping data structure test for AppBio Quantstudio parser
 ### Fixed
+- Ignore unexpected sections in AppBio Quantstudio input file
+- Accept comma as thousand indicator in AppBio Quantstudio results section
 ### Changed
 - Typing ignore tags are removed from the construction of AppBio Quantstudio structure
 - Redefinition of AppBio Quantstudio get model test to take into account calculated documents references

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_builders.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_builders.py
@@ -55,7 +55,7 @@ def get_int(data: pd.Series, key: str) -> Optional[int]:
 def get_float(data: pd.Series, key: str) -> Optional[float]:
     try:
         value = data.get(key)
-        return None if value is None else float(value)  # type: ignore[arg-type]
+        return float_or_none(value)
     except Exception as e:
         msg = f"Unable to convert {key} to float value"
         raise AllotropeConversionError(msg) from e
@@ -544,7 +544,7 @@ class ResultsBuilder:
         reader.pop()  # remove title
         data_lines = list(reader.pop_until_empty())
         csv_stream = StringIO("\n".join(data_lines))
-        data = pd.read_csv(csv_stream, sep="\t").replace(np.nan, None)
+        data = pd.read_csv(csv_stream, sep="\t", thousands=r",").replace(np.nan, None)
 
         reader.drop_empty()
 

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_builders.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_builders.py
@@ -284,7 +284,7 @@ class WellBuilder:
 
     @staticmethod
     def get_data(reader: LinesReader) -> pd.DataFrame:
-        if not reader.match(r"^\[Sample Setup\]"):
+        if reader.drop_until(r"^\[Sample Setup\]") is None:
             msg = "Unable to find Sample Setup section in input file"
             raise AllotropeConversionError(msg)
 
@@ -341,7 +341,7 @@ class AmplificationDataBuilder:
 
     @staticmethod
     def get_data(reader: LinesReader) -> pd.DataFrame:
-        if not reader.match(r"^\[Amplification Data\]"):
+        if reader.drop_until(r"^\[Amplification Data\]") is None:
             msg = "Unable to find Amplification Data section in input file"
             raise AllotropeConversionError(msg)
 
@@ -537,7 +537,7 @@ class ResultsBuilder:
 
     @staticmethod
     def get_data(reader: LinesReader) -> tuple[pd.DataFrame, pd.Series]:
-        if not reader.match(r"^\[Results\]"):
+        if reader.drop_until(r"^\[Results\]") is None:
             msg = "Unable to find Results section in input file"
             raise AllotropeConversionError(msg)
 


### PR DESCRIPTION
- Ignore unexpected sections in AppBio Quantstudio input file
- Accept comma as thousand indicator in AppBio Quantstudio results section