### PR TITLE
Pin mypy to 1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ extra-dependencies = [
   # mypy sometimes can't find cattrs even though it's a project depenedency, so add explicitly here.
   "cattrs == 23.1.2",
   "more-itertools >= 10.1.0",
-  "mypy >= 1.6.0",
+  "mypy == 1.6.0",
   # For pytest types
   "pytest >= 7.4.0",
 ]


### PR DESCRIPTION
Current version is 1.8.0, but for some reason hatch was apparently using 1.6.0 until just recently. Now it's using a later version, and no changes can be committed without fixing or suppressing some warnings.

Pin to 1.6.0 to unblock development, and follow up later to upgrade mypy.