### PR TITLE
Ignore JetBrains CSV Editor plugin config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,9 @@ cython_debug/
 # *.iml
 # *.ipr
 
+# Plugin files
+.idea/csv-editor.xml
+
 # CMake
 cmake-build-*/
 


### PR DESCRIPTION
https://plugins.jetbrains.com/plugin/10037-csv-editor
... is a useful plugin, but its config file stores info about CSV files viewed, so not helpful to commit.