### PR TITLE
Simplify LinesReader

### DIFF
--- a/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
+++ b/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
@@ -27,6 +27,7 @@ from allotropy.parsers.agilent_gen5.agilent_gen5_structure import Data
 from allotropy.parsers.agilent_gen5.constants import ReadMode
 from allotropy.parsers.agilent_gen5.plate_data import PlateData
 from allotropy.parsers.agilent_gen5.section_reader import SectionLinesReader
+from allotropy.parsers.lines_reader import read_to_lines
 from allotropy.parsers.vendor_parser import VendorParser
 
 
@@ -93,7 +94,8 @@ class AgilentGen5Parser(VendorParser):
 
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Any:
         contents = named_file_contents.contents
-        section_lines_reader = SectionLinesReader(contents, encoding=None)
+        lines = read_to_lines(contents, encoding=None)
+        section_lines_reader = SectionLinesReader(lines)
         data = Data.create(section_lines_reader)
 
         first_plate = data.plates[0]

--- a/src/allotropy/parsers/agilent_gen5/section_reader.py
+++ b/src/allotropy/parsers/agilent_gen5/section_reader.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 
-from allotropy.parsers.lines_reader import LinesReader, ListReader
+from allotropy.parsers.lines_reader import LinesReader
 
 
 class SectionLinesReader(LinesReader):
@@ -10,4 +10,4 @@ class SectionLinesReader(LinesReader):
             if (initial_line := self.pop()) is None:
                 break
             lines = [initial_line, *self.pop_until(pattern)]
-            yield ListReader(lines)
+            yield LinesReader(lines)

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
@@ -48,14 +48,15 @@ from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_structure import (
     Well,
     WellItem,
 )
-from allotropy.parsers.lines_reader import LinesReader
+from allotropy.parsers.lines_reader import LinesReader, read_to_lines
 from allotropy.parsers.vendor_parser import VendorParser
 
 
 class AppBioQuantStudioParser(VendorParser):
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Model:
         raw_contents, file_name = named_file_contents
-        reader = LinesReader(raw_contents)
+        lines = read_to_lines(raw_contents)
+        reader = LinesReader(lines)
         data = create_data(reader)
         return self._get_model(data, file_name)
 

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
@@ -23,14 +23,15 @@ from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.example_weyland_yutani.example_weyland_yutani_structure import (
     Data,
 )
-from allotropy.parsers.lines_reader import CsvReader
+from allotropy.parsers.lines_reader import CsvReader, read_to_lines
 from allotropy.parsers.vendor_parser import VendorParser
 
 
 class ExampleWeylandYutaniParser(VendorParser):
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Model:
         raw_contents = named_file_contents.contents
-        reader = CsvReader(raw_contents)
+        lines = read_to_lines(raw_contents)
+        reader = CsvReader(lines)
         return self._get_model(Data.create(reader))
 
     def _get_model(self, data: Data) -> Model:

--- a/src/allotropy/parsers/lines_reader.py
+++ b/src/allotropy/parsers/lines_reader.py
@@ -12,15 +12,6 @@ from allotropy.types import IOType
 EMPTY_STR_PATTERN = r"^\s*$"
 
 
-def _decode(bytes_content: bytes, encoding: Optional[str]) -> str:
-    if not encoding:
-        encoding = chardet.detect(bytes_content)["encoding"]
-        if not encoding:
-            error = "Unable to detect text encoding for file. The file may be empty."
-            raise AllotropeConversionError(error)
-    return bytes_content.decode(encoding)
-
-
 def read_to_lines(io_: IOType, encoding: Optional[str] = "UTF-8") -> list[str]:
     stream_contents = io_.read()
     raw_contents = (
@@ -32,9 +23,18 @@ def read_to_lines(io_: IOType, encoding: Optional[str] = "UTF-8") -> list[str]:
     return contents.split("\n")
 
 
+def _decode(bytes_content: bytes, encoding: Optional[str]) -> str:
+    if not encoding:
+        encoding = chardet.detect(bytes_content)["encoding"]
+        if not encoding:
+            error = "Unable to detect text encoding for file. The file may be empty."
+            raise AllotropeConversionError(error)
+    return bytes_content.decode(encoding)
+
+
 class LinesReader:
     lines: list[str]
-    current_line: int  # TODO: make private
+    current_line: int
 
     def __init__(self, lines: list[str]) -> None:
         self.lines = lines

--- a/src/allotropy/parsers/lines_reader.py
+++ b/src/allotropy/parsers/lines_reader.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterator
 from io import StringIO
 from re import search
-from typing import Optional
+from typing import Final, Optional
 
 import chardet
 import pandas as pd
@@ -33,7 +33,7 @@ def _decode(bytes_content: bytes, encoding: Optional[str]) -> str:
 
 
 class LinesReader:
-    lines: list[str]
+    lines: Final[list[str]]
     current_line: int
 
     def __init__(self, lines: list[str]) -> None:

--- a/src/allotropy/parsers/lines_reader.py
+++ b/src/allotropy/parsers/lines_reader.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterator
 from io import StringIO
 from re import search
-from typing import Final, Optional
+from typing import Optional
 
 import chardet
 import pandas as pd
@@ -33,7 +33,7 @@ def _decode(bytes_content: bytes, encoding: Optional[str]) -> str:
 
 
 class LinesReader:
-    lines: Final[list[str]]
+    lines: list[str]
     current_line: int
 
     def __init__(self, lines: list[str]) -> None:

--- a/src/allotropy/parsers/lines_reader.py
+++ b/src/allotropy/parsers/lines_reader.py
@@ -34,7 +34,7 @@ def read_to_lines(io_: IOType, encoding: Optional[str] = "UTF-8") -> list[str]:
 
 class LinesReader:
     lines: list[str]
-    current_line: int
+    current_line: int  # TODO: make private
 
     def __init__(self, lines: list[str]) -> None:
         self.lines = lines

--- a/src/allotropy/parsers/lines_reader.py
+++ b/src/allotropy/parsers/lines_reader.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterator
-from dataclasses import dataclass
 from io import StringIO
 from re import search
 from typing import Optional
@@ -33,10 +32,13 @@ def read_to_lines(io_: IOType, encoding: Optional[str] = "UTF-8") -> list[str]:
     return contents.split("\n")
 
 
-@dataclass
 class LinesReader:
     lines: list[str]
-    current_line: int = 0
+    current_line: int
+
+    def __init__(self, lines: list[str]) -> None:
+        self.lines = lines
+        self.current_line = 0
 
     def current_line_exists(self) -> bool:
         return 0 <= self.current_line < len(self.lines)

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
@@ -1,14 +1,15 @@
 from typing import Any
 
 from allotropy.named_file_contents import NamedFileContents
-from allotropy.parsers.lines_reader import CsvReader
+from allotropy.parsers.lines_reader import CsvReader, read_to_lines
 from allotropy.parsers.moldev_softmax_pro.softmax_pro_structure import Data
 from allotropy.parsers.vendor_parser import VendorParser
 
 
 class SoftmaxproParser(VendorParser):
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Any:
-        reader = CsvReader(named_file_contents.contents, encoding=None)
+        lines = read_to_lines(named_file_contents.contents, encoding=None)
+        reader = CsvReader(lines)
         data = Data.create(reader)
         return self._get_model(data)
 

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
@@ -52,7 +52,7 @@ from allotropy.exceptions import (
     AllotropeConversionError,
     msg_for_error_on_unrecognized_value,
 )
-from allotropy.parsers.lines_reader import CsvReader, ListCsvReader
+from allotropy.parsers.lines_reader import CsvReader
 from allotropy.parsers.utils.values import (
     assert_not_none,
     natural_sort_key,
@@ -1085,7 +1085,7 @@ class BlockList:
     def _iter_blocks(reader: CsvReader) -> Iterator[CsvReader]:
         n_blocks = BlockList._get_n_blocks(reader)
         for _ in range(n_blocks):
-            yield ListCsvReader(list(reader.pop_until(END_LINE_REGEX)))
+            yield CsvReader(list(reader.pop_until(END_LINE_REGEX)))
             reader.pop()  # drop end line
             reader.drop_empty()
 

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
@@ -42,7 +42,7 @@ from allotropy.allotrope.models.shared.definitions.definitions import (
 from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.named_file_contents import NamedFileContents
-from allotropy.parsers.lines_reader import CsvReader
+from allotropy.parsers.lines_reader import CsvReader, read_to_lines
 from allotropy.parsers.perkin_elmer_envision.perkin_elmer_envision_structure import (
     CalculatedPlateInfo,
     Data,
@@ -83,7 +83,8 @@ def safe_value(cls: type[T], value: Optional[Any]) -> Optional[T]:
 class PerkinElmerEnvisionParser(VendorParser):
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Model:
         raw_contents, filename = named_file_contents
-        reader = CsvReader(raw_contents)
+        lines = read_to_lines(named_file_contents.contents)
+        reader = CsvReader(lines)
         try:
             return self._get_model(Data.create(reader), filename)
         except (Exception) as error:

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_structure_test.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_structure_test.py
@@ -19,7 +19,7 @@ from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_structure import (
 )
 from allotropy.parsers.appbio_quantstudio.calculated_document import CalculatedDocument
 from allotropy.parsers.appbio_quantstudio.referenceable import Referenceable
-from allotropy.parsers.lines_reader import LinesReader
+from allotropy.parsers.lines_reader import LinesReader, read_to_lines
 from tests.parsers.appbio_quantstudio.appbio_quantstudio_data import (
     get_broken_calc_doc_data,
     get_data,
@@ -56,7 +56,8 @@ def rm_uuid_calc_doc(calc_doc: CalculatedDocument) -> None:
 def test_header_builder_returns_header_instance() -> None:
     header_contents = get_raw_header_contents()
 
-    assert isinstance(Header.create(LinesReader(header_contents)), Header)
+    lines = read_to_lines(header_contents)
+    assert isinstance(Header.create(LinesReader(lines)), Header)
 
 
 def test_header_builder() -> None:
@@ -81,7 +82,8 @@ def test_header_builder() -> None:
         experimental_data_identifier=experimental_data_identifier,
     )
 
-    assert Header.create(LinesReader(header_contents)) == Header(
+    lines = read_to_lines(header_contents)
+    assert Header.create(LinesReader(lines)) == Header(
         measurement_time="2010-10-01 01:44:54 AM EDT",
         plate_well_count=96,
         experiment_type=ExperimentType.genotyping_qPCR_experiment,
@@ -115,24 +117,27 @@ def test_header_builder_required_parameter_none_then_raise(
 ) -> None:
     header_contents = get_raw_header_contents(**{parameter: None})
 
+    lines = read_to_lines(header_contents)
     with pytest.raises(AllotropeConversionError, match=expected_error):
-        Header.create(LinesReader(header_contents))
+        Header.create(LinesReader(lines))
 
 
 @pytest.mark.short
 def test_header_builder_invalid_plate_well_count() -> None:
     header_contents = get_raw_header_contents(plate_well_count="0 plates")
 
+    lines = read_to_lines(header_contents)
     with pytest.raises(AllotropeConversionError):
-        Header.create(LinesReader(header_contents))
+        Header.create(LinesReader(lines))
 
 
 @pytest.mark.short
 def test_header_builder_no_header_then_raise() -> None:
     header_contents = get_raw_header_contents(raw_text="")
 
+    lines = read_to_lines(header_contents)
     with pytest.raises(AllotropeConversionError):
-        Header.create(LinesReader(header_contents))
+        Header.create(LinesReader(lines))
 
 
 @pytest.mark.short
@@ -194,7 +199,8 @@ def test_results_builder() -> None:
 )
 def test_data_builder(test_filepath: str, expected_data: Data) -> None:
     with open(test_filepath, "rb") as raw_contents:
-        reader = LinesReader(raw_contents)
+        lines = read_to_lines(raw_contents)
+    reader = LinesReader(lines)
     assert rm_uuid(create_data(reader)) == rm_uuid(expected_data)
 
 

--- a/tests/parsers/lines_reader_test.py
+++ b/tests/parsers/lines_reader_test.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 
-from allotropy.parsers.lines_reader import LinesReader
+from allotropy.parsers.lines_reader import LinesReader, read_to_lines
 
 
 def get_input_lines() -> list[str]:
@@ -33,14 +33,13 @@ def get_input_stream() -> BytesIO:
 
 
 def get_test_reader() -> LinesReader:
-    return LinesReader(get_input_stream())
+    lines = read_to_lines(get_input_stream())
+    return LinesReader(lines)
 
 
 def test_reader_constructure() -> None:
     test_reader = get_test_reader()
-    assert test_reader.contents == get_input_text()
     assert test_reader.lines == get_input_lines()
-    assert test_reader.n_lines == 16
     assert test_reader.current_line == 0
 
 

--- a/tests/parsers/perkin_elmer_envision/perkin_elmer_envision_structure_test.py
+++ b/tests/parsers/perkin_elmer_envision/perkin_elmer_envision_structure_test.py
@@ -1,5 +1,3 @@
-from io import StringIO
-
 import pytest
 
 from allotropy.allotrope.models.plate_reader_benchling_2023_09_plate_reader import (
@@ -29,7 +27,7 @@ from allotropy.parsers.perkin_elmer_envision.perkin_elmer_envision_structure imp
 
 
 def get_reader_from_lines(lines: list[str]) -> CsvReader:
-    return CsvReader(StringIO("\n".join(lines)))
+    return CsvReader(lines)
 
 
 def rm_result_list_uuids(result_list: ResultList) -> ResultList:


### PR DESCRIPTION
Separate the concerns of:
1. Parsing an input stream into a list of strings (one per line)
2. Reading through a list of strings with the methods of LinesReader (and children)

Eliminate unnecessary fields: we only need `lines` and `current_line`.

Simplify from this:
<img width="540" alt="Screenshot 2023-12-14 at 9 30 06 PM" src="https://github.com/Benchling-Open-Source/allotropy/assets/13633550/1798832d-70cf-4b03-aa6c-433e5299fb63">

... to this:
<img width="562" alt="Screenshot 2023-12-14 at 9 29 27 PM" src="https://github.com/Benchling-Open-Source/allotropy/assets/13633550/89a51117-e389-4257-acaa-8075107530a6">