### PR TITLE
Don't run flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,6 @@ dependencies = [
   # black pinned for compatability with datamodel-code-generator
   "black == 22.3.0",
   "datamodel-code-generator >= 0.21.5",
-  "flake8 >= 6.1.0",
   # Without jsonschema-spec and pydantic, pydantic spews a bunch of errors when parsing schemas
   "jsonschema-specifications >= 2023.7.1",
   "pydantic == 1.10.9",
@@ -117,7 +116,6 @@ typing = "mypy --install-types --non-interactive {args:src/allotropy tests}"
 style = [
   "ruff {args:.}",
   "black --check --diff {args:.}",
-  "flake8 .",
 ]
 fmt = [
   "black {args:.}",


### PR DESCRIPTION
[Ruff has drop-in parity with flake8](https://docs.astral.sh/ruff/), and we run ruff, so don't run flake8. (It's much slower than ruff.)