### PR TITLE
fix: Allow fuzzy timestamps in timestamp parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Fixed
+- Use fuzzy=True for timestamp parsing to handle non-standard cases (e.g. mixing 24h time and AM/PM)
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/allotropy/parsers/utils/timestamp_parser.py
+++ b/src/allotropy/parsers/utils/timestamp_parser.py
@@ -32,7 +32,7 @@ class TimestampParser:
         if not time:
             return None
         try:
-            timestamp = parser.parse(time, tzinfos=TIMEZONE_CODES_MAP)
+            timestamp = parser.parse(time, tzinfos=TIMEZONE_CODES_MAP, fuzzy=True)
         except ValueError:
             return None
         if not timestamp.tzinfo:

--- a/tests/parsers/utils/timestamp_parser_test.py
+++ b/tests/parsers/utils/timestamp_parser_test.py
@@ -61,3 +61,8 @@ def test_timestamp_parser_provided_timezone(
 @pytest.mark.parametrize("time_str", ["blah"])
 def test_timestamp_parser_returns_none_on_invalid_timestamp(time_str: str) -> None:
     assert TimestampParser().parse(time_str) is None
+
+
+@pytest.mark.short
+def test_timestamp_parser_handles_24h_pm() -> None:
+    assert TimestampParser().parse("2023-03-16 16:52:37 PM") == "2023-03-16T16:52:37+00:00"

--- a/tests/parsers/utils/timestamp_parser_test.py
+++ b/tests/parsers/utils/timestamp_parser_test.py
@@ -65,4 +65,6 @@ def test_timestamp_parser_returns_none_on_invalid_timestamp(time_str: str) -> No
 
 @pytest.mark.short
 def test_timestamp_parser_handles_24h_pm() -> None:
-    assert TimestampParser().parse("2023-03-16 16:52:37 PM") == "2023-03-16T16:52:37+00:00"
+    assert (
+        TimestampParser().parse("2023-03-16 16:52:37 PM") == "2023-03-16T16:52:37+00:00"
+    )


### PR DESCRIPTION
Motivation: we see this in some instrument files we are currently handling, so we know it happens and we would like to handle it. This does not risk mis-handling correct timestamps, just increases chance we'll handle non-correct timestamps.