### PR TITLE
Addition of SquareCentimetersPerGram to units.json

### DIFF
--- a/src/allotropy/allotrope/models/shared/definitions/units.py
+++ b/src/allotropy/allotrope/models/shared/definitions/units.py
@@ -140,3 +140,8 @@ class RelativeFluorescenceUnit:
 @dataclass
 class RelativeLightUnit:
     unit: Optional[str] = "RLU"
+
+
+@dataclass
+class SquareCentimetersPerGram:
+    unit: Optional[str] = "cm^2/g"

--- a/src/allotropy/allotrope/schemas/shared/definitions/units.json
+++ b/src/allotropy/allotrope/schemas/shared/definitions/units.json
@@ -334,5 +334,17 @@
         "required": [
             "unit"
         ]
+    },
+    "SquareCentimetersPerGram":{
+        "properties": {
+            "unit": {
+                "type": "string",
+                "const": "cm^2/g",
+                "$asm.unit-iri": "http://qudt.org/vocab/unit#SquareCentimetersPerGram"
+            }
+        },
+        "required": [
+            "unit"
+        ]
     }
 }


### PR DESCRIPTION
Addition of SquareCentimetersPerGram to support use of `attenuation coefficient` in `spectrophotometry` schema