### PR TITLE
Improve test_utils

### DIFF
--- a/tests/parsers/agilent_gen5/to_allotrope_test.py
+++ b/tests/parsers/agilent_gen5/to_allotrope_test.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 
 from allotropy.allotrope.allotrope import serialize_allotrope
@@ -9,6 +7,7 @@ from allotropy.allotrope.models.ultraviolet_absorbance_benchling_2023_09_ultravi
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.parser_factory import Vendor
 from tests.parsers.test_utils import (
+    DictType,
     from_file,
     model_from_file,
     validate_contents,
@@ -28,9 +27,7 @@ ABSORBENCE_FILENAMES = [
 ]
 
 
-def _validate_allotrope_dict(
-    allotrope_dict: dict[str, Any], expected_filepath: str
-) -> None:
+def _validate_allotrope_dict(allotrope_dict: DictType, expected_filepath: str) -> None:
     validate_schema(
         allotrope_dict,
         "ultraviolet-absorbance/BENCHLING/2023/09/ultraviolet-absorbance.json",

--- a/tests/parsers/test_utils.py
+++ b/tests/parsers/test_utils.py
@@ -29,7 +29,7 @@ def _replace_asm_converter_name_and_version(allotrope_dict: DictType) -> DictTyp
     return new_dict
 
 
-def assert_allotrope_dicts_equal(
+def _assert_allotrope_dicts_equal(
     expected: DictType,
     actual: DictType,
     identifiers_to_exclude: Optional[list[str]] = None,
@@ -71,11 +71,17 @@ def validate_schema(allotrope_dict: DictType, schema_relative_path: str) -> None
     )
 
 
-def validate_contents(allotrope_dict: DictType, expected_file: str) -> None:
+def validate_contents(
+    allotrope_dict: DictType,
+    expected_file: str,
+    identifiers_to_exclude: Optional[list[str]] = None,
+) -> None:
     """Use the newly created allotrope_dict to validate the contents inside expected_file."""
     with open(expected_file) as f:
         expected_dict = json.load(f)
-        assert_allotrope_dicts_equal(expected_dict, allotrope_dict)
+    _assert_allotrope_dicts_equal(
+        expected_dict, allotrope_dict, identifiers_to_exclude=identifiers_to_exclude
+    )
 
 
 def build_series(elements: list[tuple[Any]]) -> pd.Series[Any]:

--- a/tests/parsers/test_utils.py
+++ b/tests/parsers/test_utils.py
@@ -14,6 +14,10 @@ from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
 from allotropy.parser_factory import VendorType
 from allotropy.to_allotrope import allotrope_from_file, allotrope_model_from_file
 
+CALCULATED_DATA_IDENTIFIER = "calculated data identifier"
+DATA_SOURCE_IDENTIFIER = "data source identifier"
+MEASUREMENT_IDENTIFIER = "measurement identifier"
+
 DictType = Mapping[str, Any]
 
 
@@ -37,9 +41,9 @@ def _assert_allotrope_dicts_equal(
     expected_replaced = _replace_asm_converter_name_and_version(expected)
 
     identifiers_to_exclude = identifiers_to_exclude or [
-        "calculated data identifier",
-        "data source identifier",
-        "measurement identifier",
+        CALCULATED_DATA_IDENTIFIER,
+        DATA_SOURCE_IDENTIFIER,
+        MEASUREMENT_IDENTIFIER,
     ]
     exclude_regex_paths = [
         fr"\['{exclude_id}'\]" for exclude_id in identifiers_to_exclude


### PR DESCRIPTION
Mostly making it possible to override `identifiers_to_exclude` in `validate_contents`. Plus some renames, not overwriting input dicts, etc.

Out of scope: making the default for `identifiers_to_exclude` be an empty list. That will require changing callers.