### PR TITLE
Extract ContentsType

### DIFF
--- a/scripts/convert_weyland_yutani_to_dataframe.py
+++ b/scripts/convert_weyland_yutani_to_dataframe.py
@@ -4,15 +4,13 @@
 
 import argparse
 import sys
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 import pandas as pd
 
 from allotropy.parser_factory import Vendor
 from allotropy.to_allotrope import allotrope_model_from_io
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 def main() -> None:

--- a/scripts/convert_weyland_yutani_to_dataframe.py
+++ b/scripts/convert_weyland_yutani_to_dataframe.py
@@ -3,7 +3,6 @@
 """Convert Weyland-Yutani data to dataframe."""
 
 import argparse
-from io import IOBase
 import sys
 from typing import Any
 
@@ -11,6 +10,7 @@ import pandas as pd
 
 from allotropy.parser_factory import Vendor
 from allotropy.to_allotrope import allotrope_model_from_io
+from allotropy.types import ContentsType
 
 
 def main() -> None:
@@ -33,7 +33,7 @@ def extract_well_data(model: Any) -> list[Any]:
     ]
 
 
-def handle(filename: str, reader: IOBase) -> None:
+def handle(filename: str, reader: ContentsType) -> None:
     """Extract and show data from a single model."""
     try:
         model = allotrope_model_from_io(reader, filename, Vendor.EXAMPLE_WEYLAND_YUTANI)

--- a/scripts/convert_weyland_yutani_to_dataframe.py
+++ b/scripts/convert_weyland_yutani_to_dataframe.py
@@ -4,13 +4,15 @@
 
 import argparse
 import sys
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import pandas as pd
 
 from allotropy.parser_factory import Vendor
 from allotropy.to_allotrope import allotrope_model_from_io
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 def main() -> None:

--- a/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
+++ b/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Any, TYPE_CHECKING, Union
+from typing import Any, Union
 import uuid
 
 from allotropy.allotrope.allotrope import AllotropeConversionError
@@ -24,9 +24,7 @@ from allotropy.parsers.agilent_gen5.constants import ReadMode
 from allotropy.parsers.agilent_gen5.plate_data import PlateData
 from allotropy.parsers.agilent_gen5.section_reader import SectionLinesReader
 from allotropy.parsers.vendor_parser import VendorParser
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 class AgilentGen5Parser(VendorParser):

--- a/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
+++ b/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
@@ -1,4 +1,3 @@
-import io
 import itertools
 from typing import Any, Union
 import uuid
@@ -25,6 +24,7 @@ from allotropy.parsers.agilent_gen5.constants import ReadMode
 from allotropy.parsers.agilent_gen5.plate_data import PlateData
 from allotropy.parsers.agilent_gen5.section_reader import SectionLinesReader
 from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.types import ContentsType
 
 
 class AgilentGen5Parser(VendorParser):
@@ -86,7 +86,7 @@ class AgilentGen5Parser(VendorParser):
         msg = f"Unrecognized read mode: {first_plate.plate_type.read_mode}"
         raise AllotropeConversionError(msg)
 
-    def _parse(self, contents: io.IOBase, filename: str) -> Any:  # noqa: ARG002
+    def _parse(self, contents: ContentsType, filename: str) -> Any:  # noqa: ARG002
         section_lines_reader = SectionLinesReader(contents, encoding=None)
         data = Data.create(section_lines_reader)
 

--- a/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
+++ b/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Any, Union
+from typing import Any, TYPE_CHECKING, Union
 import uuid
 
 from allotropy.allotrope.allotrope import AllotropeConversionError
@@ -24,7 +24,9 @@ from allotropy.parsers.agilent_gen5.constants import ReadMode
 from allotropy.parsers.agilent_gen5.plate_data import PlateData
 from allotropy.parsers.agilent_gen5.section_reader import SectionLinesReader
 from allotropy.parsers.vendor_parser import VendorParser
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 class AgilentGen5Parser(VendorParser):

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from io import IOBase
 from typing import Any
 import uuid
 
@@ -42,10 +41,11 @@ from allotropy.parsers.appbio_absolute_q.constants import (
     CalculatedDataSource,
 )
 from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.types import ContentsType
 
 
 class AppbioAbsoluteQParser(VendorParser):
-    def _parse(self, raw_contents: IOBase, filename: str) -> Model:
+    def _parse(self, raw_contents: ContentsType, filename: str) -> Model:
         reader = AbsoluteQReader(raw_contents)
         return self._get_model(reader.wells, reader.group_rows, filename)
 

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, TYPE_CHECKING
+from typing import Any
 import uuid
 
 import pandas as pd
@@ -41,9 +41,7 @@ from allotropy.parsers.appbio_absolute_q.constants import (
     CalculatedDataSource,
 )
 from allotropy.parsers.vendor_parser import VendorParser
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 class AppbioAbsoluteQParser(VendorParser):

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any
+from typing import Any, TYPE_CHECKING
 import uuid
 
 import pandas as pd
@@ -41,7 +41,9 @@ from allotropy.parsers.appbio_absolute_q.constants import (
     CalculatedDataSource,
 )
 from allotropy.parsers.vendor_parser import VendorParser
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 class AppbioAbsoluteQParser(VendorParser):

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_reader.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_reader.py
@@ -1,10 +1,7 @@
-from typing import TYPE_CHECKING
-
 import numpy as np
 import pandas as pd
 
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 class AbsoluteQReader:

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_reader.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_reader.py
@@ -1,7 +1,10 @@
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas as pd
 
-from allotropy.types import ContentsType
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 class AbsoluteQReader:

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_reader.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_reader.py
@@ -1,11 +1,11 @@
-from io import IOBase
-
 import numpy as np
 import pandas as pd
 
+from allotropy.types import ContentsType
+
 
 class AbsoluteQReader:
-    def __init__(self, contents: IOBase):
+    def __init__(self, contents: ContentsType):
         absolute_q_data = pd.read_csv(  # type: ignore[call-overload]
             filepath_or_buffer=contents, parse_dates=["Date"]
         ).replace(np.nan, None)

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
@@ -1,4 +1,3 @@
-from io import IOBase
 from typing import Optional
 
 from allotropy.allotrope.models.pcr_benchling_2023_09_qpcr import (
@@ -50,10 +49,11 @@ from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_structure import (
 )
 from allotropy.parsers.lines_reader import LinesReader
 from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.types import ContentsType
 
 
 class AppBioQuantStudioParser(VendorParser):
-    def _parse(self, raw_contents: IOBase, file_name: str) -> Model:
+    def _parse(self, raw_contents: ContentsType, file_name: str) -> Model:
         reader = LinesReader(raw_contents)
         data = DataBuilder.build(reader)
         return self._get_model(data, file_name)

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from allotropy.allotrope.models.pcr_benchling_2023_09_qpcr import (
     BaselineCorrectedReporterDataCube,
@@ -49,7 +49,9 @@ from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_structure import (
 )
 from allotropy.parsers.lines_reader import LinesReader
 from allotropy.parsers.vendor_parser import VendorParser
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 class AppBioQuantStudioParser(VendorParser):

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
@@ -1,4 +1,4 @@
-from typing import Optional, TYPE_CHECKING
+from typing import Optional
 
 from allotropy.allotrope.models.pcr_benchling_2023_09_qpcr import (
     BaselineCorrectedReporterDataCube,
@@ -49,9 +49,7 @@ from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_structure import (
 )
 from allotropy.parsers.lines_reader import LinesReader
 from allotropy.parsers.vendor_parser import VendorParser
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 class AppBioQuantStudioParser(VendorParser):

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
@@ -1,6 +1,5 @@
 # mypy: disallow_any_generics = False
 
-import io
 from typing import Any
 import uuid
 
@@ -36,6 +35,7 @@ from allotropy.parsers.beckman_vi_cell_blu.constants import (
 )
 from allotropy.parsers.beckman_vi_cell_blu.vi_cell_blu_reader import ViCellBluReader
 from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.types import ContentsType
 
 property_lookup = {
     "Average viable diameter (μm)": TQuantityValueMicrometer,
@@ -58,7 +58,7 @@ def get_property_from_sample(sample: pd.Series, property_name: str) -> Any:
 
 
 class ViCellBluParser(VendorParser):
-    def _parse(self, contents: io.IOBase, filename: str) -> Model:
+    def _parse(self, contents: ContentsType, filename: str) -> Model:
         return self._get_model(ViCellBluReader.read(contents), filename)
 
     def _get_model(self, data: pd.DataFrame, filename: str) -> Model:

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
@@ -1,6 +1,6 @@
 # mypy: disallow_any_generics = False
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 import uuid
 
 import pandas as pd
@@ -35,7 +35,9 @@ from allotropy.parsers.beckman_vi_cell_blu.constants import (
 )
 from allotropy.parsers.beckman_vi_cell_blu.vi_cell_blu_reader import ViCellBluReader
 from allotropy.parsers.vendor_parser import VendorParser
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 property_lookup = {
     "Average viable diameter (μm)": TQuantityValueMicrometer,

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
@@ -1,6 +1,6 @@
 # mypy: disallow_any_generics = False
 
-from typing import Any, TYPE_CHECKING
+from typing import Any
 import uuid
 
 import pandas as pd
@@ -35,9 +35,7 @@ from allotropy.parsers.beckman_vi_cell_blu.constants import (
 )
 from allotropy.parsers.beckman_vi_cell_blu.vi_cell_blu_reader import ViCellBluReader
 from allotropy.parsers.vendor_parser import VendorParser
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 property_lookup = {
     "Average viable diameter (μm)": TQuantityValueMicrometer,

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
@@ -1,9 +1,10 @@
 # mypy: disallow_any_generics = False
 
-import io
 
 import numpy as np
 import pandas as pd
+
+from allotropy.types import ContentsType
 
 
 def convert_datetime(x: pd.Series) -> pd.Series:
@@ -52,7 +53,7 @@ desired_columns = {
 
 class ViCellBluReader:
     @classmethod
-    def read(cls, contents: io.IOBase) -> pd.DataFrame:
+    def read(cls, contents: ContentsType) -> pd.DataFrame:
         raw_data = pd.read_csv(contents, index_col=False)  # type: ignore[call-overload]
 
         columns: list[pd.Series] = []

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
@@ -1,11 +1,10 @@
 # mypy: disallow_any_generics = False
-from typing import TYPE_CHECKING
+
 
 import numpy as np
 import pandas as pd
 
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 def convert_datetime(x: pd.Series) -> pd.Series:

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_reader.py
@@ -1,10 +1,11 @@
 # mypy: disallow_any_generics = False
-
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 
-from allotropy.types import ContentsType
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 def convert_datetime(x: pd.Series) -> pd.Series:

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
@@ -1,6 +1,5 @@
 # mypy: disallow_any_generics = False
 
-import io
 from typing import Any, Optional
 import uuid
 
@@ -39,6 +38,7 @@ from allotropy.parsers.beckman_vi_cell_xr.constants import (
 )
 from allotropy.parsers.beckman_vi_cell_xr.vi_cell_xr_reader import ViCellXRReader
 from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.types import ContentsType
 
 property_lookup = {
     "Dilution factor": TQuantityValueUnitless,
@@ -54,7 +54,7 @@ def get_property_from_sample(sample: pd.Series, property_name: str) -> Any:
 
 
 class ViCellXRParser(VendorParser):
-    def _parse(self, contents: io.IOBase, filename: str) -> Model:
+    def _parse(self, contents: ContentsType, filename: str) -> Model:
         reader = ViCellXRReader(contents)
 
         return Model(

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
@@ -1,6 +1,6 @@
 # mypy: disallow_any_generics = False
 
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 import uuid
 
 import pandas as pd
@@ -38,7 +38,9 @@ from allotropy.parsers.beckman_vi_cell_xr.constants import (
 )
 from allotropy.parsers.beckman_vi_cell_xr.vi_cell_xr_reader import ViCellXRReader
 from allotropy.parsers.vendor_parser import VendorParser
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 property_lookup = {
     "Dilution factor": TQuantityValueUnitless,

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
@@ -1,6 +1,6 @@
 # mypy: disallow_any_generics = False
 
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional
 import uuid
 
 import pandas as pd
@@ -38,9 +38,7 @@ from allotropy.parsers.beckman_vi_cell_xr.constants import (
 )
 from allotropy.parsers.beckman_vi_cell_xr.vi_cell_xr_reader import ViCellXRReader
 from allotropy.parsers.vendor_parser import VendorParser
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 property_lookup = {
     "Dilution factor": TQuantityValueUnitless,

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_reader.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_reader.py
@@ -1,7 +1,6 @@
 # mypy: disallow_any_generics = False
 
 import re
-from typing import TYPE_CHECKING
 
 import pandas as pd
 
@@ -11,9 +10,7 @@ from allotropy.parsers.beckman_vi_cell_xr.constants import (
     MODEL_RE,
     XrVersion,
 )
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 class ViCellXRReader:

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_reader.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_reader.py
@@ -1,6 +1,7 @@
 # mypy: disallow_any_generics = False
 
 import re
+from typing import TYPE_CHECKING
 
 import pandas as pd
 
@@ -10,7 +11,9 @@ from allotropy.parsers.beckman_vi_cell_xr.constants import (
     MODEL_RE,
     XrVersion,
 )
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 class ViCellXRReader:

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_reader.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_reader.py
@@ -1,6 +1,5 @@
 # mypy: disallow_any_generics = False
 
-from io import IOBase
 import re
 
 import pandas as pd
@@ -11,10 +10,11 @@ from allotropy.parsers.beckman_vi_cell_xr.constants import (
     MODEL_RE,
     XrVersion,
 )
+from allotropy.types import ContentsType
 
 
 class ViCellXRReader:
-    def __init__(self, contents: IOBase) -> None:
+    def __init__(self, contents: ContentsType) -> None:
         self.contents = contents
         self.file_info = self._get_file_info()
         self.file_version = self._get_file_version()

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
@@ -1,4 +1,3 @@
-from typing import TYPE_CHECKING
 import uuid
 
 from allotropy.allotrope.allotrope import AllotropyError
@@ -25,9 +24,7 @@ from allotropy.parsers.example_weyland_yutani.example_weyland_yutani_structure i
 )
 from allotropy.parsers.lines_reader import CsvReader
 from allotropy.parsers.vendor_parser import VendorParser
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 class ExampleWeylandYutaniParser(VendorParser):

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 import uuid
 
 from allotropy.allotrope.allotrope import AllotropyError
@@ -24,7 +25,9 @@ from allotropy.parsers.example_weyland_yutani.example_weyland_yutani_structure i
 )
 from allotropy.parsers.lines_reader import CsvReader
 from allotropy.parsers.vendor_parser import VendorParser
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 class ExampleWeylandYutaniParser(VendorParser):

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
@@ -1,4 +1,3 @@
-from io import IOBase
 import uuid
 
 from allotropy.allotrope.allotrope import AllotropyError
@@ -25,10 +24,11 @@ from allotropy.parsers.example_weyland_yutani.example_weyland_yutani_structure i
 )
 from allotropy.parsers.lines_reader import CsvReader
 from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.types import ContentsType
 
 
 class ExampleWeylandYutaniParser(VendorParser):
-    def _parse(self, raw_contents: IOBase, _: str) -> Model:
+    def _parse(self, raw_contents: ContentsType, _: str) -> Model:
         reader = CsvReader(raw_contents)
         return self._get_model(Data.create(reader))
 

--- a/src/allotropy/parsers/lines_reader.py
+++ b/src/allotropy/parsers/lines_reader.py
@@ -1,7 +1,7 @@
 # mypy: disallow_any_generics = False
 
 from collections.abc import Iterator
-from io import IOBase, StringIO
+from io import StringIO
 from re import search
 from typing import Optional
 
@@ -9,6 +9,7 @@ import chardet
 import pandas as pd
 
 from allotropy.allotrope.allotrope import AllotropyError
+from allotropy.types import ContentsType
 
 EMPTY_STR_PATTERN = r"^\s*$"
 
@@ -23,7 +24,7 @@ def _decode(bytes_content: bytes, encoding: Optional[str]) -> str:
 
 
 class LinesReader:
-    def __init__(self, io_: IOBase, encoding: Optional[str] = "UTF-8"):
+    def __init__(self, io_: ContentsType, encoding: Optional[str] = "UTF-8"):
         stream_contents = io_.read()
         self.raw_contents = (
             _decode(stream_contents, encoding)

--- a/src/allotropy/parsers/lines_reader.py
+++ b/src/allotropy/parsers/lines_reader.py
@@ -3,15 +3,13 @@
 from collections.abc import Iterator
 from io import StringIO
 from re import search
-from typing import Optional, TYPE_CHECKING
+from typing import Optional
 
 import chardet
 import pandas as pd
 
 from allotropy.allotrope.allotrope import AllotropyError
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 EMPTY_STR_PATTERN = r"^\s*$"
 

--- a/src/allotropy/parsers/lines_reader.py
+++ b/src/allotropy/parsers/lines_reader.py
@@ -3,13 +3,15 @@
 from collections.abc import Iterator
 from io import StringIO
 from re import search
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import chardet
 import pandas as pd
 
 from allotropy.allotrope.allotrope import AllotropyError
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 EMPTY_STR_PATTERN = r"^\s*$"
 

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
@@ -1,9 +1,11 @@
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from allotropy.parsers.lines_reader import LinesReader
 from allotropy.parsers.moldev_softmax_pro.softmax_pro_structure import Data
 from allotropy.parsers.vendor_parser import VendorParser
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 class SoftmaxproParser(VendorParser):

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
@@ -1,11 +1,9 @@
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 from allotropy.parsers.lines_reader import LinesReader
 from allotropy.parsers.moldev_softmax_pro.softmax_pro_structure import Data
 from allotropy.parsers.vendor_parser import VendorParser
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 class SoftmaxproParser(VendorParser):

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
@@ -1,13 +1,13 @@
-import io
 from typing import Any
 
 from allotropy.parsers.lines_reader import LinesReader
 from allotropy.parsers.moldev_softmax_pro.softmax_pro_structure import Data
 from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.types import ContentsType
 
 
 class SoftmaxproParser(VendorParser):
-    def _parse(self, contents: io.IOBase, filename: str) -> Any:  # noqa: ARG002
+    def _parse(self, contents: ContentsType, filename: str) -> Any:  # noqa: ARG002
         lines_reader = LinesReader(contents)
         data = Data.create(lines_reader)
         return self._get_model(data)

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 import uuid
 
 from allotropy.allotrope.models.cell_culture_analyzer_benchling_2023_09_cell_culture_analyzer import (
@@ -11,7 +12,9 @@ from allotropy.allotrope.models.cell_culture_analyzer_benchling_2023_09_cell_cul
 )
 from allotropy.parsers.novabio_flex2.novabio_flex2_structure import Data, Sample
 from allotropy.parsers.vendor_parser import VendorParser
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 class NovaBioFlexParser(VendorParser):

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
@@ -1,4 +1,3 @@
-from typing import TYPE_CHECKING
 import uuid
 
 from allotropy.allotrope.models.cell_culture_analyzer_benchling_2023_09_cell_culture_analyzer import (
@@ -12,9 +11,7 @@ from allotropy.allotrope.models.cell_culture_analyzer_benchling_2023_09_cell_cul
 )
 from allotropy.parsers.novabio_flex2.novabio_flex2_structure import Data, Sample
 from allotropy.parsers.vendor_parser import VendorParser
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 class NovaBioFlexParser(VendorParser):

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
@@ -1,4 +1,3 @@
-import io
 import uuid
 
 from allotropy.allotrope.models.cell_culture_analyzer_benchling_2023_09_cell_culture_analyzer import (
@@ -12,10 +11,11 @@ from allotropy.allotrope.models.cell_culture_analyzer_benchling_2023_09_cell_cul
 )
 from allotropy.parsers.novabio_flex2.novabio_flex2_structure import Data, Sample
 from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.types import ContentsType
 
 
 class NovaBioFlexParser(VendorParser):
-    def _parse(self, contents: io.IOBase, filename: str) -> Model:
+    def _parse(self, contents: ContentsType, filename: str) -> Model:
         return self._get_model(Data.create(contents, filename))
 
     def _get_model(self, data: Data) -> Model:

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_structure.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_structure.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import re
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -18,7 +18,9 @@ from allotropy.parsers.novabio_flex2.constants import (
     MOLAR_CONCENTRATION_CLS_BY_UNIT,
     PROPERTY_MAPPINGS,
 )
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 @dataclass

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_structure.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_structure.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import re
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
@@ -18,9 +18,7 @@ from allotropy.parsers.novabio_flex2.constants import (
     MOLAR_CONCENTRATION_CLS_BY_UNIT,
     PROPERTY_MAPPINGS,
 )
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 @dataclass

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_structure.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_structure.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import io
 import re
 from typing import Any, Optional
 
@@ -19,6 +18,7 @@ from allotropy.parsers.novabio_flex2.constants import (
     MOLAR_CONCENTRATION_CLS_BY_UNIT,
     PROPERTY_MAPPINGS,
 )
+from allotropy.types import ContentsType
 
 
 @dataclass
@@ -133,7 +133,7 @@ class Data:
     sample_list: SampleList
 
     @staticmethod
-    def create(contents: io.IOBase, filename: str) -> Data:
+    def create(contents: ContentsType, filename: str) -> Data:
         # NOTE: type ignore is an issue with pandas typing, it accepts an io.IOBase that implements read.
         data = pd.read_csv(contents, parse_dates=["Date & Time"]).replace(np.nan, None)  # type: ignore[call-overload]
         return Data(Title.create(filename), SampleList.create(data))

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
@@ -1,4 +1,3 @@
-from io import IOBase
 from typing import Any, Optional, TypeVar
 import uuid
 
@@ -30,6 +29,7 @@ from allotropy.parsers.perkin_elmer_envision.perkin_elmer_envision_structure imp
     Plate,
 )
 from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.types import ContentsType
 
 T = TypeVar("T")
 
@@ -39,7 +39,7 @@ def safe_value(cls: type[T], value: Optional[Any]) -> Optional[T]:
 
 
 class PerkinElmerEnvisionParser(VendorParser):
-    def _parse(self, raw_contents: IOBase, _: str) -> Model:
+    def _parse(self, raw_contents: ContentsType, _: str) -> Model:
         reader = CsvReader(raw_contents)
         return self._get_model(Data.create(reader))
 

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, TYPE_CHECKING, TypeVar
+from typing import Any, Optional, TypeVar
 import uuid
 
 from allotropy.allotrope.allotrope import AllotropyError
@@ -29,9 +29,7 @@ from allotropy.parsers.perkin_elmer_envision.perkin_elmer_envision_structure imp
     Plate,
 )
 from allotropy.parsers.vendor_parser import VendorParser
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 T = TypeVar("T")
 

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, TypeVar
+from typing import Any, Optional, TYPE_CHECKING, TypeVar
 import uuid
 
 from allotropy.allotrope.allotrope import AllotropyError
@@ -29,7 +29,9 @@ from allotropy.parsers.perkin_elmer_envision.perkin_elmer_envision_structure imp
     Plate,
 )
 from allotropy.parsers.vendor_parser import VendorParser
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 T = TypeVar("T")
 

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
@@ -1,4 +1,3 @@
-import io
 import uuid
 
 from allotropy.allotrope.models.cell_culture_analyzer_benchling_2023_09_cell_culture_analyzer import (
@@ -15,10 +14,11 @@ from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_reader import (
 )
 from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_structure import Data, Sample
 from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.types import ContentsType
 
 
 class RocheCedexBiohtParser(VendorParser):
-    def _parse(self, contents: io.IOBase, filename: str) -> Model:  # noqa: ARG002
+    def _parse(self, contents: ContentsType, filename: str) -> Model:  # noqa: ARG002
         reader = RocheCedexBiohtReader(contents)
         return self._get_model(Data.create(reader))
 

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
@@ -1,4 +1,3 @@
-from typing import TYPE_CHECKING
 import uuid
 
 from allotropy.allotrope.models.cell_culture_analyzer_benchling_2023_09_cell_culture_analyzer import (
@@ -15,9 +14,7 @@ from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_reader import (
 )
 from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_structure import Data, Sample
 from allotropy.parsers.vendor_parser import VendorParser
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 class RocheCedexBiohtParser(VendorParser):

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 import uuid
 
 from allotropy.allotrope.models.cell_culture_analyzer_benchling_2023_09_cell_culture_analyzer import (
@@ -14,7 +15,9 @@ from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_reader import (
 )
 from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_structure import Data, Sample
 from allotropy.parsers.vendor_parser import VendorParser
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 class RocheCedexBiohtParser(VendorParser):

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_reader.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_reader.py
@@ -1,5 +1,5 @@
 # mypy: disallow_any_generics = False
-
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -10,7 +10,9 @@ from allotropy.parsers.roche_cedex_bioht.constants import (
     INFO_HEADER,
     SAMPLE_ROLE_TYPES,
 )
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 def to_num(data: pd.Series) -> pd.Series:

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_reader.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_reader.py
@@ -1,5 +1,5 @@
 # mypy: disallow_any_generics = False
-from typing import TYPE_CHECKING
+
 
 import numpy as np
 import pandas as pd
@@ -10,9 +10,7 @@ from allotropy.parsers.roche_cedex_bioht.constants import (
     INFO_HEADER,
     SAMPLE_ROLE_TYPES,
 )
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 def to_num(data: pd.Series) -> pd.Series:

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_reader.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_reader.py
@@ -1,6 +1,5 @@
 # mypy: disallow_any_generics = False
 
-import io
 
 import numpy as np
 import pandas as pd
@@ -11,6 +10,7 @@ from allotropy.parsers.roche_cedex_bioht.constants import (
     INFO_HEADER,
     SAMPLE_ROLE_TYPES,
 )
+from allotropy.types import ContentsType
 
 
 def to_num(data: pd.Series) -> pd.Series:
@@ -18,11 +18,11 @@ def to_num(data: pd.Series) -> pd.Series:
 
 
 class RocheCedexBiohtReader:
-    def __init__(self, contents: io.IOBase):
+    def __init__(self, contents: ContentsType):
         self.title_data = self.read_title_data(contents)
         self.samples_data = self.read_samples_data(contents)
 
-    def read_title_data(self, contents: io.IOBase) -> pd.Series:
+    def read_title_data(self, contents: ContentsType) -> pd.Series:
         contents.seek(0)
         return pd.read_csv(  # type: ignore[call-overload, no-any-return]
             contents,
@@ -32,7 +32,7 @@ class RocheCedexBiohtReader:
             nrows=1,
         ).T[0]
 
-    def read_samples_data(self, contents: io.IOBase) -> pd.DataFrame:
+    def read_samples_data(self, contents: ContentsType) -> pd.DataFrame:
         contents.seek(0)
         sample_rows: pd.DataFrame = pd.read_csv(  # type: ignore[call-overload]
             contents,

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 import chardet
 
@@ -7,9 +7,7 @@ from allotropy.allotrope.allotrope import AllotropeConversionError
 from allotropy.allotrope.models.shared.definitions.definitions import TDateTimeValue
 from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from allotropy.parsers.utils.values import assert_not_none
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 class VendorParser(ABC):

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-import io
 from typing import Any
 
 import chardet
@@ -8,6 +7,7 @@ from allotropy.allotrope.allotrope import AllotropeConversionError
 from allotropy.allotrope.models.shared.definitions.definitions import TDateTimeValue
 from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from allotropy.parsers.utils.values import assert_not_none
+from allotropy.types import ContentsType
 
 
 class VendorParser(ABC):
@@ -15,13 +15,13 @@ class VendorParser(ABC):
         self.timestamp_parser = timestamp_parser
 
     @abstractmethod
-    def _parse(self, contents: io.IOBase, filename: str) -> Any:
+    def _parse(self, contents: ContentsType, filename: str) -> Any:
         raise NotImplementedError
 
-    def to_allotrope(self, contents: io.IOBase, filename: str) -> Any:
+    def to_allotrope(self, contents: ContentsType, filename: str) -> Any:
         return self._parse(contents, filename)
 
-    def _read_contents(self, contents: io.IOBase) -> Any:
+    def _read_contents(self, contents: ContentsType) -> Any:
         file_bytes = contents.read()
         encoding = chardet.detect(file_bytes)["encoding"]
         if not encoding:

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 import chardet
 
@@ -7,7 +7,9 @@ from allotropy.allotrope.allotrope import AllotropeConversionError
 from allotropy.allotrope.models.shared.definitions.definitions import TDateTimeValue
 from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from allotropy.parsers.utils.values import assert_not_none
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 class VendorParser(ABC):

--- a/src/allotropy/to_allotrope.py
+++ b/src/allotropy/to_allotrope.py
@@ -1,14 +1,14 @@
 from datetime import tzinfo
-import io
 from pathlib import Path
 from typing import Any, Optional
 
 from allotropy.allotrope.allotrope import serialize_allotrope
 from allotropy.parser_factory import PARSER_FACTORY, VendorType
+from allotropy.types import ContentsType
 
 
 def allotrope_from_io(
-    contents: io.IOBase,
+    contents: ContentsType,
     filename: str,
     vendor_type: VendorType,
     default_timezone: Optional[tzinfo] = None,
@@ -19,7 +19,7 @@ def allotrope_from_io(
 
 
 def allotrope_model_from_io(
-    contents: io.IOBase,
+    contents: ContentsType,
     filename: str,
     vendor_type: VendorType,
     default_timezone: Optional[tzinfo] = None,

--- a/src/allotropy/to_allotrope.py
+++ b/src/allotropy/to_allotrope.py
@@ -1,12 +1,10 @@
 from datetime import tzinfo
 from pathlib import Path
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional
 
 from allotropy.allotrope.allotrope import serialize_allotrope
 from allotropy.parser_factory import PARSER_FACTORY, VendorType
-
-if TYPE_CHECKING:
-    from allotropy.types import ContentsType
+from allotropy.types import ContentsType
 
 
 def allotrope_from_io(

--- a/src/allotropy/to_allotrope.py
+++ b/src/allotropy/to_allotrope.py
@@ -1,10 +1,12 @@
 from datetime import tzinfo
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 
 from allotropy.allotrope.allotrope import serialize_allotrope
 from allotropy.parser_factory import PARSER_FACTORY, VendorType
-from allotropy.types import ContentsType
+
+if TYPE_CHECKING:
+    from allotropy.types import ContentsType
 
 
 def allotrope_from_io(

--- a/src/allotropy/types.py
+++ b/src/allotropy/types.py
@@ -1,0 +1,3 @@
+import io
+
+ContentsType = io.IOBase


### PR DESCRIPTION
Extract a constant to better see places where `io.IOBase` is currently used for typing.

Out of scope: changing `ContentsType` to something else so we can remove type suppressions when passing vars of this type to `pd.read_csv`.