### PR TITLE
Make _assert_allotrope_dicts_equal() stricter

### DIFF
--- a/tests/parsers/test_utils.py
+++ b/tests/parsers/test_utils.py
@@ -38,7 +38,7 @@ def _assert_allotrope_dicts_equal(
     ddiff = DeepDiff(
         expected_replaced,
         actual,
-        ignore_type_in_groups=[(float, np.float64), (int, np.int64)],
+        ignore_type_in_groups=[(float, np.float64)],
     )
     assert not ddiff
 


### PR DESCRIPTION
There are no existing instances of `(int, np.int64)` mismatches, so tighten checks.

We can remove `(float, np.float64)` as well, but that will require a src change in `vi_cell_blu_parser`, so we'll do that separately.