### PR TITLE
Chemometic Nucleoview: support for non-numeric values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add calculated data documents to Unchained Labs Lunatic adapter
 - Parser for ChemoMetic NucleoView
 - Add non numeric options for tQuantityValue value property
+- Add support for non-numeric values to ChemoMetic NucleoView
 ### Fixed
 ### Changed
 - Simplify Moldev Softmax Pro parsing with dataclasses

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
@@ -24,7 +24,10 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValuePercent,
     TQuantityValueUnitless,
 )
-from allotropy.allotrope.models.shared.definitions.definitions import TDateTimeValue
+from allotropy.allotrope.models.shared.definitions.definitions import (
+    TDateTimeValue,
+    ValueEnum,
+)
 from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.chemometec_nucleoview.constants import (
@@ -59,6 +62,11 @@ def get_property_from_sample(
         return None
 
     property_type = _PROPERTY_LOOKUP[property_name]
+
+    try:
+        value = float(value)
+    except ValueError:
+        return property_type(value=ValueEnum.NaN)
 
     # if the porperty type is measured in million cells per ml convert cells per ml
     if property_type == TQuantityValueMillionCellsPerMilliliter:

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_reader.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_reader.py
@@ -34,5 +34,10 @@ class NucleoviewReader:
                 raw_data["Date time"] + raw_data["Time zone offset"]
             )
         raw_data["Sample ID"] = raw_data["Image"].str.split("-", n=3).str[3]
+        raw_data.rename(
+            {"Estimated cell diameter [um]": "Estimated cell diameter (um)"},
+            axis=1,
+            inplace=True,
+        )
 
         return raw_data

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_reader.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_reader.py
@@ -34,10 +34,9 @@ class NucleoviewReader:
                 raw_data["Date time"] + raw_data["Time zone offset"]
             )
         raw_data["Sample ID"] = raw_data["Image"].str.split("-", n=3).str[3]
-        raw_data.rename(
+        raw_data = raw_data.rename(
             {"Estimated cell diameter [um]": "Estimated cell diameter (um)"},
             axis=1,
-            inplace=True,
         )
 
         return raw_data

--- a/tests/parsers/chemometec_nucleoview/chemometec_nucleoview_parser_test.py
+++ b/tests/parsers/chemometec_nucleoview/chemometec_nucleoview_parser_test.py
@@ -7,6 +7,9 @@ OUTPUT_FILES = (
     "chemometec_nucleoview_example01.csv",
     "chemometec_nucleoview_example02.csv",
     "chemometec_nucleoview_example03.csv",
+    "chemometec_nucleoview_example04.csv",
+    "chemometec_nucleoview_example05.csv",
+    "chemometec_nucleoview_example06.csv",
 )
 
 VENDOR_TYPE = Vendor.CHEMOMETEC_NUCLEOVIEW

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example04.csv
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example04.csv
@@ -1,0 +1,47 @@
+Viability and Cell Count Assay - example cell counting; ;
+Image;20231120-0012-c-cellsABCD;
+Operator;DrScientist;
+Viability (%);68.2;
+Live (cells/ml);2.45E6;
+Dead (cells/ml);1.14E6;
+Total (cells/ml);3.58E3 (Out of optimal range);
+ ; ;
+Estimated cell diameter [um];Not determined;
+Cell diameter standard deviation (um);6.9;
+(%) of cells in aggregates with five or more cells;3;
+Sample Volume (ul);200.0;
+Dilution Volume (ul);0.000;
+Multiplication factor;1.000;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+cm filename;20231120-0012-c-cellsABCD.cm
+Protocol template title;Viability and Cell Count Assay
+Protocol template purpose;Cell Count and Viability with AO and DAPI
+Protocol template filename;Viability and Cell Count Assay - NC-200.cmsx
+Protocol adaptation title;example cell counting
+Protocol adaptation purpose;Cell Count and Viability with AO and DAPI
+Protocol adaptation filename;94A29BE3f39d48cd8eb5cb9472add350.cmsu
+Instrument type;NucleoView NC-200
+Instrument s/n;s/n 9000201099909999
+Date time;20231120 163016
+Time zone offset;2
+Login ID;admin
+PC;DESKTOP-A678B9H
+Application SW version;1.4.2.0
+21 CFR Part 11;disabled
+Event log format;Plain text
+csv file version;2
+
+//[ECEC5A41]

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example04.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example04.json
@@ -1,0 +1,71 @@
+{
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "cell counting aggregate document": {
+        "cell counting document": [
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "measurement time": "2023-11-20T16:30:16+02:00",
+                            "measurement identifier": "8b1c98f3-936b-47ac-aea3-98e1a9d18abb",
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "dark field imager (cell counter)",
+                                        "detection type": "dark field"
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "cellsABCD"
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "viability (cell counter)": {
+                                            "value": 68.2,
+                                            "unit": "%"
+                                        },
+                                        "viable cell density (cell counter)": {
+                                            "value": 2.45,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "data processing document": {
+                                            "cell density dilution factor": {
+                                                "value": 1.0,
+                                                "unit": "(unitless)"
+                                            }
+                                        },
+                                        "total cell density (cell counter)": {
+                                            "value": "NaN",
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "dead cell density (cell counter)": {
+                                            "value": 1.14,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "average total cell diameter": {
+                                            "value": "NaN",
+                                            "unit": "\u03bcm"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "analyst": "DrScientist"
+            }
+        ],
+        "device system document": {
+            "model number": "NucleoView NC-200",
+            "equipment serial number": "s/n 9000201099909999"
+        },
+        "data system document": {
+            "file name": "chemometec_nucleoview_example04.csv",
+            "software name": "NucleoView",
+            "ASM converter name": "allotropy",
+            "ASM converter version": "0.1.12"
+        }
+    }
+}

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example05.csv
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example05.csv
@@ -1,0 +1,47 @@
+Viability and Cell Count Assay - example cell counting; ;
+Image;20231120-0012-c-cellsABCD;
+Operator;DrScientist;
+Viability (%);68.2;
+Live (cells/ml);2.45E6;
+Dead (cells/ml);1.14E6;
+Total (cells/ml);3.58E6;
+ ; ;
+Estimated cell diameter [um];<8;
+Cell diameter standard deviation (um);6.9;
+(%) of cells in aggregates with five or more cells;3;
+Sample Volume (ul);200.0;
+Dilution Volume (ul);0.000;
+Multiplication factor;1.000;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+cm filename;20231120-0012-c-cellsABCD.cm
+Protocol template title;Viability and Cell Count Assay
+Protocol template purpose;Cell Count and Viability with AO and DAPI
+Protocol template filename;Viability and Cell Count Assay - NC-200.cmsx
+Protocol adaptation title;example cell counting
+Protocol adaptation purpose;Cell Count and Viability with AO and DAPI
+Protocol adaptation filename;94A29BE3f39d48cd8eb5cb9472add350.cmsu
+Instrument type;NucleoView NC-200
+Instrument s/n;s/n 9000201099909999
+Date time;20231120 163016
+Time zone offset;2
+Login ID;admin
+PC;DESKTOP-A678B9H
+Application SW version;1.4.2.0
+21 CFR Part 11;disabled
+Event log format;Plain text
+csv file version;2
+
+//[ECEC5A41]

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example05.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example05.json
@@ -1,0 +1,71 @@
+{
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "cell counting aggregate document": {
+        "cell counting document": [
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "measurement time": "2023-11-20T16:30:16+02:00",
+                            "measurement identifier": "08222a88-7587-492c-8812-9a1930bcec98",
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "dark field imager (cell counter)",
+                                        "detection type": "dark field"
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "cellsABCD"
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "viability (cell counter)": {
+                                            "value": 68.2,
+                                            "unit": "%"
+                                        },
+                                        "viable cell density (cell counter)": {
+                                            "value": 2.45,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "data processing document": {
+                                            "cell density dilution factor": {
+                                                "value": 1.0,
+                                                "unit": "(unitless)"
+                                            }
+                                        },
+                                        "total cell density (cell counter)": {
+                                            "value": 3.58,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "dead cell density (cell counter)": {
+                                            "value": 1.14,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "average total cell diameter": {
+                                            "value": "NaN",
+                                            "unit": "\u03bcm"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "analyst": "DrScientist"
+            }
+        ],
+        "device system document": {
+            "model number": "NucleoView NC-200",
+            "equipment serial number": "s/n 9000201099909999"
+        },
+        "data system document": {
+            "file name": "chemometec_nucleoview_example05.csv",
+            "software name": "NucleoView",
+            "ASM converter name": "allotropy",
+            "ASM converter version": "0.1.12"
+        }
+    }
+}

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example06.csv
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example06.csv
@@ -1,0 +1,48 @@
+Viability and Cell Count Assay - example cell counting; ;
+Image;20231120-0002-c-cellsABCD;
+Operator;DrScientist;
+Viability (%);92.8;
+Live (cells/ml);1.58E6;
+Dead (cells/ml);1.22E5;
+Total (cells/ml);1.70E6;
+; ;
+Estimated cell diameter (um);13.2 (Uncertain
+determination);
+Cell diameter standard deviation (um);7.7;
+(%) of cells in aggregates with five or more cells;5;
+Sample Volume (ul);200.0;
+Dilution Volume (ul);0.000;
+Multiplication factor;1.000;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+cm filename;20231120-0039-c-cellsABCD.cm
+Protocol template title;Viability and Cell Count Assay
+Protocol template purpose;Cell Count and Viability with AO and DAPI
+Protocol template filename;Viability and Cell Count Assay - NC-200.cmsx
+Protocol adaptation title;example cell counting
+Protocol adaptation purpose;Cell Count and Viability with AO and DAPI
+Protocol adaptation filename;287764ADc8824786b882bfc202a12044.cmsu
+Instrument type;NucleoView NC-200
+Instrument s/n;s/n 9000201099909999
+Date time;20231120 110300
+Time zone offset;-7
+Login ID;admin
+PC;ABC0-NBBS-FQ01
+Application SW version;1.4.0.0
+21 CFR Part 11;disabled
+Event log format;Plain text
+csv file version;2
+
+//[25FDBA08]

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example06.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example06.json
@@ -1,0 +1,71 @@
+{
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "cell counting aggregate document": {
+        "cell counting document": [
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "measurement time": "2023-11-20T11:03:00-07:00",
+                            "measurement identifier": "c4b6b876-e4b3-4639-be87-0c70d1ebc28f",
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "dark field imager (cell counter)",
+                                        "detection type": "dark field"
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "cellsABCD"
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "viability (cell counter)": {
+                                            "value": 92.8,
+                                            "unit": "%"
+                                        },
+                                        "viable cell density (cell counter)": {
+                                            "value": 1.58,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "data processing document": {
+                                            "cell density dilution factor": {
+                                                "value": 1.0,
+                                                "unit": "(unitless)"
+                                            }
+                                        },
+                                        "total cell density (cell counter)": {
+                                            "value": 1.7,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "dead cell density (cell counter)": {
+                                            "value": 0.122,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "average total cell diameter": {
+                                            "value": "NaN",
+                                            "unit": "\u03bcm"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "analyst": "DrScientist"
+            }
+        ],
+        "device system document": {
+            "model number": "NucleoView NC-200",
+            "equipment serial number": "s/n 9000201099909999"
+        },
+        "data system document": {
+            "file name": "chemometec_nucleoview_example06.csv",
+            "software name": "NucleoView",
+            "ASM converter name": "allotropy",
+            "ASM converter version": "0.1.12"
+        }
+    }
+}


### PR DESCRIPTION
Add support for non-numeric values in fields that are mapped to TQuantity type values.