### PR TITLE
Improve ordering in shared/definitions/definitions

### DIFF
--- a/src/allotropy/allotrope/models/shared/definitions/definitions.py
+++ b/src/allotropy/allotrope/models/shared/definitions/definitions.py
@@ -4,40 +4,11 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Union
 
-TTupleData = list[Optional[Union[float, bool, str]]]
-
-
-TUnit = str
-
-
-TBooleanArray = list[bool]
-
-
-TBooleanOrNullArray = list[Optional[bool]]
-
-
-TNumberArray = list[float]
-
-
-TNumberOrNullArray = list[Optional[float]]
-
-
-TStringArray = list[str]
-
-
-TStringOrNullArray = list[Optional[str]]
-
-
-TClass = str
-
 
 @dataclass
-class TStringValueItem:
-    value: str
-    field_type: str
-
-
-TStringValue = Union[str, TStringValueItem]
+class TBooleanValueItem:
+    field_type: TClass
+    value: bool
 
 
 @dataclass
@@ -46,17 +17,26 @@ class TDateTimeValueItem:
     value: str
 
 
-TDateTimeValue = Union[str, TDateTimeValueItem]
-TDateTimeStampValue = TDateTimeValue
-
-
 @dataclass
-class TBooleanValueItem:
-    field_type: TClass
-    value: bool
+class TStringValueItem:
+    value: str
+    field_type: str
 
 
+TBooleanArray = list[bool]
+TBooleanOrNullArray = list[Optional[bool]]
 TBooleanValue = Union[bool, TBooleanValueItem]
+TClass = str
+TDateTimeValue = Union[str, TDateTimeValueItem]
+# TODO(brian): inline this
+TDateTimeStampValue = TDateTimeValue
+TNumberArray = list[float]
+TNumberOrNullArray = list[Optional[float]]
+TStringArray = list[str]
+TStringOrNullArray = list[Optional[str]]
+TStringValue = Union[str, TStringValueItem]
+TTupleData = list[Optional[Union[float, bool, str]]]
+TUnit = str
 
 
 class TStatisticDatumRole(Enum):


### PR DESCRIPTION
Move dataclasses up, then remove a lot of whitespace and sort alphabetically.