### PR TITLE
tests: Improve schema generation test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,14 +89,14 @@ path = "src/allotropy/__about__.py"
 # We define dependencies for linting and datamodel codegen in the default environment because we lint in
 # the generation script, and we test generation in tests, so we need them everywhere except the actual project.
 dependencies = [
-  "autoflake >= 2.2.0",
+  "autoflake == 2.2.0",
   # black pinned for compatability with datamodel-code-generator
   "black == 22.3.0",
-  "datamodel-code-generator >= 0.21.5",
+  "datamodel-code-generator == 0.21.5",
   # Without jsonschema-spec and pydantic, pydantic spews a bunch of errors when parsing schemas
-  "jsonschema-specifications >= 2023.7.1",
+  "jsonschema-specifications == 2023.7.1",
   "pydantic == 1.10.9",
-  "ruff >= 0.0.289",
+  "ruff == 0.0.289",
 ]
 
 [tool.hatch.envs.scripts.scripts]

--- a/src/allotropy/allotrope/schema_parser/generate_schemas.py
+++ b/src/allotropy/allotrope/schema_parser/generate_schemas.py
@@ -70,6 +70,7 @@ def generate_schemas(root_dir: Path, *, dry_run: Optional[bool] = False) -> list
     """Generate schemas from JSON schema files.
 
     :root_dir: The root directory of the project.
+    :dry_run: If true, does not save changes to any models, but still returns the list of models that would change.
     :return: A list of model files that were changed.
     """
 

--- a/src/allotropy/allotrope/schema_parser/generate_schemas.py
+++ b/src/allotropy/allotrope/schema_parser/generate_schemas.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import re
 import subprocess  # noqa: S404, RUF100
+from typing import Optional
 
 from autoflake import fix_file  # type: ignore[import-untyped]
 from datamodel_code_generator import (
@@ -65,17 +66,17 @@ def files_equal(path1: str, path2: str) -> bool:
     return True
 
 
-def generate_schemas(root_dir: Path) -> int:
+def generate_schemas(root_dir: Path, *, dry_run: Optional[bool] = False) -> list[str]:
     """Generate schemas from JSON schema files.
 
     :root_dir: The root directory of the project.
-    :return: The number of schemas generated.
+    :return: A list of model files that were changed.
     """
 
     os.chdir(os.path.join(root_dir, SCHEMA_DIR_PATH))
     schema_paths = list(Path(".").rglob("*.json"))
     os.chdir(os.path.join(root_dir))
-    number_generated = 0
+    models_changed = []
     for rel_schema_path in schema_paths:
         if str(rel_schema_path).startswith("shared"):
             continue
@@ -116,12 +117,13 @@ def generate_schemas(root_dir: Path) -> int:
 
         # Restore backups
         if os.path.exists(model_backup_path):
-            if files_equal(model_path, model_backup_path):
+            files_are_equal = files_equal(model_path, model_backup_path)
+            if not files_are_equal:
+                models_changed.append(os.path.basename(model_path))
+            if files_are_equal or dry_run:
                 os.rename(model_backup_path, model_path)
             else:
                 os.remove(model_backup_path)
         os.rename(schema_backup_path, schema_path)
 
-        number_generated += 1
-
-    return number_generated
+    return models_changed

--- a/tests/allotrope/schema_parser/generate_schemas_test.py
+++ b/tests/allotrope/schema_parser/generate_schemas_test.py
@@ -5,4 +5,7 @@ from allotropy.allotrope.schema_parser.generate_schemas import generate_schemas
 
 def test_generate_schemas_runs_to_completion() -> None:
     root_dir = Path(__file__).parent.parent.parent.parent
-    assert generate_schemas(root_dir) == 10
+    models_changed = generate_schemas(root_dir, dry_run=True)
+    assert (
+        not models_changed
+    ), f"Expected no models files to have changed by generate-schemas script, found changes in: {models_changed}. Please run scripts:generate-schemas and validate the changes."

--- a/tests/allotrope/schema_parser/generate_schemas_test.py
+++ b/tests/allotrope/schema_parser/generate_schemas_test.py
@@ -8,4 +8,4 @@ def test_generate_schemas_runs_to_completion() -> None:
     models_changed = generate_schemas(root_dir, dry_run=True)
     assert (
         not models_changed
-    ), f"Expected no models files to have changed by generate-schemas script, found changes in: {models_changed}. Please run scripts:generate-schemas and validate the changes."
+    ), f"Expected no models files to have changed by generate-schemas script, found changes in: {models_changed}.\nPlease run 'hatch run scripts:generate-schemas' and validate the changes."


### PR DESCRIPTION
Add the ability to run generate schemas script as a dry run and return the number of models changed. 

Change the test to validate that no model files are changed.

This improves test coverage and prevents the test from making changes to files.