### PR TITLE
Change default value of identifiers_to_exclude

### DIFF
--- a/tests/parsers/agilent_gen5/to_allotrope_test.py
+++ b/tests/parsers/agilent_gen5/to_allotrope_test.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 
 from allotropy.allotrope.allotrope import serialize_allotrope
@@ -9,6 +7,7 @@ from allotropy.allotrope.models.ultraviolet_absorbance_benchling_2023_09_ultravi
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.parser_factory import Vendor
 from tests.parsers.test_utils import (
+    DictType,
     from_file,
     model_from_file,
     validate_contents,
@@ -28,9 +27,7 @@ ABSORBENCE_FILENAMES = [
 ]
 
 
-def _validate_allotrope_dict(
-    allotrope_dict: dict[str, Any], expected_filepath: str
-) -> None:
+def _validate_allotrope_dict(allotrope_dict: DictType, expected_filepath: str) -> None:
     validate_schema(
         allotrope_dict,
         "ultraviolet-absorbance/BENCHLING/2023/09/ultraviolet-absorbance.json",

--- a/tests/parsers/agilent_gen5/to_allotrope_test.py
+++ b/tests/parsers/agilent_gen5/to_allotrope_test.py
@@ -9,6 +9,7 @@ from allotropy.parser_factory import Vendor
 from tests.parsers.test_utils import (
     DictType,
     from_file,
+    MEASUREMENT_IDENTIFIER,
     model_from_file,
     validate_contents,
     validate_schema,
@@ -26,13 +27,15 @@ ABSORBENCE_FILENAMES = [
     "kinetic_multiplate",
 ]
 
+IDENTIFIERS_TO_EXCLUDE = [MEASUREMENT_IDENTIFIER]
+
 
 def _validate_allotrope_dict(allotrope_dict: DictType, expected_filepath: str) -> None:
     validate_schema(
         allotrope_dict,
         "ultraviolet-absorbance/BENCHLING/2023/09/ultraviolet-absorbance.json",
     )
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)
 
 
 @pytest.mark.parametrize("filename", ABSORBENCE_FILENAMES)
@@ -72,7 +75,7 @@ def test_to_allotrope_fluorescence(filename: str) -> None:
     )
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
     validate_schema(allotrope_dict, "fluorescence/BENCHLING/2023/09/fluorescence.json")
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)
 
 
 @pytest.mark.parametrize(
@@ -89,7 +92,7 @@ def test_to_allotrope_luminescence(filename: str) -> None:
     )
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
     validate_schema(allotrope_dict, "luminescence/BENCHLING/2023/09/luminescence.json")
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)
 
 
 def test_to_allotrope_invalid_plate_data() -> None:

--- a/tests/parsers/appbio_absolute_q/appbio_absolute_q_parser_test.py
+++ b/tests/parsers/appbio_absolute_q/appbio_absolute_q_parser_test.py
@@ -1,7 +1,14 @@
 import pytest
 
 from allotropy.parser_factory import Vendor
-from tests.parsers.test_utils import from_file, validate_contents, validate_schema
+from tests.parsers.test_utils import (
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    from_file,
+    MEASUREMENT_IDENTIFIER,
+    validate_contents,
+    validate_schema,
+)
 
 OUTPUT_FILES = (
     "Appbio_AbsoluteQ_example01.csv",
@@ -12,6 +19,12 @@ OUTPUT_FILES = (
 )
 
 VENDOR_TYPE = Vendor.APPBIO_ABSOLUTE_Q
+
+IDENTIFIERS_TO_EXCLUDE = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
 
 
 @pytest.mark.parametrize("output_file", OUTPUT_FILES)
@@ -27,4 +40,4 @@ def test_parse_appbio_absolute_q_to_asm_contents(output_file: str) -> None:
     expected_filepath = test_filepath.replace(".csv", ".json")
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
 
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)

--- a/tests/parsers/appbio_absolute_q/appbio_absolute_q_parser_test.py
+++ b/tests/parsers/appbio_absolute_q/appbio_absolute_q_parser_test.py
@@ -2,10 +2,8 @@ import pytest
 
 from allotropy.parser_factory import Vendor
 from tests.parsers.test_utils import (
-    CALCULATED_DATA_IDENTIFIER,
-    DATA_SOURCE_IDENTIFIER,
+    ALL_IDENTIFIERS,
     from_file,
-    MEASUREMENT_IDENTIFIER,
     validate_contents,
     validate_schema,
 )
@@ -19,12 +17,6 @@ OUTPUT_FILES = (
 )
 
 VENDOR_TYPE = Vendor.APPBIO_ABSOLUTE_Q
-
-IDENTIFIERS_TO_EXCLUDE = [
-    CALCULATED_DATA_IDENTIFIER,
-    DATA_SOURCE_IDENTIFIER,
-    MEASUREMENT_IDENTIFIER,
-]
 
 
 @pytest.mark.parametrize("output_file", OUTPUT_FILES)
@@ -40,4 +32,4 @@ def test_parse_appbio_absolute_q_to_asm_contents(output_file: str) -> None:
     expected_filepath = test_filepath.replace(".csv", ".json")
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
 
-    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)
+    validate_contents(allotrope_dict, expected_filepath, ALL_IDENTIFIERS)

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_parser_test.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_parser_test.py
@@ -19,7 +19,14 @@ from tests.parsers.appbio_quantstudio.appbio_quantstudio_data import (
     get_rel_std_curve_data,
     get_rel_std_curve_model,
 )
-from tests.parsers.test_utils import from_file, validate_contents, validate_schema
+from tests.parsers.test_utils import (
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    from_file,
+    MEASUREMENT_IDENTIFIER,
+    validate_contents,
+    validate_schema,
+)
 
 OUTPUT_FILES = (
     "appbio_quantstudio_example01",
@@ -35,6 +42,12 @@ OUTPUT_FILES = (
 
 VENDOR_TYPE = Vendor.APPBIO_QUANTSTUDIO
 
+IDENTIFIERS_TO_EXCLUDE = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
+
 
 @pytest.mark.parametrize("output_file", OUTPUT_FILES)
 def test_parse_appbio_quantstudio_to_asm_schema(output_file: str) -> None:
@@ -49,7 +62,7 @@ def test_parse_appbio_quantstudio_to_asm_contents(output_file: str) -> None:
     expected_filepath = test_filepath.replace(".txt", ".json")
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
 
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)
 
 
 @pytest.mark.short

--- a/tests/parsers/beckman_vi_cell_blu/vi_cell_blu_parser_test.py
+++ b/tests/parsers/beckman_vi_cell_blu/vi_cell_blu_parser_test.py
@@ -12,7 +12,14 @@ from tests.parsers.beckman_vi_cell_blu.vi_cell_blu_data import (
     get_filename,
     get_model,
 )
-from tests.parsers.test_utils import from_file, validate_contents, validate_schema
+from tests.parsers.test_utils import (
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    from_file,
+    MEASUREMENT_IDENTIFIER,
+    validate_contents,
+    validate_schema,
+)
 
 OUTPUT_FILES = (
     "Beckman_Vi-Cell-BLU_example01",
@@ -22,6 +29,12 @@ OUTPUT_FILES = (
 VENDOR_TYPE = Vendor.BECKMAN_VI_CELL_BLU
 SCHEMA_FILE = "cell-counting/BENCHLING/2023/11/cell-counting.json"
 TEST_DATA_DIR = "tests/parsers/beckman_vi_cell_blu/testdata/"
+
+IDENTIFIERS_TO_EXCLUDE = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
 
 
 def _get_test_file_path(output_file: str) -> str:
@@ -44,7 +57,7 @@ def test_parse_vi_cell_blu_to_asm_expected_contents(output_file: str) -> None:
     test_filepath = _get_test_file_path(output_file)
     expected_filepath = _get_expected_file_path(output_file)
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)
 
 
 def _clear_measurement_identifier(model: Model) -> None:

--- a/tests/parsers/beckman_vi_cell_xr/vi_cell_xr_parser_test.py
+++ b/tests/parsers/beckman_vi_cell_xr/vi_cell_xr_parser_test.py
@@ -4,7 +4,14 @@ import pytest
 
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.parser_factory import Vendor
-from tests.parsers.test_utils import from_file, validate_contents, validate_schema
+from tests.parsers.test_utils import (
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    from_file,
+    MEASUREMENT_IDENTIFIER,
+    validate_contents,
+    validate_schema,
+)
 
 OUTPUT_FILES = (
     "v2.04/Beckman_Vi-Cell-XR_example03_instrumentOutput.xls",
@@ -16,6 +23,13 @@ OUTPUT_FILES = (
 
 VENDOR_TYPE = Vendor.BECKMAN_VI_CELL_XR
 SCHEMA_FILE = "cell-counting/BENCHLING/2023/11/cell-counting.json"
+
+
+IDENTIFIERS_TO_EXCLUDE = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
 
 
 @pytest.mark.parametrize("output_file", OUTPUT_FILES)
@@ -33,7 +47,7 @@ def test_parse_vi_cell_xr_to_asm_expected_contents(output_file: str) -> None:
     expected_filepath = f"tests/parsers/beckman_vi_cell_xr/testdata/{target_filename}"
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
 
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)
 
 
 def test_perse_vi_cell_xr_file_without_required_fields_then_raise() -> None:

--- a/tests/parsers/chemometec_nucleoview/chemometec_nucleoview_parser_test.py
+++ b/tests/parsers/chemometec_nucleoview/chemometec_nucleoview_parser_test.py
@@ -1,7 +1,14 @@
 import pytest
 
 from allotropy.parser_factory import Vendor
-from tests.parsers.test_utils import from_file, validate_contents, validate_schema
+from tests.parsers.test_utils import (
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    from_file,
+    MEASUREMENT_IDENTIFIER,
+    validate_contents,
+    validate_schema,
+)
 
 OUTPUT_FILES = (
     "chemometec_nucleoview_example01.csv",
@@ -14,6 +21,12 @@ OUTPUT_FILES = (
 
 VENDOR_TYPE = Vendor.CHEMOMETEC_NUCLEOVIEW
 SCHEMA_FILE = "cell-counting/BENCHLING/2023/11/cell-counting.json"
+
+IDENTIFIERS_TO_EXCLUDE = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
 
 
 @pytest.mark.parametrize("output_file", OUTPUT_FILES)
@@ -33,4 +46,4 @@ def test_parse_chemometec_nucleoview_to_asm_expected_contents(output_file: str) 
         + "json"
     )
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)

--- a/tests/parsers/example_weyland_yutani/example_weyland_yutani_parser_test.py
+++ b/tests/parsers/example_weyland_yutani/example_weyland_yutani_parser_test.py
@@ -1,7 +1,14 @@
 import pytest
 
 from allotropy.parser_factory import Vendor
-from tests.parsers.test_utils import from_file, validate_contents, validate_schema
+from tests.parsers.test_utils import (
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    from_file,
+    MEASUREMENT_IDENTIFIER,
+    validate_contents,
+    validate_schema,
+)
 
 valid_files = (
     "Weyland_Yutani_simple_correct",
@@ -12,6 +19,12 @@ SCHEMA = "fluorescence/BENCHLING/2023/09/fluorescence.json"
 TESTDATA = "tests/parsers/example_weyland_yutani/testdata"
 VENDOR_TYPE = Vendor.EXAMPLE_WEYLAND_YUTANI
 
+IDENTIFIERS_TO_EXCLUDE = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
+
 
 @pytest.mark.parametrize("filestem", valid_files)
 def test_parse_weyland_yutani_to_asm(filestem: str) -> None:
@@ -19,4 +32,4 @@ def test_parse_weyland_yutani_to_asm(filestem: str) -> None:
     expected_filepath = f"{TESTDATA}/{filestem}.json"
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
     validate_schema(allotrope_dict, SCHEMA)
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)

--- a/tests/parsers/example_weyland_yutani/example_weyland_yutani_parser_test.py
+++ b/tests/parsers/example_weyland_yutani/example_weyland_yutani_parser_test.py
@@ -2,10 +2,7 @@ import pytest
 
 from allotropy.parser_factory import Vendor
 from tests.parsers.test_utils import (
-    CALCULATED_DATA_IDENTIFIER,
-    DATA_SOURCE_IDENTIFIER,
     from_file,
-    MEASUREMENT_IDENTIFIER,
     validate_contents,
     validate_schema,
 )
@@ -19,12 +16,6 @@ SCHEMA = "fluorescence/BENCHLING/2023/09/fluorescence.json"
 TESTDATA = "tests/parsers/example_weyland_yutani/testdata"
 VENDOR_TYPE = Vendor.EXAMPLE_WEYLAND_YUTANI
 
-IDENTIFIERS_TO_EXCLUDE = [
-    CALCULATED_DATA_IDENTIFIER,
-    DATA_SOURCE_IDENTIFIER,
-    MEASUREMENT_IDENTIFIER,
-]
-
 
 @pytest.mark.parametrize("filestem", valid_files)
 def test_parse_weyland_yutani_to_asm(filestem: str) -> None:
@@ -32,4 +23,4 @@ def test_parse_weyland_yutani_to_asm(filestem: str) -> None:
     expected_filepath = f"{TESTDATA}/{filestem}.json"
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
     validate_schema(allotrope_dict, SCHEMA)
-    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)
+    validate_contents(allotrope_dict, expected_filepath)

--- a/tests/parsers/example_weyland_yutani/example_weyland_yutani_parser_test.py
+++ b/tests/parsers/example_weyland_yutani/example_weyland_yutani_parser_test.py
@@ -3,6 +3,7 @@ import pytest
 from allotropy.parser_factory import Vendor
 from tests.parsers.test_utils import (
     from_file,
+    MEASUREMENT_IDENTIFIER,
     validate_contents,
     validate_schema,
 )
@@ -16,6 +17,8 @@ SCHEMA = "fluorescence/BENCHLING/2023/09/fluorescence.json"
 TESTDATA = "tests/parsers/example_weyland_yutani/testdata"
 VENDOR_TYPE = Vendor.EXAMPLE_WEYLAND_YUTANI
 
+IDENTIFIERS_TO_EXCLUDE = [MEASUREMENT_IDENTIFIER]
+
 
 @pytest.mark.parametrize("filestem", valid_files)
 def test_parse_weyland_yutani_to_asm(filestem: str) -> None:
@@ -23,4 +26,4 @@ def test_parse_weyland_yutani_to_asm(filestem: str) -> None:
     expected_filepath = f"{TESTDATA}/{filestem}.json"
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
     validate_schema(allotrope_dict, SCHEMA)
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)

--- a/tests/parsers/moldev_softmax_pro/to_allotrope_test.py
+++ b/tests/parsers/moldev_softmax_pro/to_allotrope_test.py
@@ -4,9 +4,22 @@ import pytest
 
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.parser_factory import Vendor
-from tests.parsers.test_utils import from_file, validate_contents, validate_schema
+from tests.parsers.test_utils import (
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    from_file,
+    MEASUREMENT_IDENTIFIER,
+    validate_contents,
+    validate_schema,
+)
 
 VENDOR_TYPE = Vendor.MOLDEV_SOFTMAX_PRO
+
+IDENTIFIERS_TO_EXCLUDE = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
 
 
 @pytest.mark.parametrize(
@@ -29,7 +42,7 @@ def test_to_allotrope(file_name: str) -> None:
     expected_file = f"tests/parsers/moldev_softmax_pro/testdata/{file_name}.json"
     allotrope_dict = from_file(test_file, VENDOR_TYPE)
     validate_schema(allotrope_dict, "plate-reader/BENCHLING/2023/09/plate-reader.json")
-    validate_contents(allotrope_dict, expected_file)
+    validate_contents(allotrope_dict, expected_file, IDENTIFIERS_TO_EXCLUDE)
 
 
 def test_handles_unrecognized_read_mode() -> None:

--- a/tests/parsers/novabio_flex2/novabio_flex2_parser_test.py
+++ b/tests/parsers/novabio_flex2/novabio_flex2_parser_test.py
@@ -5,8 +5,6 @@ from allotropy.parsers.novabio_flex2.novabio_flex2_parser import NovaBioFlexPars
 from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from tests.parsers.novabio_flex2.novabio_flex2_data import get_data, get_model
 from tests.parsers.test_utils import (
-    CALCULATED_DATA_IDENTIFIER,
-    DATA_SOURCE_IDENTIFIER,
     from_file,
     MEASUREMENT_IDENTIFIER,
     validate_contents,
@@ -21,8 +19,6 @@ OUTPUT_FILES = (
 VENDOR_TYPE = Vendor.NOVABIO_FLEX2
 
 IDENTIFIERS_TO_EXCLUDE = [
-    CALCULATED_DATA_IDENTIFIER,
-    DATA_SOURCE_IDENTIFIER,
     MEASUREMENT_IDENTIFIER,
 ]
 

--- a/tests/parsers/novabio_flex2/novabio_flex2_parser_test.py
+++ b/tests/parsers/novabio_flex2/novabio_flex2_parser_test.py
@@ -4,7 +4,14 @@ from allotropy.parser_factory import Vendor
 from allotropy.parsers.novabio_flex2.novabio_flex2_parser import NovaBioFlexParser
 from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from tests.parsers.novabio_flex2.novabio_flex2_data import get_data, get_model
-from tests.parsers.test_utils import from_file, validate_contents, validate_schema
+from tests.parsers.test_utils import (
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    from_file,
+    MEASUREMENT_IDENTIFIER,
+    validate_contents,
+    validate_schema,
+)
 
 OUTPUT_FILES = (
     "SampleResultsDEVICE1232021-02-18_104838",
@@ -12,6 +19,12 @@ OUTPUT_FILES = (
 )
 
 VENDOR_TYPE = Vendor.NOVABIO_FLEX2
+
+IDENTIFIERS_TO_EXCLUDE = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
 
 
 @pytest.mark.parametrize("output_file", OUTPUT_FILES)
@@ -23,7 +36,7 @@ def test_parse_novabio_flex_to_asm(output_file: str) -> None:
         allotrope_dict,
         "cell-culture-analyzer/BENCHLING/2023/09/cell-culture-analyzer.json",
     )
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)
 
 
 @pytest.mark.short

--- a/tests/parsers/perkin_elmer_envision/perkin_elmer_envision_parser_test.py
+++ b/tests/parsers/perkin_elmer_envision/perkin_elmer_envision_parser_test.py
@@ -10,7 +10,14 @@ from tests.parsers.perkin_elmer_envision.perkin_elmer_envision_data import (
     get_data,
     get_model,
 )
-from tests.parsers.test_utils import from_file, validate_contents, validate_schema
+from tests.parsers.test_utils import (
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    from_file,
+    MEASUREMENT_IDENTIFIER,
+    validate_contents,
+    validate_schema,
+)
 
 OUTPUT_FILES = (
     "PE_Envision_absorbance_example01",
@@ -23,6 +30,12 @@ OUTPUT_FILES = (
 
 VENDOR_TYPE = Vendor.PERKIN_ELMER_ENVISION
 
+IDENTIFIERS_TO_EXCLUDE = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
+
 
 @pytest.mark.parametrize("output_file", OUTPUT_FILES)
 def test_parse_perkin_elmer_envision_to_asm(output_file: str) -> None:
@@ -32,7 +45,7 @@ def test_parse_perkin_elmer_envision_to_asm(output_file: str) -> None:
     )
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
     validate_schema(allotrope_dict, "plate-reader/BENCHLING/2023/09/plate-reader.json")
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)
 
 
 @pytest.mark.short

--- a/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_parser_test.py
+++ b/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_parser_test.py
@@ -7,8 +7,6 @@ from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_parser import (
 from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from tests.parsers.roche_cedex_bioht.roche_cedex_bioht_data import get_data, get_model
 from tests.parsers.test_utils import (
-    CALCULATED_DATA_IDENTIFIER,
-    DATA_SOURCE_IDENTIFIER,
     from_file,
     MEASUREMENT_IDENTIFIER,
     validate_contents,
@@ -26,8 +24,6 @@ VENDOR_TYPE = Vendor.ROCHE_CEDEX_BIOHT
 SCHEMA_FILE = "cell-culture-analyzer/BENCHLING/2023/09/cell-culture-analyzer.json"
 
 IDENTIFIERS_TO_EXCLUDE = [
-    CALCULATED_DATA_IDENTIFIER,
-    DATA_SOURCE_IDENTIFIER,
     MEASUREMENT_IDENTIFIER,
 ]
 

--- a/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_parser_test.py
+++ b/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_parser_test.py
@@ -6,7 +6,14 @@ from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_parser import (
 )
 from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from tests.parsers.roche_cedex_bioht.roche_cedex_bioht_data import get_data, get_model
-from tests.parsers.test_utils import from_file, validate_contents, validate_schema
+from tests.parsers.test_utils import (
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    from_file,
+    MEASUREMENT_IDENTIFIER,
+    validate_contents,
+    validate_schema,
+)
 
 OUTPUT_FILES = (
     "roche_cedex_bioht_example01",
@@ -18,6 +25,12 @@ OUTPUT_FILES = (
 VENDOR_TYPE = Vendor.ROCHE_CEDEX_BIOHT
 SCHEMA_FILE = "cell-culture-analyzer/BENCHLING/2023/09/cell-culture-analyzer.json"
 
+IDENTIFIERS_TO_EXCLUDE = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
+
 
 @pytest.mark.parametrize("output_file", OUTPUT_FILES)
 def test_parse_cedex_bioht_to_asm(output_file: str) -> None:
@@ -25,7 +38,7 @@ def test_parse_cedex_bioht_to_asm(output_file: str) -> None:
     expected_filepath = f"tests/parsers/roche_cedex_bioht/testdata/{output_file}.json"
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
     validate_schema(allotrope_dict, SCHEMA_FILE)
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)
 
 
 @pytest.mark.short

--- a/tests/parsers/test_utils.py
+++ b/tests/parsers/test_utils.py
@@ -40,11 +40,7 @@ def _assert_allotrope_dicts_equal(
 ) -> None:
     expected_replaced = _replace_asm_converter_name_and_version(expected)
 
-    identifiers_to_exclude = identifiers_to_exclude or [
-        CALCULATED_DATA_IDENTIFIER,
-        DATA_SOURCE_IDENTIFIER,
-        MEASUREMENT_IDENTIFIER,
-    ]
+    identifiers_to_exclude = identifiers_to_exclude or []
     exclude_regex_paths = [
         fr"\['{exclude_id}'\]" for exclude_id in identifiers_to_exclude
     ]
@@ -78,7 +74,7 @@ def validate_schema(allotrope_dict: DictType, schema_relative_path: str) -> None
 def validate_contents(
     allotrope_dict: DictType,
     expected_file: str,
-    identifiers_to_exclude: Optional[list[str]] = None,
+    identifiers_to_exclude: list[str],
 ) -> None:
     """Use the newly created allotrope_dict to validate the contents inside expected_file."""
     with open(expected_file) as f:

--- a/tests/parsers/test_utils.py
+++ b/tests/parsers/test_utils.py
@@ -29,7 +29,7 @@ def _replace_asm_converter_name_and_version(allotrope_dict: DictType) -> DictTyp
     return new_dict
 
 
-def assert_allotrope_dicts_equal(
+def _assert_allotrope_dicts_equal(
     expected: DictType,
     actual: DictType,
     identifiers_to_exclude: Optional[list[str]] = None,
@@ -71,11 +71,17 @@ def validate_schema(allotrope_dict: DictType, schema_relative_path: str) -> None
     )
 
 
-def validate_contents(allotrope_dict: DictType, expected_file: str) -> None:
+def validate_contents(
+    allotrope_dict: DictType,
+    expected_file: str,
+    identifiers_to_exclude: Optional[list[str]] = None,
+) -> None:
     """Use the newly created allotrope_dict to validate the contents inside expected_file."""
     with open(expected_file) as f:
         expected_dict = json.load(f)
-        assert_allotrope_dicts_equal(expected_dict, allotrope_dict)
+    _assert_allotrope_dicts_equal(
+        expected_dict, allotrope_dict, identifiers_to_exclude=identifiers_to_exclude
+    )
 
 
 def build_series(elements: list[tuple[Any]]) -> pd.Series[Any]:

--- a/tests/parsers/test_utils.py
+++ b/tests/parsers/test_utils.py
@@ -18,6 +18,13 @@ CALCULATED_DATA_IDENTIFIER = "calculated data identifier"
 DATA_SOURCE_IDENTIFIER = "data source identifier"
 MEASUREMENT_IDENTIFIER = "measurement identifier"
 
+# Use this only for tests that need to exclude all identifiers
+ALL_IDENTIFIERS = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
+
 DictType = Mapping[str, Any]
 
 

--- a/tests/parsers/test_utils.py
+++ b/tests/parsers/test_utils.py
@@ -74,7 +74,7 @@ def validate_schema(allotrope_dict: DictType, schema_relative_path: str) -> None
 def validate_contents(
     allotrope_dict: DictType,
     expected_file: str,
-    identifiers_to_exclude: list[str],
+    identifiers_to_exclude: Optional[list[str]] = None,
 ) -> None:
     """Use the newly created allotrope_dict to validate the contents inside expected_file."""
     with open(expected_file) as f:

--- a/tests/parsers/test_utils.py
+++ b/tests/parsers/test_utils.py
@@ -14,6 +14,10 @@ from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
 from allotropy.parser_factory import VendorType
 from allotropy.to_allotrope import allotrope_from_file, allotrope_model_from_file
 
+CALCULATED_DATA_IDENTIFIER = "calculated data identifier"
+DATA_SOURCE_IDENTIFIER = "data source identifier"
+MEASUREMENT_IDENTIFIER = "measurement identifier"
+
 DictType = Mapping[str, Any]
 
 
@@ -37,9 +41,9 @@ def _assert_allotrope_dicts_equal(
     expected_replaced = _replace_asm_converter_name_and_version(expected)
 
     identifiers_to_exclude = identifiers_to_exclude or [
-        "calculated data identifier",
-        "data source identifier",
-        "measurement identifier",
+        CALCULATED_DATA_IDENTIFIER,
+        DATA_SOURCE_IDENTIFIER,
+        MEASUREMENT_IDENTIFIER,
     ]
     exclude_regex_paths = [
         fr"\['{exclude_id}'\]" for exclude_id in identifiers_to_exclude

--- a/tests/parsers/thermo_fisher_nanodrop_eight/thermo_fisher_nanodrop_eight_parser_test.py
+++ b/tests/parsers/thermo_fisher_nanodrop_eight/thermo_fisher_nanodrop_eight_parser_test.py
@@ -1,7 +1,14 @@
 import pytest
 
 from allotropy.parser_factory import Vendor
-from tests.parsers.test_utils import from_file, validate_contents, validate_schema
+from tests.parsers.test_utils import (
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    from_file,
+    MEASUREMENT_IDENTIFIER,
+    validate_contents,
+    validate_schema,
+)
 
 OUTPUT_FILES = (
     "Thermo_NanoDrop_Eight_example01.txt",
@@ -12,6 +19,12 @@ OUTPUT_FILES = (
 
 VENDOR_TYPE = Vendor.THERMO_FISHER_NANODROP_EIGHT
 SCHEMA_FILE = "spectrophotometry/BENCHLING/2023/12/spectrophotometry.json"
+
+IDENTIFIERS_TO_EXCLUDE = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
 
 
 @pytest.mark.parametrize("output_file", OUTPUT_FILES)
@@ -35,4 +48,4 @@ def test_parse_thermo_fisher_nanodrop_eight_to_asm_expected_contents(
         + "json"
     )
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)

--- a/tests/parsers/unchained_labs_lunatic/unchained_labs_lunatic_parser_test.py
+++ b/tests/parsers/unchained_labs_lunatic/unchained_labs_lunatic_parser_test.py
@@ -1,7 +1,14 @@
 import pytest
 
 from allotropy.parser_factory import Vendor
-from tests.parsers.test_utils import from_file, validate_contents, validate_schema
+from tests.parsers.test_utils import (
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    from_file,
+    MEASUREMENT_IDENTIFIER,
+    validate_contents,
+    validate_schema,
+)
 
 OUTPUT_FILES = (
     "Demo_A260_dsDNA_Data",
@@ -10,6 +17,12 @@ OUTPUT_FILES = (
 
 VENDOR_TYPE = Vendor.UNCHAINED_LABS_LUNATIC
 SCHEMA_FILE = "plate-reader/BENCHLING/2023/09/plate-reader.json"
+
+IDENTIFIERS_TO_EXCLUDE = [
+    CALCULATED_DATA_IDENTIFIER,
+    DATA_SOURCE_IDENTIFIER,
+    MEASUREMENT_IDENTIFIER,
+]
 
 
 @pytest.mark.parametrize("output_file", OUTPUT_FILES)
@@ -20,4 +33,4 @@ def test_parse_cedex_bioht_to_asm(output_file: str) -> None:
     )
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
     validate_schema(allotrope_dict, SCHEMA_FILE)
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, IDENTIFIERS_TO_EXCLUDE)


### PR DESCRIPTION
Depends on #259

still to audit:
        modified:   tests/parsers/agilent_gen5/to_allotrope_test.py
        modified:   tests/parsers/appbio_absolute_q/appbio_absolute_q_parser_test.py
        modified:   tests/parsers/appbio_quantstudio/appbio_quantstudio_parser_test.py
        modified:   tests/parsers/beckman_vi_cell_blu/vi_cell_blu_parser_test.py
        modified:   tests/parsers/beckman_vi_cell_xr/vi_cell_xr_parser_test.py
        modified:   tests/parsers/chemometec_nucleoview/chemometec_nucleoview_parser_test.py
        modified:   tests/parsers/example_weyland_yutani/example_weyland_yutani_parser_test.py
        modified:   tests/parsers/moldev_softmax_pro/to_allotrope_test.py
        modified:   tests/parsers/novabio_flex2/novabio_flex2_parser_test.py