### PR TITLE
chore: Corrected dPCR json schema

### DIFF
--- a/src/allotropy/allotrope/schemas/pcr/BENCHLING/2023/09/dpcr.json
+++ b/src/allotropy/allotrope/schemas/pcr/BENCHLING/2023/09/dpcr.json
@@ -430,7 +430,6 @@
                                 "$asm.property-class": "http://purl.allotrope.org/ontologies/result#AFR_0002659",
                                 "$asm.pattern": "aggregate datum",
                                 "required": [
-                                  "data processing document",
                                   "number concentration",
                                   "positive partition count"
                                 ],
@@ -555,11 +554,11 @@
                     "$asm.type": "http://www.w3.org/2001/XMLSchema#string",
                     "$ref": "#/$defs/tStringValue"
                   },
-                  "reference sample description": {
+                  "reference DNA copy number setting": {
                     "$asm.property-class": "TODO",
                     "$asm.pattern": "value datum",
-                    "$asm.type": "http://www.w3.org/2001/XMLSchema#string",
-                    "$ref": "#/$defs/tStringValue"
+                    "$asm.pattern": "quantity datum",
+                    "$ref": "#/$custom/tQuantityValueNumber"
                   }
                 }
               },


### PR DESCRIPTION
removed data processing document as being required for processed data document

updated 'reference sample description' to 'reference DNA copy number setting' within the data processing document for the calculated data document.