### PR TITLE
Clean up ParserFactory

### DIFF
--- a/src/allotropy/parser_factory.py
+++ b/src/allotropy/parser_factory.py
@@ -29,8 +29,8 @@ from allotropy.parsers.vendor_parser import VendorParser
 
 class Vendor(Enum):
     AGILENT_GEN5 = "AGILENT_GEN5"
-    APPBIO_QUANTSTUDIO = "APPBIO_QUANTSTUDIO"
     APPBIO_ABSOLUTE_Q = "APPBIO_ABSOLUTE_Q"
+    APPBIO_QUANTSTUDIO = "APPBIO_QUANTSTUDIO"
     BECKMAN_VI_CELL_BLU = "BECKMAN_VI_CELL_BLU"
     BECKMAN_VI_CELL_XR = "BECKMAN_VI_CELL_XR"
     EXAMPLE_WEYLAND_YUTANI = "EXAMPLE_WEYLAND_YUTANI"
@@ -45,22 +45,19 @@ VendorType = Union[Vendor, str]
 
 _VENDOR_TO_PARSER: dict[Vendor, type[VendorParser]] = {
     Vendor.AGILENT_GEN5: AgilentGen5Parser,
-    Vendor.APPBIO_QUANTSTUDIO: AppBioQuantStudioParser,
     Vendor.APPBIO_ABSOLUTE_Q: AppbioAbsoluteQParser,
+    Vendor.APPBIO_QUANTSTUDIO: AppBioQuantStudioParser,
     Vendor.BECKMAN_VI_CELL_BLU: ViCellBluParser,
     Vendor.BECKMAN_VI_CELL_XR: ViCellXRParser,
     Vendor.EXAMPLE_WEYLAND_YUTANI: ExampleWeylandYutaniParser,
-    Vendor.NOVABIO_FLEX2: NovaBioFlexParser,
     Vendor.MOLDEV_SOFTMAX_PRO: SoftmaxproParser,
+    Vendor.NOVABIO_FLEX2: NovaBioFlexParser,
     Vendor.PERKIN_ELMER_ENVISION: PerkinElmerEnvisionParser,
     Vendor.ROCHE_CEDEX_BIOHT: RocheCedexBiohtParser,
 }
 
 
-class ParserFactory:
-    def __init__(self) -> None:
-        pass
-
+class _ParserFactory:
     def create(
         self, vendor_type: VendorType, default_timezone: Optional[tzinfo] = None
     ) -> VendorParser:
@@ -72,10 +69,10 @@ class ParserFactory:
             raise AllotropeConversionError(error) from e
 
 
+PARSER_FACTORY: _ParserFactory = _ParserFactory()
+
+
 def get_parser(
     vendor_type: VendorType, default_timezone: Optional[tzinfo] = None
 ) -> VendorParser:
     return PARSER_FACTORY.create(vendor_type, default_timezone=default_timezone)
-
-
-PARSER_FACTORY: ParserFactory = ParserFactory()

--- a/src/allotropy/parser_factory.py
+++ b/src/allotropy/parser_factory.py
@@ -69,10 +69,10 @@ class _ParserFactory:
             raise AllotropeConversionError(error) from e
 
 
-PARSER_FACTORY = _ParserFactory()
+_PARSER_FACTORY = _ParserFactory()
 
 
 def get_parser(
     vendor_type: VendorType, default_timezone: Optional[tzinfo] = None
 ) -> VendorParser:
-    return PARSER_FACTORY.create(vendor_type, default_timezone=default_timezone)
+    return _PARSER_FACTORY.create(vendor_type, default_timezone=default_timezone)

--- a/src/allotropy/parser_factory.py
+++ b/src/allotropy/parser_factory.py
@@ -69,7 +69,7 @@ class _ParserFactory:
             raise AllotropeConversionError(error) from e
 
 
-PARSER_FACTORY: _ParserFactory = _ParserFactory()
+PARSER_FACTORY = _ParserFactory()
 
 
 def get_parser(

--- a/src/allotropy/to_allotrope.py
+++ b/src/allotropy/to_allotrope.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from allotropy.allotrope.allotrope import serialize_allotrope
-from allotropy.parser_factory import PARSER_FACTORY, VendorType
+from allotropy.parser_factory import get_parser, VendorType
 
 
 def allotrope_from_io(
@@ -24,7 +24,7 @@ def allotrope_model_from_io(
     vendor_type: VendorType,
     default_timezone: Optional[tzinfo] = None,
 ) -> Any:
-    parser = PARSER_FACTORY.create(vendor_type, default_timezone=default_timezone)
+    parser = get_parser(vendor_type, default_timezone=default_timezone)
     return parser.to_allotrope(contents, filename)
 
 


### PR DESCRIPTION
Use `get_parser()` externally, rename to indicate members that shouldn't be used externally, and sort lines.