### PR TITLE
Rename 'fix' to 'fmt' to match Hatch default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ style = [
   "black --check --diff {args:.}",
   "flake8 .",
 ]
-fix = [
+fmt = [
   "black {args:.}",
   "ruff --fix {args:.}",
   "style",


### PR DESCRIPTION
"Fix" may be more self-evidently named, but better to stick with Hatch default command keyword, especially given that all other `lint` commands use the default keywords.

Note that CI checks run `hatch run lint:all`, which does not run `fmt` but `style`.