### PR TITLE
Pin pandas-stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ extra-dependencies = [
   "cattrs == 23.1.2",
   "more-itertools >= 10.1.0",
   "mypy >= 1.6.0",
+  "pandas-stubs == 2.1.4.231227",
   # For pytest types
   "pytest >= 7.4.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "jsonschema >= 4.17.0",
   "numpy >= 1.25.0",
   "openpyxl >= 3.1.0",
-  "pandas >= 2.1.0",
+  "pandas == 2.1.0",
   "pytz",
   "xlrd >= 2.0.0",
   "rfc3339-validator >= 0.1.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "jsonschema >= 4.17.0",
   "numpy >= 1.25.0",
   "openpyxl >= 3.1.0",
-  "pandas == 2.1.0",
+  "pandas >= 2.1.0",
   "pytz",
   "xlrd >= 2.0.0",
   "rfc3339-validator >= 0.1.4",


### PR DESCRIPTION
pandas-stubs released a 2.2.x version two days ago:
https://pypi.org/project/pandas-stubs/#history

It broke mypy. Pin to prior version to unblock development.