### PR TITLE
Refactor random UUID generation (take 1)

### DIFF
--- a/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
+++ b/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
@@ -27,8 +27,7 @@ from allotropy.parsers.agilent_gen5.constants import ReadMode
 from allotropy.parsers.agilent_gen5.plate_data import PlateData
 from allotropy.parsers.agilent_gen5.section_reader import SectionLinesReader
 from allotropy.parsers.lines_reader import read_to_lines
-from allotropy.parsers.utils.uuids import random_uuid_str
-from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
 
 
 class AgilentGen5Parser(VendorParser):

--- a/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
+++ b/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
@@ -37,7 +37,7 @@ class AgilentGen5Parser(VendorParser):
         if first_plate.plate_type.read_mode == ReadMode.ABSORBANCE:
             return AbsorbanceModel(
                 measurement_aggregate_document=AbsorbanceMeasurementAggregateDocument(
-                    measurement_identifier=self._random_uuid_str(),
+                    measurement_identifier=self.random_uuid_str(),
                     measurement_time=self._get_date_time(
                         first_plate.plate_number.datetime
                     ),
@@ -54,7 +54,7 @@ class AgilentGen5Parser(VendorParser):
         elif first_plate.plate_type.read_mode == ReadMode.FLUORESCENCE:
             return FluorescenceModel(
                 measurement_aggregate_document=FluorescenceMeasurementAggregateDocument(
-                    measurement_identifier=self._random_uuid_str(),
+                    measurement_identifier=self.random_uuid_str(),
                     measurement_time=self._get_date_time(
                         first_plate.plate_number.datetime
                     ),
@@ -71,7 +71,7 @@ class AgilentGen5Parser(VendorParser):
         elif first_plate.plate_type.read_mode == ReadMode.LUMINESCENCE:
             return LuminescenceModel(
                 measurement_aggregate_document=LuminescenceMeasurementAggregateDocument(
-                    measurement_identifier=self._random_uuid_str(),
+                    measurement_identifier=self.random_uuid_str(),
                     measurement_time=self._get_date_time(
                         first_plate.plate_number.datetime
                     ),

--- a/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
+++ b/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
@@ -37,7 +37,7 @@ class AgilentGen5Parser(VendorParser):
         if first_plate.plate_type.read_mode == ReadMode.ABSORBANCE:
             return AbsorbanceModel(
                 measurement_aggregate_document=AbsorbanceMeasurementAggregateDocument(
-                    measurement_identifier=self.random_uuid_str(),
+                    measurement_identifier=self._random_uuid_str(),
                     measurement_time=self._get_date_time(
                         first_plate.plate_number.datetime
                     ),
@@ -54,7 +54,7 @@ class AgilentGen5Parser(VendorParser):
         elif first_plate.plate_type.read_mode == ReadMode.FLUORESCENCE:
             return FluorescenceModel(
                 measurement_aggregate_document=FluorescenceMeasurementAggregateDocument(
-                    measurement_identifier=self.random_uuid_str(),
+                    measurement_identifier=self._random_uuid_str(),
                     measurement_time=self._get_date_time(
                         first_plate.plate_number.datetime
                     ),
@@ -71,7 +71,7 @@ class AgilentGen5Parser(VendorParser):
         elif first_plate.plate_type.read_mode == ReadMode.LUMINESCENCE:
             return LuminescenceModel(
                 measurement_aggregate_document=LuminescenceMeasurementAggregateDocument(
-                    measurement_identifier=self.random_uuid_str(),
+                    measurement_identifier=self._random_uuid_str(),
                     measurement_time=self._get_date_time(
                         first_plate.plate_number.datetime
                     ),

--- a/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
+++ b/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
@@ -27,7 +27,7 @@ from allotropy.parsers.agilent_gen5.constants import ReadMode
 from allotropy.parsers.agilent_gen5.plate_data import PlateData
 from allotropy.parsers.agilent_gen5.section_reader import SectionLinesReader
 from allotropy.parsers.lines_reader import read_to_lines
-from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
+from allotropy.parsers.vendor_parser import VendorParser
 
 
 class AgilentGen5Parser(VendorParser):
@@ -37,7 +37,7 @@ class AgilentGen5Parser(VendorParser):
         if first_plate.plate_type.read_mode == ReadMode.ABSORBANCE:
             return AbsorbanceModel(
                 measurement_aggregate_document=AbsorbanceMeasurementAggregateDocument(
-                    measurement_identifier=random_uuid_str(),
+                    measurement_identifier=self.random_uuid_str(),
                     measurement_time=self._get_date_time(
                         first_plate.plate_number.datetime
                     ),
@@ -54,7 +54,7 @@ class AgilentGen5Parser(VendorParser):
         elif first_plate.plate_type.read_mode == ReadMode.FLUORESCENCE:
             return FluorescenceModel(
                 measurement_aggregate_document=FluorescenceMeasurementAggregateDocument(
-                    measurement_identifier=random_uuid_str(),
+                    measurement_identifier=self.random_uuid_str(),
                     measurement_time=self._get_date_time(
                         first_plate.plate_number.datetime
                     ),
@@ -71,7 +71,7 @@ class AgilentGen5Parser(VendorParser):
         elif first_plate.plate_type.read_mode == ReadMode.LUMINESCENCE:
             return LuminescenceModel(
                 measurement_aggregate_document=LuminescenceMeasurementAggregateDocument(
-                    measurement_identifier=random_uuid_str(),
+                    measurement_identifier=self.random_uuid_str(),
                     measurement_time=self._get_date_time(
                         first_plate.plate_number.datetime
                     ),

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
@@ -93,7 +93,7 @@ class AppbioAbsoluteQParser(VendorParser):
     ) -> DPCRDocumentItem:
         measurement_documents = []
         for _, well_item in well_data.iterrows():
-            measurement_identifier = self.random_uuid_str()
+            measurement_identifier = self._random_uuid_str()
 
             key = str((well_item["Group"], well_item["Target"]))
             group_ids[key].append(measurement_identifier)
@@ -172,7 +172,7 @@ class AppbioAbsoluteQParser(VendorParser):
                     continue
 
                 datum_value = float(group[calculated_data_item.column])
-                calculated_data_id = self.random_uuid_str()
+                calculated_data_id = self._random_uuid_str()
                 calculated_data_ids[calculated_data_item.name] = calculated_data_id
 
                 data_source_document = [
@@ -199,7 +199,7 @@ class AppbioAbsoluteQParser(VendorParser):
             # TODO: this should be inproved (repeat less code)
             for calculated_data_item in defered_calculated_data_items:
                 datum_value = float(group[calculated_data_item.column])
-                calculated_data_id = self.random_uuid_str()
+                calculated_data_id = self._random_uuid_str()
 
                 data_source_document = [
                     DataSourceDocumentItem(

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
@@ -40,7 +40,7 @@ from allotropy.parsers.appbio_absolute_q.constants import (
     CalculatedDataItem,
     CalculatedDataSource,
 )
-from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
+from allotropy.parsers.vendor_parser import VendorParser
 
 
 class AppbioAbsoluteQParser(VendorParser):
@@ -93,7 +93,7 @@ class AppbioAbsoluteQParser(VendorParser):
     ) -> DPCRDocumentItem:
         measurement_documents = []
         for _, well_item in well_data.iterrows():
-            measurement_identifier = random_uuid_str()
+            measurement_identifier = self.random_uuid_str()
 
             key = str((well_item["Group"], well_item["Target"]))
             group_ids[key].append(measurement_identifier)
@@ -142,9 +142,8 @@ class AppbioAbsoluteQParser(VendorParser):
             )
         )
 
-    @staticmethod
     def get_calculated_data_document(
-        group_ids: dict, group_rows: pd.DataFrame
+        self, group_ids: dict, group_rows: pd.DataFrame
     ) -> list[CalculatedDataDocumentItem]:
         calculated_data_document: list[CalculatedDataDocumentItem] = []
 
@@ -173,7 +172,7 @@ class AppbioAbsoluteQParser(VendorParser):
                     continue
 
                 datum_value = float(group[calculated_data_item.column])
-                calculated_data_id = random_uuid_str()
+                calculated_data_id = self.random_uuid_str()
                 calculated_data_ids[calculated_data_item.name] = calculated_data_id
 
                 data_source_document = [
@@ -200,7 +199,7 @@ class AppbioAbsoluteQParser(VendorParser):
             # TODO: this should be inproved (repeat less code)
             for calculated_data_item in defered_calculated_data_items:
                 datum_value = float(group[calculated_data_item.column])
-                calculated_data_id = random_uuid_str()
+                calculated_data_id = self.random_uuid_str()
 
                 data_source_document = [
                     DataSourceDocumentItem(

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
@@ -93,7 +93,7 @@ class AppbioAbsoluteQParser(VendorParser):
     ) -> DPCRDocumentItem:
         measurement_documents = []
         for _, well_item in well_data.iterrows():
-            measurement_identifier = self._random_uuid_str()
+            measurement_identifier = self.random_uuid_str()
 
             key = str((well_item["Group"], well_item["Target"]))
             group_ids[key].append(measurement_identifier)
@@ -172,7 +172,7 @@ class AppbioAbsoluteQParser(VendorParser):
                     continue
 
                 datum_value = float(group[calculated_data_item.column])
-                calculated_data_id = self._random_uuid_str()
+                calculated_data_id = self.random_uuid_str()
                 calculated_data_ids[calculated_data_item.name] = calculated_data_id
 
                 data_source_document = [
@@ -199,7 +199,7 @@ class AppbioAbsoluteQParser(VendorParser):
             # TODO: this should be inproved (repeat less code)
             for calculated_data_item in defered_calculated_data_items:
                 datum_value = float(group[calculated_data_item.column])
-                calculated_data_id = self._random_uuid_str()
+                calculated_data_id = self.random_uuid_str()
 
                 data_source_document = [
                     DataSourceDocumentItem(

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
@@ -40,8 +40,7 @@ from allotropy.parsers.appbio_absolute_q.constants import (
     CalculatedDataItem,
     CalculatedDataSource,
 )
-from allotropy.parsers.utils.uuids import random_uuid_str
-from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
 
 
 class AppbioAbsoluteQParser(VendorParser):

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_calculated_documents.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_calculated_documents.py
@@ -2,9 +2,6 @@ from collections.abc import Iterator
 from typing import Optional
 
 from allotropy.allotrope.models.pcr_benchling_2023_09_qpcr import ExperimentType
-from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_parser import (
-    AppBioQuantStudioParser,
-)
 from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_structure import (
     WellItem,
     WellList,
@@ -23,6 +20,10 @@ from allotropy.parsers.appbio_quantstudio.views import ViewData
 
 
 def random_uuid_str() -> str:
+    from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_parser import (
+        AppBioQuantStudioParser,
+    )
+
     return AppBioQuantStudioParser.random_uuid_str()
 
 

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_calculated_documents.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_calculated_documents.py
@@ -2,6 +2,9 @@ from collections.abc import Iterator
 from typing import Optional
 
 from allotropy.allotrope.models.pcr_benchling_2023_09_qpcr import ExperimentType
+from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_parser import (
+    AppBioQuantStudioParser,
+)
 from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_structure import (
     WellItem,
     WellList,
@@ -17,7 +20,10 @@ from allotropy.parsers.appbio_quantstudio.calculated_document import (
 )
 from allotropy.parsers.appbio_quantstudio.decorators import cache
 from allotropy.parsers.appbio_quantstudio.views import ViewData
-from allotropy.parsers.vendor_parser import random_uuid_str
+
+
+def random_uuid_str() -> str:
+    return AppBioQuantStudioParser.random_uuid_str()
 
 
 @cache

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_calculated_documents.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_calculated_documents.py
@@ -17,7 +17,7 @@ from allotropy.parsers.appbio_quantstudio.calculated_document import (
 )
 from allotropy.parsers.appbio_quantstudio.decorators import cache
 from allotropy.parsers.appbio_quantstudio.views import ViewData
-from allotropy.parsers.utils.uuids import random_uuid_str
+from allotropy.parsers.vendor_parser import random_uuid_str
 
 
 @cache

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_structure.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_structure.py
@@ -22,7 +22,6 @@ from allotropy.allotrope.pandas_util import read_csv
 from allotropy.parsers.appbio_quantstudio.calculated_document import CalculatedDocument
 from allotropy.parsers.appbio_quantstudio.referenceable import Referenceable
 from allotropy.parsers.lines_reader import LinesReader
-from allotropy.parsers.moldev_softmax_pro.softmax_pro_parser import SoftmaxproParser
 from allotropy.parsers.utils.values import (
     assert_not_empty_df,
     assert_not_none,
@@ -40,6 +39,8 @@ from allotropy.parsers.utils.values import (
 
 
 def random_uuid_str() -> str:
+    from allotropy.parsers.moldev_softmax_pro.softmax_pro_parser import SoftmaxproParser
+
     return SoftmaxproParser.random_uuid_str()
 
 

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_structure.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_structure.py
@@ -22,6 +22,7 @@ from allotropy.allotrope.pandas_util import read_csv
 from allotropy.parsers.appbio_quantstudio.calculated_document import CalculatedDocument
 from allotropy.parsers.appbio_quantstudio.referenceable import Referenceable
 from allotropy.parsers.lines_reader import LinesReader
+from allotropy.parsers.moldev_softmax_pro.softmax_pro_parser import SoftmaxproParser
 from allotropy.parsers.utils.values import (
     assert_not_empty_df,
     assert_not_none,
@@ -36,7 +37,10 @@ from allotropy.parsers.utils.values import (
     try_str_from_series_or_default,
     try_str_from_series_or_none,
 )
-from allotropy.parsers.vendor_parser import random_uuid_str
+
+
+def random_uuid_str() -> str:
+    return SoftmaxproParser.random_uuid_str()
 
 
 @dataclass(frozen=True)

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_structure.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_structure.py
@@ -22,7 +22,6 @@ from allotropy.allotrope.pandas_util import read_csv
 from allotropy.parsers.appbio_quantstudio.calculated_document import CalculatedDocument
 from allotropy.parsers.appbio_quantstudio.referenceable import Referenceable
 from allotropy.parsers.lines_reader import LinesReader
-from allotropy.parsers.utils.uuids import random_uuid_str
 from allotropy.parsers.utils.values import (
     assert_not_empty_df,
     assert_not_none,
@@ -37,6 +36,7 @@ from allotropy.parsers.utils.values import (
     try_str_from_series_or_default,
     try_str_from_series_or_none,
 )
+from allotropy.parsers.vendor_parser import random_uuid_str
 
 
 @dataclass(frozen=True)

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
@@ -37,8 +37,7 @@ from allotropy.parsers.beckman_vi_cell_blu.constants import (
     VICELL_BLU_SOFTWARE_NAME,
 )
 from allotropy.parsers.beckman_vi_cell_blu.vi_cell_blu_reader import ViCellBluReader
-from allotropy.parsers.utils.uuids import random_uuid_str
-from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
 
 
 class SampleProperty(Enum):

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
@@ -129,7 +129,7 @@ class ViCellBluParser(VendorParser):
                         measurement_time=self._get_date_time(
                             sample.get_value_not_none("Analysis date/time")
                         ),
-                        measurement_identifier=self.random_uuid_str(),
+                        measurement_identifier=self._random_uuid_str(),
                         sample_document=SampleDocument(sample_identifier=sample.get_value("Sample ID")),  # type: ignore[arg-type]
                         device_control_aggregate_document=CellCountingDetectorDeviceControlAggregateDocument(
                             device_control_document=[

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
@@ -37,7 +37,7 @@ from allotropy.parsers.beckman_vi_cell_blu.constants import (
     VICELL_BLU_SOFTWARE_NAME,
 )
 from allotropy.parsers.beckman_vi_cell_blu.vi_cell_blu_reader import ViCellBluReader
-from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
+from allotropy.parsers.vendor_parser import VendorParser
 
 
 class SampleProperty(Enum):
@@ -129,7 +129,7 @@ class ViCellBluParser(VendorParser):
                         measurement_time=self._get_date_time(
                             sample.get_value_not_none("Analysis date/time")
                         ),
-                        measurement_identifier=random_uuid_str(),
+                        measurement_identifier=self.random_uuid_str(),
                         sample_document=SampleDocument(sample_identifier=sample.get_value("Sample ID")),  # type: ignore[arg-type]
                         device_control_aggregate_document=CellCountingDetectorDeviceControlAggregateDocument(
                             device_control_document=[

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
@@ -129,7 +129,7 @@ class ViCellBluParser(VendorParser):
                         measurement_time=self._get_date_time(
                             sample.get_value_not_none("Analysis date/time")
                         ),
-                        measurement_identifier=self._random_uuid_str(),
+                        measurement_identifier=self.random_uuid_str(),
                         sample_document=SampleDocument(sample_identifier=sample.get_value("Sample ID")),  # type: ignore[arg-type]
                         device_control_aggregate_document=CellCountingDetectorDeviceControlAggregateDocument(
                             device_control_document=[

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
@@ -124,7 +124,7 @@ class ViCellXRParser(VendorParser):
             measurement_aggregate_document=MeasurementAggregateDocument(
                 measurement_document=[
                     CellCountingDetectorMeasurementDocumentItem(
-                        measurement_identifier=self._random_uuid_str(),
+                        measurement_identifier=self.random_uuid_str(),
                         measurement_time=self._get_date_time(
                             str(sample.get(DATE_HEADER[file_version]))
                         ),

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
@@ -38,8 +38,7 @@ from allotropy.parsers.beckman_vi_cell_xr.constants import (
     XrVersion,
 )
 from allotropy.parsers.beckman_vi_cell_xr.vi_cell_xr_reader import ViCellXRReader
-from allotropy.parsers.utils.uuids import random_uuid_str
-from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
 
 
 class SampleProperty(Enum):

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
@@ -124,7 +124,7 @@ class ViCellXRParser(VendorParser):
             measurement_aggregate_document=MeasurementAggregateDocument(
                 measurement_document=[
                     CellCountingDetectorMeasurementDocumentItem(
-                        measurement_identifier=self.random_uuid_str(),
+                        measurement_identifier=self._random_uuid_str(),
                         measurement_time=self._get_date_time(
                             str(sample.get(DATE_HEADER[file_version]))
                         ),

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
@@ -38,7 +38,7 @@ from allotropy.parsers.beckman_vi_cell_xr.constants import (
     XrVersion,
 )
 from allotropy.parsers.beckman_vi_cell_xr.vi_cell_xr_reader import ViCellXRReader
-from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
+from allotropy.parsers.vendor_parser import VendorParser
 
 
 class SampleProperty(Enum):
@@ -124,7 +124,7 @@ class ViCellXRParser(VendorParser):
             measurement_aggregate_document=MeasurementAggregateDocument(
                 measurement_document=[
                     CellCountingDetectorMeasurementDocumentItem(
-                        measurement_identifier=random_uuid_str(),
+                        measurement_identifier=self.random_uuid_str(),
                         measurement_time=self._get_date_time(
                             str(sample.get(DATE_HEADER[file_version]))
                         ),

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
@@ -36,8 +36,7 @@ from allotropy.parsers.chemometec_nucleoview.constants import (
     NUCLEOCOUNTER_SOFTWARE_NAME,
 )
 from allotropy.parsers.chemometec_nucleoview.nucleoview_reader import NucleoviewReader
-from allotropy.parsers.utils.uuids import random_uuid_str
-from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
 
 _PROPERTY_LOOKUP = {
     "Dead (cells/ml)": TQuantityValueMillionCellsPerMilliliter,

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
@@ -36,7 +36,7 @@ from allotropy.parsers.chemometec_nucleoview.constants import (
     NUCLEOCOUNTER_SOFTWARE_NAME,
 )
 from allotropy.parsers.chemometec_nucleoview.nucleoview_reader import NucleoviewReader
-from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
+from allotropy.parsers.vendor_parser import VendorParser
 
 _PROPERTY_LOOKUP = {
     "Dead (cells/ml)": TQuantityValueMillionCellsPerMilliliter,
@@ -122,7 +122,7 @@ class ChemometecNucleoviewParser(VendorParser):
             measurement_aggregate_document=MeasurementAggregateDocument(
                 measurement_document=[
                     CellCountingDetectorMeasurementDocumentItem(
-                        measurement_identifier=random_uuid_str(),
+                        measurement_identifier=self.random_uuid_str(),
                         measurement_time=self._get_date_time_or_epoch(
                             _get_value(data_frame, row, "datetime")
                         ),

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
@@ -122,7 +122,7 @@ class ChemometecNucleoviewParser(VendorParser):
             measurement_aggregate_document=MeasurementAggregateDocument(
                 measurement_document=[
                     CellCountingDetectorMeasurementDocumentItem(
-                        measurement_identifier=self.random_uuid_str(),
+                        measurement_identifier=self._random_uuid_str(),
                         measurement_time=self._get_date_time_or_epoch(
                             _get_value(data_frame, row, "datetime")
                         ),

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
@@ -122,7 +122,7 @@ class ChemometecNucleoviewParser(VendorParser):
             measurement_aggregate_document=MeasurementAggregateDocument(
                 measurement_document=[
                     CellCountingDetectorMeasurementDocumentItem(
-                        measurement_identifier=self._random_uuid_str(),
+                        measurement_identifier=self.random_uuid_str(),
                         measurement_time=self._get_date_time_or_epoch(
                             _get_value(data_frame, row, "datetime")
                         ),

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
@@ -22,8 +22,7 @@ from allotropy.parsers.example_weyland_yutani.example_weyland_yutani_structure i
     Data,
 )
 from allotropy.parsers.lines_reader import CsvReader, read_to_lines
-from allotropy.parsers.utils.uuids import random_uuid_str
-from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
 
 
 class ExampleWeylandYutaniParser(VendorParser):

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
@@ -39,7 +39,7 @@ class ExampleWeylandYutaniParser(VendorParser):
 
         return Model(
             measurement_aggregate_document=MeasurementAggregateDocument(
-                measurement_identifier=self.random_uuid_str(),
+                measurement_identifier=self._random_uuid_str(),
                 measurement_time=self._get_measurement_time(data),
                 analytical_method_identifier=data.basic_assay_info.protocol_id,
                 experimental_data_identifier=data.basic_assay_info.assay_id,

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
@@ -22,7 +22,7 @@ from allotropy.parsers.example_weyland_yutani.example_weyland_yutani_structure i
     Data,
 )
 from allotropy.parsers.lines_reader import CsvReader, read_to_lines
-from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
+from allotropy.parsers.vendor_parser import VendorParser
 
 
 class ExampleWeylandYutaniParser(VendorParser):
@@ -39,7 +39,7 @@ class ExampleWeylandYutaniParser(VendorParser):
 
         return Model(
             measurement_aggregate_document=MeasurementAggregateDocument(
-                measurement_identifier=random_uuid_str(),
+                measurement_identifier=self.random_uuid_str(),
                 measurement_time=self._get_measurement_time(data),
                 analytical_method_identifier=data.basic_assay_info.protocol_id,
                 experimental_data_identifier=data.basic_assay_info.assay_id,

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
@@ -39,7 +39,7 @@ class ExampleWeylandYutaniParser(VendorParser):
 
         return Model(
             measurement_aggregate_document=MeasurementAggregateDocument(
-                measurement_identifier=self._random_uuid_str(),
+                measurement_identifier=self.random_uuid_str(),
                 measurement_time=self._get_measurement_time(data),
                 analytical_method_identifier=data.basic_assay_info.protocol_id,
                 experimental_data_identifier=data.basic_assay_info.assay_id,

--- a/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
+++ b/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
@@ -116,7 +116,7 @@ class LuminexXponentParser(VendorParser):
             )
 
         return MeasurementDocumentItem(
-            measurement_identifier=self.random_uuid_str(),
+            measurement_identifier=self._random_uuid_str(),
             measurement_time=self._get_date_time(header_data.measurement_time),
             sample_document=SampleDocument(
                 sample_identifier=measurement.sample_identifier,
@@ -143,7 +143,7 @@ class LuminexXponentParser(VendorParser):
             analyte_aggregate_document=AnalyteAggregateDocument(
                 analyte_document=[
                     AnalyteDocumentItem(
-                        analyte_identifier=self.random_uuid_str(),
+                        analyte_identifier=self._random_uuid_str(),
                         analyte_name=analyte.analyte_name,
                         assay_bead_identifier=analyte.assay_bead_identifier,
                         assay_bead_count=TQuantityValueNumber(

--- a/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
+++ b/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
@@ -33,7 +33,7 @@ from allotropy.parsers.luminex_xponent.luminex_xponent_structure import (
     Header,
     Measurement,
 )
-from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
+from allotropy.parsers.vendor_parser import VendorParser
 
 DEFAULT_SOFTWARE_NAME = "xPONENT"
 DEFAULT_CONTAINER_TYPE = "well plate"
@@ -116,7 +116,7 @@ class LuminexXponentParser(VendorParser):
             )
 
         return MeasurementDocumentItem(
-            measurement_identifier=random_uuid_str(),
+            measurement_identifier=self.random_uuid_str(),
             measurement_time=self._get_date_time(header_data.measurement_time),
             sample_document=SampleDocument(
                 sample_identifier=measurement.sample_identifier,
@@ -143,7 +143,7 @@ class LuminexXponentParser(VendorParser):
             analyte_aggregate_document=AnalyteAggregateDocument(
                 analyte_document=[
                     AnalyteDocumentItem(
-                        analyte_identifier=random_uuid_str(),
+                        analyte_identifier=self.random_uuid_str(),
                         analyte_name=analyte.analyte_name,
                         assay_bead_identifier=analyte.assay_bead_identifier,
                         assay_bead_count=TQuantityValueNumber(

--- a/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
+++ b/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
@@ -116,7 +116,7 @@ class LuminexXponentParser(VendorParser):
             )
 
         return MeasurementDocumentItem(
-            measurement_identifier=self._random_uuid_str(),
+            measurement_identifier=self.random_uuid_str(),
             measurement_time=self._get_date_time(header_data.measurement_time),
             sample_document=SampleDocument(
                 sample_identifier=measurement.sample_identifier,
@@ -143,7 +143,7 @@ class LuminexXponentParser(VendorParser):
             analyte_aggregate_document=AnalyteAggregateDocument(
                 analyte_document=[
                     AnalyteDocumentItem(
-                        analyte_identifier=self._random_uuid_str(),
+                        analyte_identifier=self.random_uuid_str(),
                         analyte_name=analyte.analyte_name,
                         assay_bead_identifier=analyte.assay_bead_identifier,
                         assay_bead_count=TQuantityValueNumber(

--- a/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
+++ b/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
@@ -33,8 +33,7 @@ from allotropy.parsers.luminex_xponent.luminex_xponent_structure import (
     Header,
     Measurement,
 )
-from allotropy.parsers.utils.uuids import random_uuid_str
-from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
 
 DEFAULT_SOFTWARE_NAME = "xPONENT"
 DEFAULT_CONTAINER_TYPE = "well plate"

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
@@ -62,7 +62,7 @@ from allotropy.parsers.moldev_softmax_pro.softmax_pro_structure import (
 from allotropy.parsers.utils.values import (
     assert_not_none,
 )
-from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
+from allotropy.parsers.vendor_parser import VendorParser
 
 
 def to_json_float(value: float) -> JsonFloat:
@@ -315,7 +315,7 @@ class SoftmaxproParser(VendorParser):
         description: Optional[str] = None,
     ) -> CalculatedDataDocumentItem:
         return CalculatedDataDocumentItem(
-            calculated_data_identifier=random_uuid_str(),
+            calculated_data_identifier=self.random_uuid_str(),
             calculated_data_name=name,
             calculation_description=description,
             calculated_result=TQuantityValue(

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
@@ -59,11 +59,10 @@ from allotropy.parsers.moldev_softmax_pro.softmax_pro_structure import (
     PlateBlock,
     ScanPosition,
 )
-from allotropy.parsers.utils.uuids import random_uuid_str
 from allotropy.parsers.utils.values import (
     assert_not_none,
 )
-from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
 
 
 def to_json_float(value: float) -> JsonFloat:

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
@@ -16,6 +16,7 @@ from allotropy.exceptions import (
     msg_for_error_on_unrecognized_value,
 )
 from allotropy.parsers.lines_reader import CsvReader
+from allotropy.parsers.moldev_softmax_pro.softmax_pro_parser import SoftmaxproParser
 from allotropy.parsers.utils.values import (
     assert_not_none,
     num_to_chars,
@@ -26,11 +27,14 @@ from allotropy.parsers.utils.values import (
     try_str_from_series,
     try_str_from_series_or_none,
 )
-from allotropy.parsers.vendor_parser import random_uuid_str
 
 BLOCKS_LINE_REGEX = r"^##BLOCKS=\s*(\d+)$"
 END_LINE_REGEX = "~End"
 EXPORT_VERSION = "1.3"
+
+
+def random_uuid_str() -> str:
+    return SoftmaxproParser.random_uuid_str()
 
 
 def try_non_nan_float_or_none(value: Optional[str]) -> Optional[float]:

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
@@ -16,7 +16,6 @@ from allotropy.exceptions import (
     msg_for_error_on_unrecognized_value,
 )
 from allotropy.parsers.lines_reader import CsvReader
-from allotropy.parsers.moldev_softmax_pro.softmax_pro_parser import SoftmaxproParser
 from allotropy.parsers.utils.values import (
     assert_not_none,
     num_to_chars,
@@ -34,6 +33,8 @@ EXPORT_VERSION = "1.3"
 
 
 def random_uuid_str() -> str:
+    from allotropy.parsers.moldev_softmax_pro.softmax_pro_parser import SoftmaxproParser
+
     return SoftmaxproParser.random_uuid_str()
 
 

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
@@ -16,7 +16,6 @@ from allotropy.exceptions import (
     msg_for_error_on_unrecognized_value,
 )
 from allotropy.parsers.lines_reader import CsvReader
-from allotropy.parsers.utils.uuids import random_uuid_str
 from allotropy.parsers.utils.values import (
     assert_not_none,
     num_to_chars,
@@ -27,6 +26,7 @@ from allotropy.parsers.utils.values import (
     try_str_from_series,
     try_str_from_series_or_none,
 )
+from allotropy.parsers.vendor_parser import random_uuid_str
 
 BLOCKS_LINE_REGEX = r"^##BLOCKS=\s*(\d+)$"
 END_LINE_REGEX = "~End"

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
@@ -9,8 +9,7 @@ from allotropy.allotrope.models.cell_culture_analyzer_benchling_2023_09_cell_cul
 )
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.novabio_flex2.novabio_flex2_structure import Data, Sample
-from allotropy.parsers.utils.uuids import random_uuid_str
-from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
 
 
 class NovaBioFlexParser(VendorParser):

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
@@ -19,7 +19,7 @@ class NovaBioFlexParser(VendorParser):
     def _get_model(self, data: Data) -> Model:
         return Model(
             measurement_aggregate_document=MeasurementAggregateDocument(
-                measurement_identifier=self.random_uuid_str(),
+                measurement_identifier=self._random_uuid_str(),
                 data_processing_time=self._get_date_time(data.title.processing_time),
                 analyst=data.sample_list.analyst,
                 device_system_document=DeviceSystemDocument(

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
@@ -19,7 +19,7 @@ class NovaBioFlexParser(VendorParser):
     def _get_model(self, data: Data) -> Model:
         return Model(
             measurement_aggregate_document=MeasurementAggregateDocument(
-                measurement_identifier=self._random_uuid_str(),
+                measurement_identifier=self.random_uuid_str(),
                 data_processing_time=self._get_date_time(data.title.processing_time),
                 analyst=data.sample_list.analyst,
                 device_system_document=DeviceSystemDocument(

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
@@ -9,7 +9,7 @@ from allotropy.allotrope.models.cell_culture_analyzer_benchling_2023_09_cell_cul
 )
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.novabio_flex2.novabio_flex2_structure import Data, Sample
-from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
+from allotropy.parsers.vendor_parser import VendorParser
 
 
 class NovaBioFlexParser(VendorParser):
@@ -19,7 +19,7 @@ class NovaBioFlexParser(VendorParser):
     def _get_model(self, data: Data) -> Model:
         return Model(
             measurement_aggregate_document=MeasurementAggregateDocument(
-                measurement_identifier=random_uuid_str(),
+                measurement_identifier=self.random_uuid_str(),
                 data_processing_time=self._get_date_time(data.title.processing_time),
                 analyst=data.sample_list.analyst,
                 device_system_document=DeviceSystemDocument(

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
@@ -29,6 +29,9 @@ from allotropy.allotrope.models.plate_reader_benchling_2023_09_plate_reader impo
 from allotropy.allotrope.models.shared.components.plate_reader import SampleRoleType
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.parsers.lines_reader import CsvReader
+from allotropy.parsers.unchained_labs_lunatic.unchained_labs_lunatic_parser import (
+    UnchainedLabsLunaticParser,
+)
 from allotropy.parsers.utils.values import (
     assert_not_none,
     try_float_from_series,
@@ -36,7 +39,10 @@ from allotropy.parsers.utils.values import (
     try_str_from_series,
     try_str_from_series_or_none,
 )
-from allotropy.parsers.vendor_parser import random_uuid_str
+
+
+def random_uuid_str() -> str:
+    return UnchainedLabsLunaticParser.random_uuid_str()
 
 
 def df_to_series(df: pd.DataFrame) -> pd.Series[Any]:

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
@@ -29,7 +29,6 @@ from allotropy.allotrope.models.plate_reader_benchling_2023_09_plate_reader impo
 from allotropy.allotrope.models.shared.components.plate_reader import SampleRoleType
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.parsers.lines_reader import CsvReader
-from allotropy.parsers.utils.uuids import random_uuid_str
 from allotropy.parsers.utils.values import (
     assert_not_none,
     try_float_from_series,
@@ -37,6 +36,7 @@ from allotropy.parsers.utils.values import (
     try_str_from_series,
     try_str_from_series_or_none,
 )
+from allotropy.parsers.vendor_parser import random_uuid_str
 
 
 def df_to_series(df: pd.DataFrame) -> pd.Series[Any]:

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
@@ -29,9 +29,6 @@ from allotropy.allotrope.models.plate_reader_benchling_2023_09_plate_reader impo
 from allotropy.allotrope.models.shared.components.plate_reader import SampleRoleType
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.parsers.lines_reader import CsvReader
-from allotropy.parsers.unchained_labs_lunatic.unchained_labs_lunatic_parser import (
-    UnchainedLabsLunaticParser,
-)
 from allotropy.parsers.utils.values import (
     assert_not_none,
     try_float_from_series,
@@ -42,6 +39,10 @@ from allotropy.parsers.utils.values import (
 
 
 def random_uuid_str() -> str:
+    from allotropy.parsers.unchained_labs_lunatic.unchained_labs_lunatic_parser import (
+        UnchainedLabsLunaticParser,
+    )
+
     return UnchainedLabsLunaticParser.random_uuid_str()
 
 

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
@@ -12,8 +12,7 @@ from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_reader import (
     RocheCedexBiohtReader,
 )
 from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_structure import Data, Sample
-from allotropy.parsers.utils.uuids import random_uuid_str
-from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
 
 
 class RocheCedexBiohtParser(VendorParser):

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
@@ -12,7 +12,7 @@ from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_reader import (
     RocheCedexBiohtReader,
 )
 from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_structure import Data, Sample
-from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
+from allotropy.parsers.vendor_parser import VendorParser
 
 
 class RocheCedexBiohtParser(VendorParser):
@@ -24,7 +24,7 @@ class RocheCedexBiohtParser(VendorParser):
     def _get_model(self, data: Data) -> Model:
         return Model(
             measurement_aggregate_document=MeasurementAggregateDocument(
-                measurement_identifier=random_uuid_str(),
+                measurement_identifier=self.random_uuid_str(),
                 data_processing_time=self._get_date_time(
                     data.title.data_processing_time
                 ),

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
@@ -24,7 +24,7 @@ class RocheCedexBiohtParser(VendorParser):
     def _get_model(self, data: Data) -> Model:
         return Model(
             measurement_aggregate_document=MeasurementAggregateDocument(
-                measurement_identifier=self._random_uuid_str(),
+                measurement_identifier=self.random_uuid_str(),
                 data_processing_time=self._get_date_time(
                     data.title.data_processing_time
                 ),

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
@@ -24,7 +24,7 @@ class RocheCedexBiohtParser(VendorParser):
     def _get_model(self, data: Data) -> Model:
         return Model(
             measurement_aggregate_document=MeasurementAggregateDocument(
-                measurement_identifier=self.random_uuid_str(),
+                measurement_identifier=self._random_uuid_str(),
                 data_processing_time=self._get_date_time(
                     data.title.data_processing_time
                 ),

--- a/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
+++ b/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
@@ -42,9 +42,8 @@ from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.thermo_fisher_nanodrop_eight.nanodrop_eight_reader import (
     NanoDropEightReader,
 )
-from allotropy.parsers.utils.uuids import random_uuid_str
 from allotropy.parsers.utils.values import assert_not_none
-from allotropy.parsers.vendor_parser import VendorParser
+from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
 
 ConcentrationType = Union[
     TQuantityValueMicrogramPerMicroliter,

--- a/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
+++ b/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
@@ -43,7 +43,7 @@ from allotropy.parsers.thermo_fisher_nanodrop_eight.nanodrop_eight_reader import
     NanoDropEightReader,
 )
 from allotropy.parsers.utils.values import assert_not_none
-from allotropy.parsers.vendor_parser import random_uuid_str, VendorParser
+from allotropy.parsers.vendor_parser import VendorParser
 
 ConcentrationType = Union[
     TQuantityValueMicrogramPerMicroliter,
@@ -136,8 +136,8 @@ class NanodropEightParser(VendorParser):
         )
 
     def _add_measurement_uuids(self, data: pd.DataFrame) -> pd.DataFrame:
-        data["a260 uuid"] = [random_uuid_str() for _ in range(len(data.index))]
-        data["a280 uuid"] = [random_uuid_str() for _ in range(len(data.index))]
+        data["a260 uuid"] = [self.random_uuid_str() for _ in range(len(data.index))]
+        data["a280 uuid"] = [self.random_uuid_str() for _ in range(len(data.index))]
         return data
 
     def _get_spectrophotometry_document(
@@ -167,7 +167,7 @@ class NanodropEightParser(VendorParser):
             calculated_result=TQuantityValue(
                 value=_get_float(data, row, "260/280"), unit=UNITLESS
             ),
-            calculated_data_identifier=random_uuid_str(),
+            calculated_data_identifier=self.random_uuid_str(),
             data_source_aggregate_document=DataSourceAggregateDocument(
                 data_source_document=[
                     DataSourceDocumentItem(
@@ -188,7 +188,7 @@ class NanodropEightParser(VendorParser):
             calculated_result=TQuantityValue(
                 value=_get_float(data, row, "260/230"), unit=UNITLESS
             ),
-            calculated_data_identifier=random_uuid_str(),
+            calculated_data_identifier=self.random_uuid_str(),
             data_source_aggregate_document=DataSourceAggregateDocument(
                 data_source_document=[
                     DataSourceDocumentItem(

--- a/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
+++ b/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
@@ -136,8 +136,8 @@ class NanodropEightParser(VendorParser):
         )
 
     def _add_measurement_uuids(self, data: pd.DataFrame) -> pd.DataFrame:
-        data["a260 uuid"] = [self._random_uuid_str() for _ in range(len(data.index))]
-        data["a280 uuid"] = [self._random_uuid_str() for _ in range(len(data.index))]
+        data["a260 uuid"] = [self.random_uuid_str() for _ in range(len(data.index))]
+        data["a280 uuid"] = [self.random_uuid_str() for _ in range(len(data.index))]
         return data
 
     def _get_spectrophotometry_document(
@@ -167,7 +167,7 @@ class NanodropEightParser(VendorParser):
             calculated_result=TQuantityValue(
                 value=_get_float(data, row, "260/280"), unit=UNITLESS
             ),
-            calculated_data_identifier=self._random_uuid_str(),
+            calculated_data_identifier=self.random_uuid_str(),
             data_source_aggregate_document=DataSourceAggregateDocument(
                 data_source_document=[
                     DataSourceDocumentItem(
@@ -188,7 +188,7 @@ class NanodropEightParser(VendorParser):
             calculated_result=TQuantityValue(
                 value=_get_float(data, row, "260/230"), unit=UNITLESS
             ),
-            calculated_data_identifier=self._random_uuid_str(),
+            calculated_data_identifier=self.random_uuid_str(),
             data_source_aggregate_document=DataSourceAggregateDocument(
                 data_source_document=[
                     DataSourceDocumentItem(

--- a/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
+++ b/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
@@ -136,8 +136,8 @@ class NanodropEightParser(VendorParser):
         )
 
     def _add_measurement_uuids(self, data: pd.DataFrame) -> pd.DataFrame:
-        data["a260 uuid"] = [self.random_uuid_str() for _ in range(len(data.index))]
-        data["a280 uuid"] = [self.random_uuid_str() for _ in range(len(data.index))]
+        data["a260 uuid"] = [self._random_uuid_str() for _ in range(len(data.index))]
+        data["a280 uuid"] = [self._random_uuid_str() for _ in range(len(data.index))]
         return data
 
     def _get_spectrophotometry_document(
@@ -167,7 +167,7 @@ class NanodropEightParser(VendorParser):
             calculated_result=TQuantityValue(
                 value=_get_float(data, row, "260/280"), unit=UNITLESS
             ),
-            calculated_data_identifier=self.random_uuid_str(),
+            calculated_data_identifier=self._random_uuid_str(),
             data_source_aggregate_document=DataSourceAggregateDocument(
                 data_source_document=[
                     DataSourceDocumentItem(
@@ -188,7 +188,7 @@ class NanodropEightParser(VendorParser):
             calculated_result=TQuantityValue(
                 value=_get_float(data, row, "260/230"), unit=UNITLESS
             ),
-            calculated_data_identifier=self.random_uuid_str(),
+            calculated_data_identifier=self._random_uuid_str(),
             data_source_aggregate_document=DataSourceAggregateDocument(
                 data_source_document=[
                     DataSourceDocumentItem(

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
@@ -14,13 +14,19 @@ from allotropy.parsers.unchained_labs_lunatic.constants import (
     NO_WAVELENGTH_COLUMN_ERROR_MSG,
     WAVELENGTH_COLUMNS_RE,
 )
+from allotropy.parsers.unchained_labs_lunatic.unchained_labs_lunatic_parser import (
+    UnchainedLabsLunaticParser,
+)
 from allotropy.parsers.utils.values import (
     try_float_from_series,
     try_float_from_series_or_none,
     try_str_from_series,
     try_str_from_series_or_none,
 )
-from allotropy.parsers.vendor_parser import random_uuid_str
+
+
+def random_uuid_str() -> str:
+    return UnchainedLabsLunaticParser.random_uuid_str()
 
 
 @dataclass(frozen=True)

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
@@ -14,9 +14,6 @@ from allotropy.parsers.unchained_labs_lunatic.constants import (
     NO_WAVELENGTH_COLUMN_ERROR_MSG,
     WAVELENGTH_COLUMNS_RE,
 )
-from allotropy.parsers.unchained_labs_lunatic.unchained_labs_lunatic_parser import (
-    UnchainedLabsLunaticParser,
-)
 from allotropy.parsers.utils.values import (
     try_float_from_series,
     try_float_from_series_or_none,
@@ -26,6 +23,10 @@ from allotropy.parsers.utils.values import (
 
 
 def random_uuid_str() -> str:
+    from allotropy.parsers.unchained_labs_lunatic.unchained_labs_lunatic_parser import (
+        UnchainedLabsLunaticParser,
+    )
+
     return UnchainedLabsLunaticParser.random_uuid_str()
 
 

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
@@ -14,13 +14,13 @@ from allotropy.parsers.unchained_labs_lunatic.constants import (
     NO_WAVELENGTH_COLUMN_ERROR_MSG,
     WAVELENGTH_COLUMNS_RE,
 )
-from allotropy.parsers.utils.uuids import random_uuid_str
 from allotropy.parsers.utils.values import (
     try_float_from_series,
     try_float_from_series_or_none,
     try_str_from_series,
     try_str_from_series_or_none,
 )
+from allotropy.parsers.vendor_parser import random_uuid_str
 
 
 @dataclass(frozen=True)

--- a/src/allotropy/parsers/utils/uuids.py
+++ b/src/allotropy/parsers/utils/uuids.py
@@ -1,5 +1,0 @@
-import uuid
-
-
-def random_uuid_str() -> str:
-    return str(uuid.uuid4())

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -26,8 +26,9 @@ class VendorParser(ABC):
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Any:
         raise NotImplementedError
 
+    # TODO: make protected
     @final
-    def _random_uuid_str(self) -> str:
+    def random_uuid_str(self) -> str:
         return random_uuid_str()
 
     def _get_date_time(self, time: str) -> TDateTimeValue:

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -10,6 +10,17 @@ from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from allotropy.parsers.utils.values import assert_not_none
 
 
+class IdGenerator(ABC):
+    @abstractmethod
+    def generate_id(self) -> str:
+        raise NotImplementedError
+
+
+class UuidGenerator(IdGenerator):
+    def generate_id(self) -> str:
+        return str(uuid.uuid4())
+
+
 class VendorParser(ABC):
     timestamp_parser: TimestampParser
 
@@ -25,7 +36,12 @@ class VendorParser(ABC):
     @classmethod
     @final
     def random_uuid_str(cls) -> str:
-        return str(uuid.uuid4())
+        return cls._get_id_generator().generate_id()
+
+    @classmethod
+    @final
+    def _get_id_generator(cls) -> IdGenerator:
+        return UuidGenerator()
 
     def _get_date_time(self, time: str) -> TDateTimeValue:
         assert_not_none(time, "time")

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Any
+import uuid
 
 from pandas import Timestamp
 
@@ -7,6 +8,10 @@ from allotropy.allotrope.models.shared.definitions.definitions import TDateTimeV
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from allotropy.parsers.utils.values import assert_not_none
+
+
+def random_uuid_str() -> str:
+    return str(uuid.uuid4())
 
 
 class VendorParser(ABC):

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -16,6 +16,7 @@ class IdGenerator(ABC):
         raise NotImplementedError
 
 
+@final
 class UuidGenerator(IdGenerator):
     def generate_id(self) -> str:
         return str(uuid.uuid4())

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -40,8 +40,3 @@ class VendorParser(ABC):
 
         time = str(timestamp)
         return self._get_date_time(time)
-
-
-# TODO: delete this function
-def random_uuid_str() -> str:
-    return VendorParser.random_uuid_str()

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -26,9 +26,8 @@ class VendorParser(ABC):
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Any:
         raise NotImplementedError
 
-    # TODO: make protected
     @final
-    def random_uuid_str(self) -> str:
+    def _random_uuid_str(self) -> str:
         return random_uuid_str()
 
     def _get_date_time(self, time: str) -> TDateTimeValue:

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, final
 import uuid
 
 from pandas import Timestamp
@@ -25,6 +25,11 @@ class VendorParser(ABC):
     @abstractmethod
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Any:
         raise NotImplementedError
+
+    # TODO: make protected
+    @final
+    def random_uuid_str(self) -> str:
+        return random_uuid_str()
 
     def _get_date_time(self, time: str) -> TDateTimeValue:
         assert_not_none(time, "time")

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -10,10 +10,6 @@ from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from allotropy.parsers.utils.values import assert_not_none
 
 
-def random_uuid_str() -> str:
-    return str(uuid.uuid4())
-
-
 class VendorParser(ABC):
     timestamp_parser: TimestampParser
 
@@ -26,10 +22,10 @@ class VendorParser(ABC):
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Any:
         raise NotImplementedError
 
-    # TODO: make protected
+    @classmethod
     @final
-    def random_uuid_str(self) -> str:
-        return random_uuid_str()
+    def random_uuid_str(cls) -> str:
+        return str(uuid.uuid4())
 
     def _get_date_time(self, time: str) -> TDateTimeValue:
         assert_not_none(time, "time")
@@ -44,3 +40,8 @@ class VendorParser(ABC):
 
         time = str(timestamp)
         return self._get_date_time(time)
+
+
+# TODO: delete this function
+def random_uuid_str() -> str:
+    return VendorParser.random_uuid_str()


### PR DESCRIPTION
These changes will facilitate mocking `VendorParser._get_id_generator()` in tests to create stable identifiers. Not to mention potentially allowing changing id generation in src).

Note that making the id generator an instance method on `VendorParser` rather than a singleton accessed by a function makes mocking in tests significantly easier. If this were accessed via a function, we would have to mock each import differently in tests.

Steps taken:
1. Move `random_uuid_str` to vendor_parser module
2. Create classmethod of same name in VendorParser that calls function and use it in children
3. Create IdGenerator interface and supply a default implementation
4. Delete utility function
5. Create utility function in each module that was still importing it, using the child of VendorParser appropriate to the module