### PR TITLE
Add generics to vi_cell_blu_reader

### DIFF
--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 from typing import Any
 

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
@@ -1,5 +1,3 @@
-# mypy: disallow_any_generics = False
-
 import io
 from typing import Any
 
@@ -19,7 +17,7 @@ def convert_int(x: pd.Series[Any]) -> pd.Series[int]:
     return pd.to_numeric(x, errors="coerce")
 
 
-def convert_string(x: pd.Series) -> pd.Series[str]:
+def convert_string(x: pd.Series[Any]) -> pd.Series[str]:
     return x.astype(str)
 
 
@@ -56,7 +54,7 @@ class ViCellBluReader:
     def read(cls, contents: io.IOBase) -> pd.DataFrame:
         raw_data = pd.read_csv(contents, index_col=False)  # type: ignore[call-overload]
 
-        columns: list[pd.Series] = []
+        columns: list[pd.Series[Any]] = []
         for column, desired_type in desired_columns.items():
             col = raw_data.get(column)
             if not isinstance(col, pd.Series):

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
@@ -1,24 +1,25 @@
 # mypy: disallow_any_generics = False
 
 import io
+from typing import Any
 
 import numpy as np
 import pandas as pd
 
 
-def convert_datetime(x: pd.Series) -> pd.Series:
+def convert_datetime(x: pd.Series[Any]) -> pd.Series[str]:
     return pd.to_datetime(x).dt.strftime("%Y-%m-%d %H:%M:%S")
 
 
-def convert_float(x: pd.Series) -> pd.Series:
+def convert_float(x: pd.Series[Any]) -> pd.Series[float]:
     return pd.to_numeric(x, errors="coerce")
 
 
-def convert_int(x: pd.Series) -> pd.Series:
+def convert_int(x: pd.Series[Any]) -> pd.Series[int]:
     return pd.to_numeric(x, errors="coerce")
 
 
-def convert_string(x: pd.Series) -> pd.Series:
+def convert_string(x: pd.Series) -> pd.Series[str]:
     return x.astype(str)
 
 
@@ -64,6 +65,6 @@ class ViCellBluReader:
             new_col = (
                 col if col.dtype == desired_type else conversors[desired_type](col)
             )
-            columns.append(new_col)
+            columns.append(new_col)  # type: ignore [arg-type]
 
         return pd.concat(columns, axis=1).replace(np.nan, None)

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
@@ -1,23 +1,22 @@
 import io
-from typing import Any
 
 import numpy as np
 import pandas as pd
 
 
-def convert_datetime(x: pd.Series[Any]) -> pd.Series[str]:
+def convert_datetime(x: pd.Series[np.dtypes.ObjectDType]) -> pd.Series[str]:
     return pd.to_datetime(x).dt.strftime("%Y-%m-%d %H:%M:%S")
 
 
-def convert_float(x: pd.Series[Any]) -> pd.Series[float]:
+def convert_float(x: pd.Series[np.dtypes.ObjectDType]) -> pd.Series[float]:
     return pd.to_numeric(x, errors="coerce")
 
 
-def convert_int(x: pd.Series[Any]) -> pd.Series[int]:
+def convert_int(x: pd.Series[np.dtypes.ObjectDType]) -> pd.Series[int]:
     return pd.to_numeric(x, errors="coerce")
 
 
-def convert_string(x: pd.Series[Any]) -> pd.Series[str]:
+def convert_string(x: pd.Series[np.dtypes.ObjectDType]) -> pd.Series[str]:
     return x.astype(str)
 
 
@@ -54,15 +53,15 @@ class ViCellBluReader:
     def read(cls, contents: io.IOBase) -> pd.DataFrame:
         raw_data = pd.read_csv(contents, index_col=False)  # type: ignore[call-overload]
 
-        columns: list[pd.Series[Any]] = []
+        columns: list[pd.Series[np.dtypes.ObjectDType]] = []
         for column, desired_type in desired_columns.items():
             col = raw_data.get(column)
             if not isinstance(col, pd.Series):
                 continue
 
             new_col = (
-                col if col.dtype == desired_type else conversors[desired_type](col)
+                col if col.dtype == desired_type else conversors[desired_type](col)  # type: ignore[arg-type]
             )
-            columns.append(new_col)  # type: ignore [arg-type]
+            columns.append(new_col)  # type: ignore[arg-type]
 
         return pd.concat(columns, axis=1).replace(np.nan, None)

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
@@ -1,22 +1,23 @@
 import io
+from typing import Any
 
 import numpy as np
 import pandas as pd
 
 
-def convert_datetime(x: pd.Series[np.dtypes.ObjectDType]) -> pd.Series[str]:
+def convert_datetime(x: pd.Series[Any]) -> pd.Series[str]:
     return pd.to_datetime(x).dt.strftime("%Y-%m-%d %H:%M:%S")
 
 
-def convert_float(x: pd.Series[np.dtypes.ObjectDType]) -> pd.Series[float]:
+def convert_float(x: pd.Series[Any]) -> pd.Series[float]:
     return pd.to_numeric(x, errors="coerce")
 
 
-def convert_int(x: pd.Series[np.dtypes.ObjectDType]) -> pd.Series[int]:
+def convert_int(x: pd.Series[Any]) -> pd.Series[int]:
     return pd.to_numeric(x, errors="coerce")
 
 
-def convert_string(x: pd.Series[np.dtypes.ObjectDType]) -> pd.Series[str]:
+def convert_string(x: pd.Series[Any]) -> pd.Series[str]:
     return x.astype(str)
 
 
@@ -53,15 +54,15 @@ class ViCellBluReader:
     def read(cls, contents: io.IOBase) -> pd.DataFrame:
         raw_data = pd.read_csv(contents, index_col=False)  # type: ignore[call-overload]
 
-        columns: list[pd.Series[np.dtypes.ObjectDType]] = []
+        columns: list[pd.Series[Any]] = []
         for column, desired_type in desired_columns.items():
             col = raw_data.get(column)
             if not isinstance(col, pd.Series):
                 continue
 
             new_col = (
-                col if col.dtype == desired_type else conversors[desired_type](col)  # type: ignore[arg-type]
+                col if col.dtype == desired_type else conversors[desired_type](col)
             )
-            columns.append(new_col)  # type: ignore[arg-type]
+            columns.append(new_col)  # type: ignore [arg-type]
 
         return pd.concat(columns, axis=1).replace(np.nan, None)


### PR DESCRIPTION
Note that `Series` does not have generics in src but does in stubs, so `from __future__ import annotations` is needed:
https://stackoverflow.com/questions/75452897/adding-generic-typing-to-function-signature-with-pandas-series-results-in-type