### PR TITLE
Pin cattrs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-  "cattrs >= 23.0.0",
+  "cattrs == 23.0.0",
   "chardet >= 5.2.0",
   "jsonschema >= 4.17.0",
   "numpy >= 1.25.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-  "cattrs == 23.0.0",
+  "cattrs == 23.1.2",
   "chardet >= 5.2.0",
   "jsonschema >= 4.17.0",
   "numpy >= 1.25.0",
@@ -105,7 +105,7 @@ generate-schemas = "scripts/generate_schemas.py"
 [tool.hatch.envs.lint]
 extra-dependencies = [
   # mypy sometimes can't find cattrs even though it's a project depenedency, so add explicitly here.
-  "cattrs >= 23.0.0",
+  "cattrs == 23.1.2",
   "mypy >= 1.6.0",
   # For pytest types
   "pytest >= 7.4.0",


### PR DESCRIPTION
Pin cattrs to 23.1.2, the latest version released before today. Updating to 23.2.0 should be done carefully as there are some potentially breaking changes called out in release notes:
https://catt.rs/en/latest/history.html#history

(not to mention upgrading requires at least one type suppression or code change, and checks on all open PRs are currently failing)