### PR TITLE
Fix: calculated data name in elmer envision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add calculated data documents to Unchained Labs Lunatic adapter
 - Parser for ChemoMetic NucleoView
 - Add non numeric options for tQuantityValue value property
+- Add support for non-numeric values to ChemoMetic NucleoView
 ### Fixed
+- Perkin Elmer Envision: calculated data name now captures string to the left - rather than right - of the ‘=’ in the Formula cell.
+
 ### Changed
 - Simplify Moldev Softmax Pro parsing with dataclasses
 ### Deprecated

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
@@ -100,6 +100,10 @@ class CalculatedPlateInfo(PlateInfo):
             "Formula",
             msg="Unable to find expected formula for calculated results section.",
         )
+        name = assert_not_none(
+            search(r"^([^=]*)=", formula),
+            msg="Unable to find expected formula name for calculated results section.",
+        ).group(1)
 
         return CalculatedPlateInfo(
             number=plate_number,
@@ -111,10 +115,7 @@ class CalculatedPlateInfo(PlateInfo):
                 "Chamber temperature at start",
             ),
             formula=formula,
-            name=assert_not_none(
-                search(r"=\s*(.*)", formula),
-                msg="Unable to find expected formula description for calculated results section.",
-            ).group(1),
+            name=name.strip(),
         )
 
 

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_absorbance_example01.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_absorbance_example01.json
@@ -36114,7 +36114,7 @@
         "calculated data aggregate document": {
             "calculated data document": [
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36131,7 +36131,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36148,7 +36148,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36165,7 +36165,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36182,7 +36182,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36199,7 +36199,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36216,7 +36216,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36233,7 +36233,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36250,7 +36250,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36267,7 +36267,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36284,7 +36284,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36301,7 +36301,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36318,7 +36318,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36335,7 +36335,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36352,7 +36352,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36369,7 +36369,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36386,7 +36386,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36403,7 +36403,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36420,7 +36420,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36437,7 +36437,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36454,7 +36454,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36471,7 +36471,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36488,7 +36488,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36505,7 +36505,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36522,7 +36522,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36539,7 +36539,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36556,7 +36556,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36573,7 +36573,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36590,7 +36590,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36607,7 +36607,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36624,7 +36624,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36641,7 +36641,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -36658,7 +36658,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36675,7 +36675,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36692,7 +36692,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36709,7 +36709,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36726,7 +36726,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36743,7 +36743,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36760,7 +36760,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36777,7 +36777,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36794,7 +36794,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36811,7 +36811,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36828,7 +36828,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36845,7 +36845,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36862,7 +36862,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36879,7 +36879,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36896,7 +36896,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -36913,7 +36913,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36930,7 +36930,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36947,7 +36947,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -36964,7 +36964,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -36981,7 +36981,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -36998,7 +36998,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37015,7 +37015,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -37032,7 +37032,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37049,7 +37049,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37066,7 +37066,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37083,7 +37083,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37100,7 +37100,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37117,7 +37117,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37134,7 +37134,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37151,7 +37151,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37168,7 +37168,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37185,7 +37185,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37202,7 +37202,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37219,7 +37219,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37236,7 +37236,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37253,7 +37253,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37270,7 +37270,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37287,7 +37287,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37304,7 +37304,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37321,7 +37321,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37338,7 +37338,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37355,7 +37355,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37372,7 +37372,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37389,7 +37389,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -37406,7 +37406,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37423,7 +37423,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37440,7 +37440,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37457,7 +37457,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37474,7 +37474,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37491,7 +37491,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37508,7 +37508,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -37525,7 +37525,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37542,7 +37542,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37559,7 +37559,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37576,7 +37576,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37593,7 +37593,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37610,7 +37610,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37627,7 +37627,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37644,7 +37644,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37661,7 +37661,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37678,7 +37678,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37695,7 +37695,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37712,7 +37712,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37729,7 +37729,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37746,7 +37746,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37763,7 +37763,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37780,7 +37780,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37797,7 +37797,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -37814,7 +37814,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37831,7 +37831,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37848,7 +37848,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37865,7 +37865,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37882,7 +37882,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37899,7 +37899,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -37916,7 +37916,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37933,7 +37933,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37950,7 +37950,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37967,7 +37967,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -37984,7 +37984,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -38001,7 +38001,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38018,7 +38018,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38035,7 +38035,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38052,7 +38052,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38069,7 +38069,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38086,7 +38086,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38103,7 +38103,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38120,7 +38120,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38137,7 +38137,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38154,7 +38154,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38171,7 +38171,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38188,7 +38188,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38205,7 +38205,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38222,7 +38222,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38239,7 +38239,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38256,7 +38256,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -38273,7 +38273,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38290,7 +38290,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38307,7 +38307,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38324,7 +38324,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38341,7 +38341,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -38358,7 +38358,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38375,7 +38375,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38392,7 +38392,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38409,7 +38409,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38426,7 +38426,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38443,7 +38443,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38460,7 +38460,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38477,7 +38477,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38494,7 +38494,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38511,7 +38511,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38528,7 +38528,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38545,7 +38545,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38562,7 +38562,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38579,7 +38579,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38596,7 +38596,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38613,7 +38613,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38630,7 +38630,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38647,7 +38647,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38664,7 +38664,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38681,7 +38681,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38698,7 +38698,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38715,7 +38715,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38732,7 +38732,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38749,7 +38749,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38766,7 +38766,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38783,7 +38783,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38800,7 +38800,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38817,7 +38817,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38834,7 +38834,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38851,7 +38851,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38868,7 +38868,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38885,7 +38885,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38902,7 +38902,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38919,7 +38919,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38936,7 +38936,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -38953,7 +38953,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38970,7 +38970,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -38987,7 +38987,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39004,7 +39004,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39021,7 +39021,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39038,7 +39038,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39055,7 +39055,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -39072,7 +39072,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39089,7 +39089,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39106,7 +39106,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39123,7 +39123,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39140,7 +39140,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39157,7 +39157,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39174,7 +39174,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39191,7 +39191,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39208,7 +39208,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39225,7 +39225,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39242,7 +39242,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39259,7 +39259,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39276,7 +39276,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39293,7 +39293,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39310,7 +39310,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39327,7 +39327,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39344,7 +39344,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39361,7 +39361,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39378,7 +39378,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39395,7 +39395,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39412,7 +39412,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39429,7 +39429,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39446,7 +39446,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39463,7 +39463,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39480,7 +39480,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39497,7 +39497,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39514,7 +39514,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39531,7 +39531,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -39548,7 +39548,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39565,7 +39565,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39582,7 +39582,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39599,7 +39599,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39616,7 +39616,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39633,7 +39633,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39650,7 +39650,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39667,7 +39667,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39684,7 +39684,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39701,7 +39701,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39718,7 +39718,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39735,7 +39735,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39752,7 +39752,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39769,7 +39769,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39786,7 +39786,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39803,7 +39803,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39820,7 +39820,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39837,7 +39837,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39854,7 +39854,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39871,7 +39871,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -39888,7 +39888,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39905,7 +39905,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39922,7 +39922,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39939,7 +39939,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39956,7 +39956,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39973,7 +39973,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39990,7 +39990,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40007,7 +40007,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40024,7 +40024,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40041,7 +40041,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40058,7 +40058,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40075,7 +40075,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40092,7 +40092,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40109,7 +40109,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40126,7 +40126,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40143,7 +40143,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40160,7 +40160,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40177,7 +40177,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40194,7 +40194,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40211,7 +40211,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40228,7 +40228,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40245,7 +40245,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40262,7 +40262,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40279,7 +40279,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40296,7 +40296,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40313,7 +40313,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40330,7 +40330,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -40347,7 +40347,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40364,7 +40364,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40381,7 +40381,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40398,7 +40398,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -40415,7 +40415,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40432,7 +40432,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -40449,7 +40449,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40466,7 +40466,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40483,7 +40483,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40500,7 +40500,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40517,7 +40517,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40534,7 +40534,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40551,7 +40551,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40568,7 +40568,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40585,7 +40585,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40602,7 +40602,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40619,7 +40619,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40636,7 +40636,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40653,7 +40653,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40670,7 +40670,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40687,7 +40687,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40704,7 +40704,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40721,7 +40721,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40738,7 +40738,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40755,7 +40755,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40772,7 +40772,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -40789,7 +40789,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40806,7 +40806,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40823,7 +40823,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40840,7 +40840,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40857,7 +40857,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40874,7 +40874,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40891,7 +40891,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40908,7 +40908,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40925,7 +40925,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40942,7 +40942,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40959,7 +40959,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40976,7 +40976,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40993,7 +40993,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41010,7 +41010,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41027,7 +41027,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41044,7 +41044,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41061,7 +41061,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41078,7 +41078,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41095,7 +41095,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41112,7 +41112,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41129,7 +41129,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41146,7 +41146,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41163,7 +41163,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -41180,7 +41180,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41197,7 +41197,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41214,7 +41214,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41231,7 +41231,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41248,7 +41248,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41265,7 +41265,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41282,7 +41282,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41299,7 +41299,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41316,7 +41316,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41333,7 +41333,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41350,7 +41350,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41367,7 +41367,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41384,7 +41384,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41401,7 +41401,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41418,7 +41418,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41435,7 +41435,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41452,7 +41452,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41469,7 +41469,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41486,7 +41486,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41503,7 +41503,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41520,7 +41520,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41537,7 +41537,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41554,7 +41554,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41571,7 +41571,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41588,7 +41588,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41605,7 +41605,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41622,7 +41622,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41639,7 +41639,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41656,7 +41656,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41673,7 +41673,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41690,7 +41690,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -41707,7 +41707,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41724,7 +41724,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41741,7 +41741,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41758,7 +41758,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41775,7 +41775,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41792,7 +41792,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41809,7 +41809,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41826,7 +41826,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41843,7 +41843,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41860,7 +41860,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41877,7 +41877,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41894,7 +41894,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41911,7 +41911,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41928,7 +41928,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41945,7 +41945,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41962,7 +41962,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41979,7 +41979,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41996,7 +41996,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42013,7 +42013,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42030,7 +42030,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42047,7 +42047,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42064,7 +42064,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42081,7 +42081,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42098,7 +42098,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42115,7 +42115,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42132,7 +42132,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42149,7 +42149,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42166,7 +42166,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42183,7 +42183,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42200,7 +42200,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42217,7 +42217,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42234,7 +42234,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42251,7 +42251,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42268,7 +42268,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42285,7 +42285,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42302,7 +42302,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42319,7 +42319,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -42336,7 +42336,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42353,7 +42353,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42370,7 +42370,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42387,7 +42387,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42404,7 +42404,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42421,7 +42421,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42438,7 +42438,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -42455,7 +42455,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42472,7 +42472,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42489,7 +42489,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42506,7 +42506,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42523,7 +42523,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42540,7 +42540,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42557,7 +42557,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42574,7 +42574,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42591,7 +42591,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42608,7 +42608,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42625,7 +42625,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : Screen 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example01.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example01.json
@@ -5490,7 +5490,7 @@
         "calculated data aggregate document": {
             "calculated data document": [
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 3912.12920565,
                         "unit": "unitless"
@@ -5511,7 +5511,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 3923.92517971,
                         "unit": "unitless"
@@ -5532,7 +5532,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 3948.45245355,
                         "unit": "unitless"
@@ -5553,7 +5553,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 3933.03506298,
                         "unit": "unitless"
@@ -5574,7 +5574,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 4061.92827247,
                         "unit": "unitless"
@@ -5595,7 +5595,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 3996.61746992,
                         "unit": "unitless"
@@ -5616,7 +5616,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 2385.72193555,
                         "unit": "unitless"
@@ -5637,7 +5637,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 2384.42487617,
                         "unit": "unitless"
@@ -5658,7 +5658,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 2396.10683014,
                         "unit": "unitless"
@@ -5679,7 +5679,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 2390.61028269,
                         "unit": "unitless"
@@ -5700,7 +5700,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 2396.68321027,
                         "unit": "unitless"
@@ -5721,7 +5721,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 2424.70697585,
                         "unit": "unitless"
@@ -5742,7 +5742,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 1497.6939597,
                         "unit": "unitless"
@@ -5763,7 +5763,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 1488.29789767,
                         "unit": "unitless"
@@ -5784,7 +5784,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 1474.23429335,
                         "unit": "unitless"
@@ -5805,7 +5805,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 1513.01294815,
                         "unit": "unitless"
@@ -5826,7 +5826,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 1487.52148035,
                         "unit": "unitless"
@@ -5847,7 +5847,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 1471.02712185,
                         "unit": "unitless"
@@ -5868,7 +5868,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 1004.96752006,
                         "unit": "unitless"
@@ -5889,7 +5889,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 997.698002862,
                         "unit": "unitless"
@@ -5910,7 +5910,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 984.957281601,
                         "unit": "unitless"
@@ -5931,7 +5931,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 1017.18554813,
                         "unit": "unitless"
@@ -5952,7 +5952,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 968.985790113,
                         "unit": "unitless"
@@ -5973,7 +5973,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 1005.07749543,
                         "unit": "unitless"
@@ -5994,7 +5994,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 707.203907204,
                         "unit": "unitless"
@@ -6015,7 +6015,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 697.464104756,
                         "unit": "unitless"
@@ -6036,7 +6036,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 703.487537674,
                         "unit": "unitless"
@@ -6057,7 +6057,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 726.238246392,
                         "unit": "unitless"
@@ -6078,7 +6078,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 701.399029629,
                         "unit": "unitless"
@@ -6099,7 +6099,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 721.275009761,
                         "unit": "unitless"
@@ -6120,7 +6120,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 562.804988252,
                         "unit": "unitless"
@@ -6141,7 +6141,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 557.881619938,
                         "unit": "unitless"
@@ -6162,7 +6162,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 559.664129137,
                         "unit": "unitless"
@@ -6183,7 +6183,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 573.562254074,
                         "unit": "unitless"
@@ -6204,7 +6204,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 567.634735212,
                         "unit": "unitless"
@@ -6225,7 +6225,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 563.983204482,
                         "unit": "unitless"
@@ -6246,7 +6246,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 481.189418042,
                         "unit": "unitless"
@@ -6267,7 +6267,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 482.180558541,
                         "unit": "unitless"
@@ -6288,7 +6288,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 480.169042819,
                         "unit": "unitless"
@@ -6309,7 +6309,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 478.930200648,
                         "unit": "unitless"
@@ -6330,7 +6330,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 482.450907876,
                         "unit": "unitless"
@@ -6351,7 +6351,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 491.042828331,
                         "unit": "unitless"
@@ -6372,7 +6372,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 403.155127082,
                         "unit": "unitless"
@@ -6393,7 +6393,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 414.191684058,
                         "unit": "unitless"
@@ -6414,7 +6414,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 399.233942251,
                         "unit": "unitless"
@@ -6435,7 +6435,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 403.302222012,
                         "unit": "unitless"
@@ -6456,7 +6456,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 406.559451108,
                         "unit": "unitless"
@@ -6477,7 +6477,7 @@
                     "calculation description": "Calc 1: General = (X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000"
                 },
                 {
-                    "calculated data name": "(X / Y) * Z where X = AC HTRF Laser [Eu](1) channel 1 window 1  Y = AC HTRF Laser [Eu](1) channel 2 window 1  Z = 10000",
+                    "calculated data name": "Calc 1: General",
                     "calculated result": {
                         "value": 409.025761641,
                         "unit": "unitless"

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example04.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example04.json
@@ -33042,7 +33042,7 @@
         "calculated data aggregate document": {
             "calculated data document": [
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -33059,7 +33059,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -33076,7 +33076,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33093,7 +33093,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -33110,7 +33110,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -33127,7 +33127,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -33144,7 +33144,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 52.0,
                         "unit": "unitless"
@@ -33161,7 +33161,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33178,7 +33178,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33195,7 +33195,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33212,7 +33212,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 52.0,
                         "unit": "unitless"
@@ -33229,7 +33229,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33246,7 +33246,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 52.0,
                         "unit": "unitless"
@@ -33263,7 +33263,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -33280,7 +33280,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33297,7 +33297,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -33314,7 +33314,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -33331,7 +33331,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -33348,7 +33348,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -33365,7 +33365,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -33382,7 +33382,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -33399,7 +33399,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -33416,7 +33416,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -33433,7 +33433,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 16.0,
                         "unit": "unitless"
@@ -33450,7 +33450,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -33467,7 +33467,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33484,7 +33484,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -33501,7 +33501,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -33518,7 +33518,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33535,7 +33535,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -33552,7 +33552,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -33569,7 +33569,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -33586,7 +33586,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33603,7 +33603,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -33620,7 +33620,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 52.0,
                         "unit": "unitless"
@@ -33637,7 +33637,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -33654,7 +33654,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -33671,7 +33671,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -33688,7 +33688,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33705,7 +33705,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -33722,7 +33722,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -33739,7 +33739,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33756,7 +33756,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -33773,7 +33773,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -33790,7 +33790,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -33807,7 +33807,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -33824,7 +33824,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -33841,7 +33841,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -33858,7 +33858,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 16.0,
                         "unit": "unitless"
@@ -33875,7 +33875,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -33892,7 +33892,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -33909,7 +33909,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -33926,7 +33926,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33943,7 +33943,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -33960,7 +33960,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33977,7 +33977,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -33994,7 +33994,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34011,7 +34011,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -34028,7 +34028,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34045,7 +34045,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34062,7 +34062,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -34079,7 +34079,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34096,7 +34096,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -34113,7 +34113,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -34130,7 +34130,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -34147,7 +34147,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -34164,7 +34164,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -34181,7 +34181,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -34198,7 +34198,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -34215,7 +34215,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -34232,7 +34232,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -34249,7 +34249,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 16.0,
                         "unit": "unitless"
@@ -34266,7 +34266,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -34283,7 +34283,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -34300,7 +34300,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -34317,7 +34317,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -34334,7 +34334,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -34351,7 +34351,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34368,7 +34368,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -34385,7 +34385,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 56.0,
                         "unit": "unitless"
@@ -34402,7 +34402,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -34419,7 +34419,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 64.0,
                         "unit": "unitless"
@@ -34436,7 +34436,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -34453,7 +34453,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -34470,7 +34470,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -34487,7 +34487,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -34504,7 +34504,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -34521,7 +34521,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -34538,7 +34538,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -34555,7 +34555,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -34572,7 +34572,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -34589,7 +34589,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -34606,7 +34606,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -34623,7 +34623,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -34640,7 +34640,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -34657,7 +34657,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -34674,7 +34674,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -34691,7 +34691,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -34708,7 +34708,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -34725,7 +34725,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 56.0,
                         "unit": "unitless"
@@ -34742,7 +34742,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -34759,7 +34759,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34776,7 +34776,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -34793,7 +34793,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -34810,7 +34810,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -34827,7 +34827,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -34844,7 +34844,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -34861,7 +34861,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -34878,7 +34878,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -34895,7 +34895,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -34912,7 +34912,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -34929,7 +34929,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34946,7 +34946,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -34963,7 +34963,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -34980,7 +34980,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -34997,7 +34997,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -35014,7 +35014,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -35031,7 +35031,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -35048,7 +35048,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -35065,7 +35065,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -35082,7 +35082,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -35099,7 +35099,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 52.0,
                         "unit": "unitless"
@@ -35116,7 +35116,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35133,7 +35133,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35150,7 +35150,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -35167,7 +35167,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35184,7 +35184,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -35201,7 +35201,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35218,7 +35218,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35235,7 +35235,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -35252,7 +35252,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -35269,7 +35269,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -35286,7 +35286,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 52.0,
                         "unit": "unitless"
@@ -35303,7 +35303,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35320,7 +35320,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -35337,7 +35337,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35354,7 +35354,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -35371,7 +35371,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35388,7 +35388,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35405,7 +35405,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35422,7 +35422,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35439,7 +35439,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -35456,7 +35456,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -35473,7 +35473,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 16.0,
                         "unit": "unitless"
@@ -35490,7 +35490,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -35507,7 +35507,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -35524,7 +35524,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -35541,7 +35541,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -35558,7 +35558,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35575,7 +35575,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -35592,7 +35592,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35609,7 +35609,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35626,7 +35626,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -35643,7 +35643,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35660,7 +35660,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -35677,7 +35677,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35694,7 +35694,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35711,7 +35711,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 56.0,
                         "unit": "unitless"
@@ -35728,7 +35728,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -35745,7 +35745,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -35762,7 +35762,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -35779,7 +35779,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -35796,7 +35796,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -35813,7 +35813,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -35830,7 +35830,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35847,7 +35847,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -35864,7 +35864,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -35881,7 +35881,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -35898,7 +35898,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -35915,7 +35915,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -35932,7 +35932,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -35949,7 +35949,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -35966,7 +35966,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35983,7 +35983,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36000,7 +36000,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36017,7 +36017,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -36034,7 +36034,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36051,7 +36051,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36068,7 +36068,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36085,7 +36085,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36102,7 +36102,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -36119,7 +36119,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -36136,7 +36136,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -36153,7 +36153,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36170,7 +36170,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -36187,7 +36187,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36204,7 +36204,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -36221,7 +36221,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36238,7 +36238,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -36255,7 +36255,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36272,7 +36272,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36289,7 +36289,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 16.0,
                         "unit": "unitless"
@@ -36306,7 +36306,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -36323,7 +36323,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36340,7 +36340,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36357,7 +36357,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36374,7 +36374,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36391,7 +36391,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36408,7 +36408,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36425,7 +36425,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -36442,7 +36442,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36459,7 +36459,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36476,7 +36476,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36493,7 +36493,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36510,7 +36510,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36527,7 +36527,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -36544,7 +36544,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36561,7 +36561,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36578,7 +36578,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -36595,7 +36595,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -36612,7 +36612,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36629,7 +36629,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36646,7 +36646,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36663,7 +36663,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36680,7 +36680,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36697,7 +36697,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -36714,7 +36714,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -36731,7 +36731,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36748,7 +36748,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -36765,7 +36765,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -36782,7 +36782,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36799,7 +36799,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36816,7 +36816,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36833,7 +36833,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36850,7 +36850,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36867,7 +36867,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36884,7 +36884,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36901,7 +36901,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -36918,7 +36918,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36935,7 +36935,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36952,7 +36952,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -36969,7 +36969,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -36986,7 +36986,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37003,7 +37003,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37020,7 +37020,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37037,7 +37037,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37054,7 +37054,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -37071,7 +37071,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -37088,7 +37088,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37105,7 +37105,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -37122,7 +37122,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 16.0,
                         "unit": "unitless"
@@ -37139,7 +37139,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37156,7 +37156,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -37173,7 +37173,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37190,7 +37190,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -37207,7 +37207,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -37224,7 +37224,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37241,7 +37241,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -37258,7 +37258,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37275,7 +37275,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37292,7 +37292,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37309,7 +37309,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -37326,7 +37326,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37343,7 +37343,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37360,7 +37360,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37377,7 +37377,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37394,7 +37394,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -37411,7 +37411,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37428,7 +37428,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37445,7 +37445,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37462,7 +37462,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37479,7 +37479,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37496,7 +37496,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -37513,7 +37513,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -37530,7 +37530,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -37547,7 +37547,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37564,7 +37564,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -37581,7 +37581,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37598,7 +37598,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37615,7 +37615,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37632,7 +37632,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37649,7 +37649,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37666,7 +37666,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37683,7 +37683,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -37700,7 +37700,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -37717,7 +37717,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37734,7 +37734,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37751,7 +37751,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37768,7 +37768,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37785,7 +37785,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37802,7 +37802,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -37819,7 +37819,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37836,7 +37836,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -37853,7 +37853,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37870,7 +37870,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37887,7 +37887,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -37904,7 +37904,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37921,7 +37921,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 16.0,
                         "unit": "unitless"
@@ -37938,7 +37938,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 16.0,
                         "unit": "unitless"
@@ -37955,7 +37955,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37972,7 +37972,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -37989,7 +37989,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38006,7 +38006,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38023,7 +38023,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38040,7 +38040,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38057,7 +38057,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38074,7 +38074,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38091,7 +38091,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38108,7 +38108,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38125,7 +38125,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38142,7 +38142,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 52.0,
                         "unit": "unitless"
@@ -38159,7 +38159,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -38176,7 +38176,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38193,7 +38193,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -38210,7 +38210,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38227,7 +38227,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -38244,7 +38244,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38261,7 +38261,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38278,7 +38278,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38295,7 +38295,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -38312,7 +38312,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38329,7 +38329,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -38346,7 +38346,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 20.0,
                         "unit": "unitless"
@@ -38363,7 +38363,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38380,7 +38380,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -38397,7 +38397,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38414,7 +38414,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -38431,7 +38431,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38448,7 +38448,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -38465,7 +38465,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38482,7 +38482,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38499,7 +38499,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38516,7 +38516,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38533,7 +38533,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -38550,7 +38550,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38567,7 +38567,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38584,7 +38584,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -38601,7 +38601,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38618,7 +38618,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38635,7 +38635,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -38652,7 +38652,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38669,7 +38669,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 56.0,
                         "unit": "unitless"
@@ -38686,7 +38686,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38703,7 +38703,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38720,7 +38720,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38737,7 +38737,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 16.0,
                         "unit": "unitless"
@@ -38754,7 +38754,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -38771,7 +38771,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -38788,7 +38788,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -38805,7 +38805,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38822,7 +38822,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38839,7 +38839,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38856,7 +38856,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38873,7 +38873,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38890,7 +38890,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -38907,7 +38907,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38924,7 +38924,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38941,7 +38941,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -38958,7 +38958,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -38975,7 +38975,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -38992,7 +38992,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -39009,7 +39009,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -39026,7 +39026,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 24.0,
                         "unit": "unitless"
@@ -39043,7 +39043,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -39060,7 +39060,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -39077,7 +39077,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -39094,7 +39094,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -39111,7 +39111,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -39128,7 +39128,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -39145,7 +39145,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39162,7 +39162,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 28.0,
                         "unit": "unitless"
@@ -39179,7 +39179,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -39196,7 +39196,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -39213,7 +39213,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -39230,7 +39230,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -39247,7 +39247,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -39264,7 +39264,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -39281,7 +39281,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -39298,7 +39298,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39315,7 +39315,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -39332,7 +39332,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39349,7 +39349,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -39366,7 +39366,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -39383,7 +39383,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -39400,7 +39400,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -39417,7 +39417,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 44.0,
                         "unit": "unitless"
@@ -39434,7 +39434,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -39451,7 +39451,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39468,7 +39468,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39485,7 +39485,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 48.0,
                         "unit": "unitless"
@@ -39502,7 +39502,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -39519,7 +39519,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 36.0,
                         "unit": "unitless"
@@ -39536,7 +39536,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 32.0,
                         "unit": "unitless"
@@ -39553,7 +39553,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 16.0,
                         "unit": "unitless"
@@ -39570,7 +39570,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : RA 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39587,7 +39587,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39604,7 +39604,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39621,7 +39621,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39638,7 +39638,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39655,7 +39655,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39672,7 +39672,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39689,7 +39689,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39706,7 +39706,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39723,7 +39723,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39740,7 +39740,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39757,7 +39757,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39774,7 +39774,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39791,7 +39791,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39808,7 +39808,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39825,7 +39825,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39842,7 +39842,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39859,7 +39859,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39876,7 +39876,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39893,7 +39893,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39910,7 +39910,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39927,7 +39927,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39944,7 +39944,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -39961,7 +39961,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39978,7 +39978,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -39995,7 +39995,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40012,7 +40012,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40029,7 +40029,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40046,7 +40046,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40063,7 +40063,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40080,7 +40080,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40097,7 +40097,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40114,7 +40114,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40131,7 +40131,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40148,7 +40148,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40165,7 +40165,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40182,7 +40182,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40199,7 +40199,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40216,7 +40216,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40233,7 +40233,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40250,7 +40250,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40267,7 +40267,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40284,7 +40284,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40301,7 +40301,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40318,7 +40318,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40335,7 +40335,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40352,7 +40352,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40369,7 +40369,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40386,7 +40386,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40403,7 +40403,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40420,7 +40420,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40437,7 +40437,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40454,7 +40454,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -40471,7 +40471,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40488,7 +40488,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40505,7 +40505,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40522,7 +40522,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40539,7 +40539,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40556,7 +40556,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40573,7 +40573,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40590,7 +40590,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40607,7 +40607,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -40624,7 +40624,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40641,7 +40641,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40658,7 +40658,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40675,7 +40675,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40692,7 +40692,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -40709,7 +40709,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40726,7 +40726,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40743,7 +40743,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40760,7 +40760,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40777,7 +40777,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40794,7 +40794,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40811,7 +40811,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40828,7 +40828,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40845,7 +40845,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40862,7 +40862,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40879,7 +40879,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40896,7 +40896,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40913,7 +40913,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40930,7 +40930,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40947,7 +40947,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40964,7 +40964,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -40981,7 +40981,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -40998,7 +40998,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41015,7 +41015,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41032,7 +41032,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41049,7 +41049,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41066,7 +41066,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41083,7 +41083,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41100,7 +41100,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41117,7 +41117,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41134,7 +41134,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41151,7 +41151,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41168,7 +41168,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41185,7 +41185,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41202,7 +41202,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41219,7 +41219,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41236,7 +41236,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41253,7 +41253,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41270,7 +41270,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41287,7 +41287,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 16.0,
                         "unit": "unitless"
@@ -41304,7 +41304,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41321,7 +41321,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41338,7 +41338,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41355,7 +41355,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41372,7 +41372,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41389,7 +41389,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41406,7 +41406,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41423,7 +41423,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41440,7 +41440,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41457,7 +41457,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41474,7 +41474,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41491,7 +41491,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41508,7 +41508,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41525,7 +41525,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41542,7 +41542,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41559,7 +41559,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41576,7 +41576,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41593,7 +41593,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41610,7 +41610,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41627,7 +41627,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41644,7 +41644,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41661,7 +41661,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41678,7 +41678,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41695,7 +41695,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41712,7 +41712,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41729,7 +41729,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41746,7 +41746,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41763,7 +41763,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41780,7 +41780,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41797,7 +41797,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41814,7 +41814,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41831,7 +41831,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41848,7 +41848,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41865,7 +41865,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41882,7 +41882,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41899,7 +41899,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41916,7 +41916,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41933,7 +41933,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41950,7 +41950,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -41967,7 +41967,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -41984,7 +41984,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42001,7 +42001,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42018,7 +42018,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42035,7 +42035,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42052,7 +42052,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -42069,7 +42069,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42086,7 +42086,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42103,7 +42103,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42120,7 +42120,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42137,7 +42137,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42154,7 +42154,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42171,7 +42171,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42188,7 +42188,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42205,7 +42205,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42222,7 +42222,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42239,7 +42239,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42256,7 +42256,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42273,7 +42273,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42290,7 +42290,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42307,7 +42307,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42324,7 +42324,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42341,7 +42341,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42358,7 +42358,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42375,7 +42375,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42392,7 +42392,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42409,7 +42409,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42426,7 +42426,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42443,7 +42443,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42460,7 +42460,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42477,7 +42477,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42494,7 +42494,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42511,7 +42511,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42528,7 +42528,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42545,7 +42545,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42562,7 +42562,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42579,7 +42579,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42596,7 +42596,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -42613,7 +42613,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42630,7 +42630,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -42647,7 +42647,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42664,7 +42664,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42681,7 +42681,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42698,7 +42698,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42715,7 +42715,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42732,7 +42732,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42749,7 +42749,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42766,7 +42766,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42783,7 +42783,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42800,7 +42800,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42817,7 +42817,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42834,7 +42834,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42851,7 +42851,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42868,7 +42868,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42885,7 +42885,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42902,7 +42902,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42919,7 +42919,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42936,7 +42936,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42953,7 +42953,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -42970,7 +42970,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -42987,7 +42987,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43004,7 +43004,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -43021,7 +43021,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43038,7 +43038,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43055,7 +43055,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43072,7 +43072,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43089,7 +43089,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43106,7 +43106,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43123,7 +43123,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43140,7 +43140,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43157,7 +43157,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43174,7 +43174,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43191,7 +43191,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43208,7 +43208,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43225,7 +43225,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43242,7 +43242,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43259,7 +43259,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43276,7 +43276,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43293,7 +43293,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43310,7 +43310,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43327,7 +43327,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43344,7 +43344,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43361,7 +43361,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43378,7 +43378,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43395,7 +43395,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43412,7 +43412,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43429,7 +43429,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43446,7 +43446,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43463,7 +43463,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43480,7 +43480,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43497,7 +43497,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43514,7 +43514,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43531,7 +43531,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43548,7 +43548,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43565,7 +43565,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43582,7 +43582,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43599,7 +43599,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43616,7 +43616,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43633,7 +43633,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43650,7 +43650,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43667,7 +43667,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43684,7 +43684,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43701,7 +43701,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43718,7 +43718,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43735,7 +43735,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43752,7 +43752,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43769,7 +43769,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43786,7 +43786,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43803,7 +43803,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -43820,7 +43820,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43837,7 +43837,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43854,7 +43854,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43871,7 +43871,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43888,7 +43888,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43905,7 +43905,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -43922,7 +43922,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43939,7 +43939,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -43956,7 +43956,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43973,7 +43973,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -43990,7 +43990,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44007,7 +44007,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44024,7 +44024,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44041,7 +44041,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44058,7 +44058,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44075,7 +44075,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44092,7 +44092,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44109,7 +44109,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44126,7 +44126,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44143,7 +44143,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44160,7 +44160,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44177,7 +44177,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44194,7 +44194,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44211,7 +44211,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44228,7 +44228,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44245,7 +44245,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44262,7 +44262,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44279,7 +44279,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44296,7 +44296,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44313,7 +44313,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44330,7 +44330,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44347,7 +44347,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44364,7 +44364,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44381,7 +44381,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44398,7 +44398,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44415,7 +44415,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44432,7 +44432,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44449,7 +44449,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44466,7 +44466,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44483,7 +44483,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44500,7 +44500,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44517,7 +44517,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44534,7 +44534,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44551,7 +44551,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44568,7 +44568,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44585,7 +44585,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -44602,7 +44602,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44619,7 +44619,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44636,7 +44636,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44653,7 +44653,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44670,7 +44670,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44687,7 +44687,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44704,7 +44704,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44721,7 +44721,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44738,7 +44738,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44755,7 +44755,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44772,7 +44772,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44789,7 +44789,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44806,7 +44806,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44823,7 +44823,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44840,7 +44840,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44857,7 +44857,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44874,7 +44874,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44891,7 +44891,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44908,7 +44908,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44925,7 +44925,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44942,7 +44942,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44959,7 +44959,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -44976,7 +44976,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -44993,7 +44993,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45010,7 +45010,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45027,7 +45027,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45044,7 +45044,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45061,7 +45061,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45078,7 +45078,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45095,7 +45095,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45112,7 +45112,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -45129,7 +45129,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45146,7 +45146,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45163,7 +45163,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45180,7 +45180,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45197,7 +45197,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45214,7 +45214,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45231,7 +45231,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45248,7 +45248,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45265,7 +45265,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45282,7 +45282,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45299,7 +45299,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45316,7 +45316,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45333,7 +45333,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45350,7 +45350,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45367,7 +45367,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45384,7 +45384,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45401,7 +45401,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45418,7 +45418,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45435,7 +45435,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45452,7 +45452,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -45469,7 +45469,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45486,7 +45486,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45503,7 +45503,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45520,7 +45520,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45537,7 +45537,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45554,7 +45554,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45571,7 +45571,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45588,7 +45588,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45605,7 +45605,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45622,7 +45622,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45639,7 +45639,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45656,7 +45656,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45673,7 +45673,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45690,7 +45690,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45707,7 +45707,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45724,7 +45724,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45741,7 +45741,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 12.0,
                         "unit": "unitless"
@@ -45758,7 +45758,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45775,7 +45775,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45792,7 +45792,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45809,7 +45809,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45826,7 +45826,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45843,7 +45843,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45860,7 +45860,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45877,7 +45877,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45894,7 +45894,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45911,7 +45911,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45928,7 +45928,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45945,7 +45945,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -45962,7 +45962,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45979,7 +45979,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -45996,7 +45996,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -46013,7 +46013,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -46030,7 +46030,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -46047,7 +46047,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"
@@ -46064,7 +46064,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 4.0,
                         "unit": "unitless"
@@ -46081,7 +46081,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : HTS 384 OptiPlate(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 8.0,
                         "unit": "unitless"

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_luminescence_example01.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_luminescence_example01.json
@@ -32274,7 +32274,7 @@
         "calculated data aggregate document": {
             "calculated data document": [
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32291,7 +32291,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32308,7 +32308,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32325,7 +32325,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32342,7 +32342,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32359,7 +32359,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32376,7 +32376,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 80.0,
                         "unit": "unitless"
@@ -32393,7 +32393,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32410,7 +32410,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32427,7 +32427,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32444,7 +32444,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32461,7 +32461,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32478,7 +32478,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32495,7 +32495,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32512,7 +32512,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32529,7 +32529,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32546,7 +32546,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32563,7 +32563,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32580,7 +32580,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32597,7 +32597,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32614,7 +32614,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32631,7 +32631,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32648,7 +32648,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32665,7 +32665,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32682,7 +32682,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32699,7 +32699,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32716,7 +32716,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32733,7 +32733,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32750,7 +32750,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32767,7 +32767,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32784,7 +32784,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32801,7 +32801,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32818,7 +32818,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32835,7 +32835,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32852,7 +32852,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32869,7 +32869,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32886,7 +32886,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32903,7 +32903,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -32920,7 +32920,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32937,7 +32937,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32954,7 +32954,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32971,7 +32971,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -32988,7 +32988,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33005,7 +33005,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33022,7 +33022,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33039,7 +33039,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33056,7 +33056,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33073,7 +33073,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33090,7 +33090,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33107,7 +33107,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33124,7 +33124,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33141,7 +33141,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33158,7 +33158,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33175,7 +33175,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33192,7 +33192,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33209,7 +33209,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33226,7 +33226,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33243,7 +33243,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33260,7 +33260,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33277,7 +33277,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33294,7 +33294,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33311,7 +33311,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33328,7 +33328,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33345,7 +33345,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33362,7 +33362,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33379,7 +33379,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33396,7 +33396,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33413,7 +33413,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33430,7 +33430,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33447,7 +33447,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33464,7 +33464,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33481,7 +33481,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33498,7 +33498,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33515,7 +33515,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33532,7 +33532,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33549,7 +33549,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33566,7 +33566,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33583,7 +33583,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33600,7 +33600,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33617,7 +33617,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33634,7 +33634,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33651,7 +33651,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33668,7 +33668,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33685,7 +33685,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33702,7 +33702,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33719,7 +33719,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33736,7 +33736,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33753,7 +33753,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33770,7 +33770,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33787,7 +33787,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33804,7 +33804,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33821,7 +33821,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33838,7 +33838,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33855,7 +33855,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33872,7 +33872,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -33889,7 +33889,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33906,7 +33906,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33923,7 +33923,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33940,7 +33940,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33957,7 +33957,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33974,7 +33974,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -33991,7 +33991,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34008,7 +34008,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34025,7 +34025,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34042,7 +34042,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34059,7 +34059,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34076,7 +34076,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34093,7 +34093,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34110,7 +34110,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34127,7 +34127,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 80.0,
                         "unit": "unitless"
@@ -34144,7 +34144,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34161,7 +34161,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34178,7 +34178,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34195,7 +34195,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34212,7 +34212,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34229,7 +34229,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34246,7 +34246,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34263,7 +34263,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34280,7 +34280,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34297,7 +34297,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34314,7 +34314,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34331,7 +34331,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34348,7 +34348,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34365,7 +34365,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34382,7 +34382,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34399,7 +34399,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34416,7 +34416,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34433,7 +34433,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34450,7 +34450,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34467,7 +34467,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34484,7 +34484,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34501,7 +34501,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34518,7 +34518,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34535,7 +34535,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34552,7 +34552,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34569,7 +34569,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34586,7 +34586,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34603,7 +34603,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34620,7 +34620,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34637,7 +34637,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34654,7 +34654,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34671,7 +34671,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34688,7 +34688,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34705,7 +34705,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34722,7 +34722,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34739,7 +34739,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34756,7 +34756,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34773,7 +34773,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34790,7 +34790,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34807,7 +34807,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34824,7 +34824,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34841,7 +34841,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34858,7 +34858,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34875,7 +34875,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34892,7 +34892,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34909,7 +34909,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34926,7 +34926,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -34943,7 +34943,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34960,7 +34960,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34977,7 +34977,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -34994,7 +34994,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35011,7 +35011,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35028,7 +35028,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 120.0,
                         "unit": "unitless"
@@ -35045,7 +35045,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35062,7 +35062,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35079,7 +35079,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35096,7 +35096,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35113,7 +35113,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35130,7 +35130,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35147,7 +35147,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35164,7 +35164,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35181,7 +35181,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35198,7 +35198,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35215,7 +35215,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35232,7 +35232,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35249,7 +35249,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35266,7 +35266,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35283,7 +35283,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35300,7 +35300,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35317,7 +35317,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35334,7 +35334,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35351,7 +35351,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35368,7 +35368,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35385,7 +35385,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35402,7 +35402,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35419,7 +35419,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35436,7 +35436,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35453,7 +35453,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35470,7 +35470,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35487,7 +35487,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35504,7 +35504,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35521,7 +35521,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35538,7 +35538,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35555,7 +35555,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35572,7 +35572,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35589,7 +35589,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35606,7 +35606,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35623,7 +35623,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35640,7 +35640,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35657,7 +35657,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 120.0,
                         "unit": "unitless"
@@ -35674,7 +35674,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35691,7 +35691,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35708,7 +35708,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35725,7 +35725,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35742,7 +35742,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35759,7 +35759,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35776,7 +35776,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35793,7 +35793,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35810,7 +35810,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35827,7 +35827,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35844,7 +35844,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35861,7 +35861,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35878,7 +35878,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35895,7 +35895,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -35912,7 +35912,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35929,7 +35929,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35946,7 +35946,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35963,7 +35963,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35980,7 +35980,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -35997,7 +35997,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36014,7 +36014,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36031,7 +36031,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36048,7 +36048,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36065,7 +36065,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36082,7 +36082,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36099,7 +36099,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36116,7 +36116,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36133,7 +36133,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36150,7 +36150,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36167,7 +36167,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36184,7 +36184,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36201,7 +36201,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36218,7 +36218,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36235,7 +36235,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36252,7 +36252,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 80.0,
                         "unit": "unitless"
@@ -36269,7 +36269,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36286,7 +36286,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36303,7 +36303,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36320,7 +36320,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36337,7 +36337,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36354,7 +36354,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36371,7 +36371,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36388,7 +36388,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36405,7 +36405,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36422,7 +36422,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36439,7 +36439,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36456,7 +36456,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36473,7 +36473,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36490,7 +36490,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36507,7 +36507,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36524,7 +36524,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36541,7 +36541,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36558,7 +36558,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36575,7 +36575,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36592,7 +36592,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36609,7 +36609,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36626,7 +36626,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36643,7 +36643,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36660,7 +36660,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36677,7 +36677,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36694,7 +36694,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36711,7 +36711,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36728,7 +36728,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36745,7 +36745,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36762,7 +36762,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36779,7 +36779,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36796,7 +36796,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36813,7 +36813,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36830,7 +36830,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36847,7 +36847,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36864,7 +36864,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36881,7 +36881,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36898,7 +36898,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36915,7 +36915,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36932,7 +36932,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36949,7 +36949,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -36966,7 +36966,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -36983,7 +36983,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37000,7 +37000,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37017,7 +37017,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37034,7 +37034,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 80.0,
                         "unit": "unitless"
@@ -37051,7 +37051,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37068,7 +37068,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37085,7 +37085,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37102,7 +37102,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37119,7 +37119,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37136,7 +37136,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37153,7 +37153,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37170,7 +37170,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37187,7 +37187,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37204,7 +37204,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37221,7 +37221,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37238,7 +37238,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37255,7 +37255,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37272,7 +37272,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37289,7 +37289,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37306,7 +37306,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37323,7 +37323,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37340,7 +37340,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37357,7 +37357,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37374,7 +37374,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37391,7 +37391,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37408,7 +37408,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37425,7 +37425,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37442,7 +37442,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 80.0,
                         "unit": "unitless"
@@ -37459,7 +37459,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37476,7 +37476,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37493,7 +37493,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37510,7 +37510,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37527,7 +37527,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37544,7 +37544,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37561,7 +37561,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37578,7 +37578,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37595,7 +37595,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37612,7 +37612,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37629,7 +37629,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37646,7 +37646,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37663,7 +37663,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 80.0,
                         "unit": "unitless"
@@ -37680,7 +37680,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37697,7 +37697,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37714,7 +37714,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37731,7 +37731,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37748,7 +37748,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37765,7 +37765,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37782,7 +37782,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37799,7 +37799,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37816,7 +37816,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37833,7 +37833,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37850,7 +37850,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37867,7 +37867,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37884,7 +37884,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37901,7 +37901,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37918,7 +37918,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37935,7 +37935,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37952,7 +37952,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -37969,7 +37969,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -37986,7 +37986,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38003,7 +38003,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38020,7 +38020,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38037,7 +38037,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38054,7 +38054,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38071,7 +38071,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38088,7 +38088,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38105,7 +38105,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38122,7 +38122,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38139,7 +38139,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38156,7 +38156,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38173,7 +38173,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38190,7 +38190,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38207,7 +38207,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38224,7 +38224,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38241,7 +38241,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38258,7 +38258,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38275,7 +38275,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38292,7 +38292,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38309,7 +38309,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38326,7 +38326,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38343,7 +38343,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38360,7 +38360,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38377,7 +38377,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38394,7 +38394,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38411,7 +38411,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38428,7 +38428,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38445,7 +38445,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38462,7 +38462,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38479,7 +38479,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38496,7 +38496,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38513,7 +38513,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38530,7 +38530,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38547,7 +38547,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38564,7 +38564,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38581,7 +38581,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38598,7 +38598,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38615,7 +38615,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38632,7 +38632,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38649,7 +38649,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38666,7 +38666,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38683,7 +38683,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38700,7 +38700,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38717,7 +38717,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38734,7 +38734,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38751,7 +38751,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38768,7 +38768,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38785,7 +38785,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38802,7 +38802,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38819,7 +38819,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38836,7 +38836,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38853,7 +38853,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38870,7 +38870,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38887,7 +38887,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38904,7 +38904,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38921,7 +38921,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38938,7 +38938,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -38955,7 +38955,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38972,7 +38972,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -38989,7 +38989,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39006,7 +39006,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39023,7 +39023,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39040,7 +39040,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39057,7 +39057,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39074,7 +39074,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39091,7 +39091,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39108,7 +39108,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39125,7 +39125,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39142,7 +39142,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39159,7 +39159,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39176,7 +39176,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39193,7 +39193,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39210,7 +39210,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39227,7 +39227,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39244,7 +39244,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39261,7 +39261,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 80.0,
                         "unit": "unitless"
@@ -39278,7 +39278,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39295,7 +39295,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39312,7 +39312,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39329,7 +39329,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39346,7 +39346,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39363,7 +39363,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39380,7 +39380,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39397,7 +39397,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39414,7 +39414,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39431,7 +39431,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39448,7 +39448,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39465,7 +39465,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39482,7 +39482,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39499,7 +39499,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39516,7 +39516,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39533,7 +39533,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39550,7 +39550,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39567,7 +39567,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39584,7 +39584,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39601,7 +39601,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 80.0,
                         "unit": "unitless"
@@ -39618,7 +39618,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39635,7 +39635,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39652,7 +39652,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39669,7 +39669,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39686,7 +39686,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39703,7 +39703,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39720,7 +39720,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39737,7 +39737,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39754,7 +39754,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39771,7 +39771,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39788,7 +39788,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39805,7 +39805,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39822,7 +39822,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39839,7 +39839,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39856,7 +39856,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39873,7 +39873,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39890,7 +39890,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39907,7 +39907,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39924,7 +39924,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -39941,7 +39941,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39958,7 +39958,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39975,7 +39975,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -39992,7 +39992,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40009,7 +40009,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40026,7 +40026,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40043,7 +40043,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40060,7 +40060,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40077,7 +40077,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40094,7 +40094,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40111,7 +40111,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40128,7 +40128,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40145,7 +40145,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40162,7 +40162,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40179,7 +40179,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40196,7 +40196,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40213,7 +40213,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40230,7 +40230,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40247,7 +40247,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40264,7 +40264,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40281,7 +40281,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40298,7 +40298,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40315,7 +40315,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40332,7 +40332,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40349,7 +40349,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40366,7 +40366,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40383,7 +40383,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40400,7 +40400,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40417,7 +40417,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40434,7 +40434,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 80.0,
                         "unit": "unitless"
@@ -40451,7 +40451,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40468,7 +40468,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40485,7 +40485,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40502,7 +40502,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40519,7 +40519,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40536,7 +40536,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40553,7 +40553,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40570,7 +40570,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40587,7 +40587,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40604,7 +40604,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40621,7 +40621,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40638,7 +40638,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40655,7 +40655,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40672,7 +40672,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40689,7 +40689,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40706,7 +40706,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40723,7 +40723,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40740,7 +40740,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40757,7 +40757,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40774,7 +40774,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40791,7 +40791,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40808,7 +40808,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40825,7 +40825,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40842,7 +40842,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40859,7 +40859,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40876,7 +40876,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40893,7 +40893,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40910,7 +40910,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40927,7 +40927,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40944,7 +40944,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40961,7 +40961,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -40978,7 +40978,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -40995,7 +40995,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41012,7 +41012,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41029,7 +41029,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41046,7 +41046,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41063,7 +41063,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41080,7 +41080,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41097,7 +41097,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41114,7 +41114,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41131,7 +41131,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41148,7 +41148,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41165,7 +41165,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41182,7 +41182,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41199,7 +41199,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41216,7 +41216,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41233,7 +41233,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41250,7 +41250,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41267,7 +41267,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41284,7 +41284,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41301,7 +41301,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41318,7 +41318,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41335,7 +41335,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41352,7 +41352,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41369,7 +41369,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41386,7 +41386,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41403,7 +41403,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41420,7 +41420,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41437,7 +41437,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 80.0,
                         "unit": "unitless"
@@ -41454,7 +41454,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41471,7 +41471,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41488,7 +41488,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41505,7 +41505,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41522,7 +41522,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41539,7 +41539,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41556,7 +41556,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41573,7 +41573,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41590,7 +41590,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41607,7 +41607,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41624,7 +41624,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41641,7 +41641,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41658,7 +41658,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41675,7 +41675,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41692,7 +41692,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41709,7 +41709,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41726,7 +41726,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41743,7 +41743,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41760,7 +41760,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41777,7 +41777,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41794,7 +41794,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41811,7 +41811,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41828,7 +41828,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41845,7 +41845,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41862,7 +41862,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41879,7 +41879,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41896,7 +41896,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41913,7 +41913,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41930,7 +41930,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41947,7 +41947,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -41964,7 +41964,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41981,7 +41981,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -41998,7 +41998,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42015,7 +42015,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42032,7 +42032,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42049,7 +42049,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42066,7 +42066,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42083,7 +42083,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42100,7 +42100,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42117,7 +42117,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42134,7 +42134,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42151,7 +42151,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42168,7 +42168,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42185,7 +42185,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42202,7 +42202,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42219,7 +42219,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42236,7 +42236,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42253,7 +42253,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42270,7 +42270,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42287,7 +42287,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42304,7 +42304,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42321,7 +42321,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42338,7 +42338,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42355,7 +42355,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42372,7 +42372,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42389,7 +42389,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42406,7 +42406,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42423,7 +42423,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42440,7 +42440,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42457,7 +42457,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42474,7 +42474,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42491,7 +42491,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42508,7 +42508,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42525,7 +42525,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42542,7 +42542,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42559,7 +42559,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42576,7 +42576,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42593,7 +42593,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42610,7 +42610,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42627,7 +42627,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42644,7 +42644,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42661,7 +42661,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42678,7 +42678,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42695,7 +42695,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42712,7 +42712,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42729,7 +42729,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42746,7 +42746,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42763,7 +42763,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42780,7 +42780,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42797,7 +42797,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42814,7 +42814,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42831,7 +42831,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42848,7 +42848,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42865,7 +42865,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42882,7 +42882,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42899,7 +42899,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42916,7 +42916,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42933,7 +42933,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42950,7 +42950,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -42967,7 +42967,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -42984,7 +42984,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43001,7 +43001,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43018,7 +43018,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43035,7 +43035,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43052,7 +43052,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43069,7 +43069,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43086,7 +43086,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43103,7 +43103,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43120,7 +43120,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43137,7 +43137,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43154,7 +43154,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43171,7 +43171,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43188,7 +43188,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43205,7 +43205,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43222,7 +43222,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43239,7 +43239,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43256,7 +43256,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43273,7 +43273,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43290,7 +43290,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43307,7 +43307,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43324,7 +43324,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43341,7 +43341,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43358,7 +43358,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43375,7 +43375,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43392,7 +43392,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43409,7 +43409,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43426,7 +43426,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43443,7 +43443,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43460,7 +43460,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43477,7 +43477,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43494,7 +43494,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43511,7 +43511,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43528,7 +43528,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43545,7 +43545,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43562,7 +43562,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43579,7 +43579,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43596,7 +43596,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43613,7 +43613,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43630,7 +43630,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43647,7 +43647,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43664,7 +43664,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43681,7 +43681,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43698,7 +43698,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43715,7 +43715,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43732,7 +43732,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43749,7 +43749,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43766,7 +43766,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43783,7 +43783,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43800,7 +43800,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43817,7 +43817,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43834,7 +43834,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43851,7 +43851,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43868,7 +43868,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43885,7 +43885,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43902,7 +43902,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43919,7 +43919,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43936,7 +43936,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -43953,7 +43953,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43970,7 +43970,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -43987,7 +43987,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44004,7 +44004,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44021,7 +44021,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44038,7 +44038,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44055,7 +44055,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44072,7 +44072,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44089,7 +44089,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44106,7 +44106,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44123,7 +44123,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44140,7 +44140,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44157,7 +44157,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44174,7 +44174,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44191,7 +44191,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44208,7 +44208,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44225,7 +44225,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44242,7 +44242,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44259,7 +44259,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44276,7 +44276,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44293,7 +44293,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44310,7 +44310,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44327,7 +44327,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44344,7 +44344,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44361,7 +44361,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44378,7 +44378,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44395,7 +44395,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44412,7 +44412,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44429,7 +44429,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44446,7 +44446,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44463,7 +44463,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44480,7 +44480,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44497,7 +44497,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44514,7 +44514,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44531,7 +44531,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44548,7 +44548,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44565,7 +44565,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44582,7 +44582,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44599,7 +44599,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44616,7 +44616,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44633,7 +44633,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44650,7 +44650,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44667,7 +44667,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44684,7 +44684,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44701,7 +44701,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44718,7 +44718,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44735,7 +44735,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44752,7 +44752,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44769,7 +44769,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44786,7 +44786,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44803,7 +44803,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44820,7 +44820,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44837,7 +44837,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44854,7 +44854,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44871,7 +44871,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44888,7 +44888,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44905,7 +44905,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44922,7 +44922,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44939,7 +44939,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -44956,7 +44956,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44973,7 +44973,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -44990,7 +44990,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45007,7 +45007,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45024,7 +45024,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -45041,7 +45041,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45058,7 +45058,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45075,7 +45075,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -45092,7 +45092,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45109,7 +45109,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -45126,7 +45126,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -45143,7 +45143,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45160,7 +45160,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45177,7 +45177,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45194,7 +45194,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -45211,7 +45211,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45228,7 +45228,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45245,7 +45245,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -45262,7 +45262,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -45279,7 +45279,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 0.0,
                         "unit": "unitless"
@@ -45296,7 +45296,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"
@@ -45313,7 +45313,7 @@
                     "calculation description": "Calc 1: Crosstalk = Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1"
                 },
                 {
-                    "calculated data name": "Crosstalk correction where Label : 0_1 US LUM 384(1) channel 1",
+                    "calculated data name": "Calc 1: Crosstalk",
                     "calculated result": {
                         "value": 40.0,
                         "unit": "unitless"


### PR DESCRIPTION
In the Perkin Elmer Envision Adapter the calculated data name of the calculated data documents was being incorrectly parsed.
- Instead of grabbing the left part of the `formula` column on the `Plate information` block, the adapter was taking the right part.
- Added additional test for the structure class in charge of parsing this property.
