### PR TITLE
fix: add missing ct mean calc docs to relative std curve in AppBio Quantstudio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Fixed
+- Add missing ct mean calculated data documents to relative std curve experiments in AppBio Quantstudio
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_calculated_documents.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_calculated_documents.py
@@ -576,6 +576,9 @@ def iter_relative_standard_curve_calc_docs(
         if calc_doc := build_quantity_sd(view_st_data, sample, target):
             yield from calc_doc.iter_struct()
 
+        if calc_doc := build_ct_mean(view_st_data, sample, target):
+            yield from calc_doc.iter_struct()
+
         if calc_doc := build_ct_sd(view_st_data, sample, target):
             yield from calc_doc.iter_struct()
 

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_data.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_data.py
@@ -1832,6 +1832,108 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
+                uuid="be28fba1-d101-4cfc-b62b-9e31e833e261",
+                name="ct mean",
+                value=30.115,
+                data_sources=[
+                    DataSource(
+                        feature="cycle threshold result",
+                        reference=WellItem(
+                            uuid="90476d22-abb1-4ad1-ad79-350d8726e90e",
+                            identifier=37,
+                            target_dna_description="RNaseP",
+                            sample_identifier="800",
+                            reporter_dye_setting="FAM",
+                            position="D1",
+                            well_location_identifier="D1",
+                            quencher_dye_setting="NFQ-MGB",
+                            sample_role_type="UNKNOWN",
+                            _amplification_data=AmplificationData(
+                                total_cycle_number_setting=1.0,
+                                cycle=[1],
+                                rn=[0.627],
+                                delta_rn=[0.001],
+                            ),
+                            _result=Result(
+                                cycle_threshold_value_setting=0.133,
+                                cycle_threshold_result=30.155,
+                                automatic_cycle_threshold_enabled_setting=True,
+                                automatic_baseline_determination_enabled_setting=True,
+                                normalized_reporter_result=None,
+                                baseline_corrected_reporter_result=None,
+                                genotyping_determination_result=None,
+                                genotyping_determination_method_setting=None,
+                                quantity=794.91,
+                                quantity_mean=818.012,
+                                quantity_sd=29.535,
+                                ct_mean=30.115,
+                                ct_sd=0.051,
+                                delta_ct_mean=None,
+                                delta_ct_se=None,
+                                delta_delta_ct=None,
+                                rq=0.798,
+                                rq_min=0.658,
+                                rq_max=0.967,
+                                rn_mean=None,
+                                rn_sd=None,
+                                y_intercept=39.662,
+                                r_squared=0.999,
+                                slope=-3.278,
+                                efficiency=101.866,
+                            ),
+                        ),
+                    ),
+                    DataSource(
+                        feature="cycle threshold result",
+                        reference=WellItem(
+                            uuid="ad05b7ea-33f8-4d50-a8f4-6e13f4eb386c",
+                            identifier=38,
+                            target_dna_description="RNaseP",
+                            sample_identifier="800",
+                            reporter_dye_setting="FAM",
+                            position="D2",
+                            well_location_identifier="D2",
+                            quencher_dye_setting="NFQ-MGB",
+                            sample_role_type="UNKNOWN",
+                            _amplification_data=AmplificationData(
+                                total_cycle_number_setting=1.0,
+                                cycle=[1],
+                                rn=[0.612],
+                                delta_rn=[-0.001],
+                            ),
+                            _result=Result(
+                                cycle_threshold_value_setting=0.133,
+                                cycle_threshold_result=30.2,
+                                automatic_cycle_threshold_enabled_setting=True,
+                                automatic_baseline_determination_enabled_setting=True,
+                                normalized_reporter_result=None,
+                                baseline_corrected_reporter_result=None,
+                                genotyping_determination_result=None,
+                                genotyping_determination_method_setting=None,
+                                quantity=769.776,
+                                quantity_mean=818.012,
+                                quantity_sd=29.535,
+                                ct_mean=30.115,
+                                ct_sd=0.051,
+                                delta_ct_mean=None,
+                                delta_ct_se=None,
+                                delta_delta_ct=None,
+                                rq=0.798,
+                                rq_min=0.658,
+                                rq_max=0.967,
+                                rn_mean=None,
+                                rn_sd=None,
+                                y_intercept=39.662,
+                                r_squared=0.999,
+                                slope=-3.278,
+                                efficiency=101.866,
+                            ),
+                        ),
+                    ),
+                ],
+                iterated=True,
+            ),
+            CalculatedDocument(
                 uuid="88749c03-5cdb-49c1-b829-092e95e863ff",
                 name="ct sd",
                 value=0.051,
@@ -2857,6 +2959,33 @@ def get_rel_std_curve_model() -> Model:
                         ),
                     ),
                     CalculatedDataDocumentItem(
+                        calculated_data_identifier="be28fba1-d101-4cfc-b62b-9e31e833e261",
+                        data_source_aggregate_document=DataSourceAggregateDocument(
+                            data_source_document=[
+                                DataSourceDocumentItem(
+                                    data_source_identifier="90476d22-abb1-4ad1-ad79-350d8726e90e",
+                                    data_source_feature="cycle threshold result",
+                                ),
+                                DataSourceDocumentItem(
+                                    data_source_identifier="ad05b7ea-33f8-4d50-a8f4-6e13f4eb386c",
+                                    data_source_feature="cycle threshold result",
+                                ),
+                            ]
+                        ),
+                        data_processing_document=DataProcessingDocument1(
+                            reference_DNA_description="RNaseP",
+                            reference_sample_description="800",
+                        ),
+                        calculated_data_name="ct mean",
+                        calculated_data_description=None,
+                        calculated_datum=TQuantityValueUnitless(
+                            value=30.115,
+                            unit="(unitless)",
+                            has_statistic_datum_role=None,
+                            field_type=None,
+                        ),
+                    ),
+                    CalculatedDataDocumentItem(
                         calculated_data_identifier="88749c03-5cdb-49c1-b829-092e95e863ff",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
@@ -3047,6 +3176,61 @@ def get_broken_calc_doc_data() -> Data:
         reference_sample="800",
         calculated_documents=[
             CalculatedDocument(
+                uuid="f8cb25cf-8052-40eb-aead-1b6d371b9f25",
+                name="ct mean",
+                value=30.115,
+                data_sources=[
+                    DataSource(
+                        feature="cycle threshold result",
+                        reference=WellItem(
+                            uuid="ba6db637-e3c9-4c08-bb0d-86b5cf1a14ab",
+                            identifier=37,
+                            target_dna_description="RNaseP",
+                            sample_identifier="800",
+                            reporter_dye_setting="FAM",
+                            position="D1",
+                            well_location_identifier="D1",
+                            quencher_dye_setting="NFQ-MGB",
+                            sample_role_type="UNKNOWN",
+                            _amplification_data=AmplificationData(
+                                total_cycle_number_setting=1.0,
+                                cycle=[1],
+                                rn=[0.627],
+                                delta_rn=[0.001],
+                            ),
+                            _result=Result(
+                                cycle_threshold_value_setting=0.133,
+                                cycle_threshold_result=30.155,
+                                automatic_cycle_threshold_enabled_setting=True,
+                                automatic_baseline_determination_enabled_setting=True,
+                                normalized_reporter_result=None,
+                                baseline_corrected_reporter_result=None,
+                                genotyping_determination_result=None,
+                                genotyping_determination_method_setting=None,
+                                quantity=None,
+                                quantity_mean=818.012,
+                                quantity_sd=29.535,
+                                ct_mean=30.115,
+                                ct_sd=0.051,
+                                delta_ct_mean=None,
+                                delta_ct_se=None,
+                                delta_delta_ct=None,
+                                rq=0.798,
+                                rq_min=0.658,
+                                rq_max=0.967,
+                                rn_mean=None,
+                                rn_sd=None,
+                                y_intercept=39.662,
+                                r_squared=0.999,
+                                slope=-3.278,
+                                efficiency=101.866,
+                            ),
+                        ),
+                    )
+                ],
+                iterated=True,
+            ),
+            CalculatedDocument(
                 uuid="d6d4d929-aa30-414b-a56a-12d2cac78bb3",
                 name="ct sd",
                 value=0.051,
@@ -3100,7 +3284,7 @@ def get_broken_calc_doc_data() -> Data:
                     )
                 ],
                 iterated=True,
-            )
+            ),
         ],
     )
 
@@ -3259,6 +3443,29 @@ def get_broken_calc_doc_model() -> Model:
             calculated_data_aggregate_document=TCalculatedDataAggregateDocument(
                 calculated_data_document=[
                     CalculatedDataDocumentItem(
+                        calculated_data_identifier="f8cb25cf-8052-40eb-aead-1b6d371b9f25",
+                        data_source_aggregate_document=DataSourceAggregateDocument(
+                            data_source_document=[
+                                DataSourceDocumentItem(
+                                    data_source_identifier="ba6db637-e3c9-4c08-bb0d-86b5cf1a14ab",
+                                    data_source_feature="cycle threshold result",
+                                )
+                            ]
+                        ),
+                        data_processing_document=DataProcessingDocument1(
+                            reference_DNA_description="RNaseP",
+                            reference_sample_description="800",
+                        ),
+                        calculated_data_name="ct mean",
+                        calculated_data_description=None,
+                        calculated_datum=TQuantityValueUnitless(
+                            value=30.115,
+                            unit="(unitless)",
+                            has_statistic_datum_role=None,
+                            field_type=None,
+                        ),
+                    ),
+                    CalculatedDataDocumentItem(
                         calculated_data_identifier="d6d4d929-aa30-414b-a56a-12d2cac78bb3",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
@@ -3277,7 +3484,7 @@ def get_broken_calc_doc_model() -> Model:
                         calculated_datum=TQuantityValueUnitless(
                             value=0.051,
                         ),
-                    )
+                    ),
                 ]
             ),
         ),

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example07.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example07.json
@@ -30854,7 +30854,7 @@
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.20"
         },
         "calculated data aggregate document": {
             "calculated data document": [
@@ -31044,6 +31044,70 @@
                         "reference DNA description": "IPC",
                         "reference sample description": "1000"
                     },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 30.095,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_123",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_0",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_1",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_2",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_12",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_13",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_14",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_24",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_25",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_26",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_36",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_37",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_38",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
                     "calculated data name": "ct sd",
                     "calculated datum": {
                         "value": 0.059,
@@ -31051,11 +31115,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_125",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_126",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_125",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31071,11 +31135,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_125",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_123",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -31091,7 +31155,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_123",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31155,11 +31219,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_126",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_127",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_125",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31175,7 +31239,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_127",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_128",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31203,7 +31267,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_128",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_129",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31231,7 +31295,35 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_129",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_130",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_48",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_49",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_50",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 32.705,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_131",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31259,7 +31351,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_130",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_132",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31323,7 +31415,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_131",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_133",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31387,7 +31479,71 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_132",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_134",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_3",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_4",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_5",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_15",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_16",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_17",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_27",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_28",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_29",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_39",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_40",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_41",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 29.094,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_135",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31451,11 +31607,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_135",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_138",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_134",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_137",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31471,11 +31627,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_134",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_137",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_133",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_136",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -31491,7 +31647,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_133",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_136",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31555,11 +31711,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_136",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_139",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_134",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_137",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31575,7 +31731,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_137",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_140",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31603,7 +31759,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_138",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_141",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31631,7 +31787,35 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_139",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_142",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_51",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_52",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_53",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 32.861,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31659,7 +31843,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_140",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31723,7 +31907,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_141",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_145",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31787,7 +31971,71 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_142",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_6",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_7",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_8",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_18",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_19",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_20",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_30",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_31",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_32",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_42",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_43",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_44",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 27.502,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_147",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31851,11 +32099,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_145",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_150",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31871,11 +32119,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_148",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -31891,7 +32139,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_148",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31955,11 +32203,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_151",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31975,7 +32223,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_147",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_152",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32003,7 +32251,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_148",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_153",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32031,7 +32279,35 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_154",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_54",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_55",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_56",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 33.02,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_155",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32059,7 +32335,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_150",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_156",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32123,7 +32399,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_151",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_157",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32187,7 +32463,71 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_152",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_158",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_9",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_10",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_11",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_21",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_22",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_23",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_33",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_34",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_35",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_45",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_46",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_47",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 29.8,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_159",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32251,11 +32591,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_155",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_162",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_154",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_161",
                                 "data source feature": "rq"
                             }
                         ]
@@ -32271,11 +32611,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_154",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_161",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_153",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_160",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -32291,7 +32631,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_153",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_160",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32355,11 +32695,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_156",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_163",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_154",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_161",
                                 "data source feature": "rq"
                             }
                         ]
@@ -32375,7 +32715,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_157",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_164",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32403,7 +32743,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_158",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_165",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32431,7 +32771,35 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_159",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_166",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_57",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_58",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_59",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 32.862,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_167",
                     "data source aggregate document": {
                         "data source document": [
                             {

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example08.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example08.json
@@ -30854,7 +30854,7 @@
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.20"
         },
         "calculated data aggregate document": {
             "calculated data document": [
@@ -31044,6 +31044,70 @@
                         "reference DNA description": "IPC",
                         "reference sample description": "1000"
                     },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 30.095,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_63",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_0",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_1",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_2",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_12",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_13",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_14",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_24",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_25",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_26",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_36",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_37",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_38",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
                     "calculated data name": "ct sd",
                     "calculated datum": {
                         "value": 0.059,
@@ -31051,11 +31115,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_66",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31071,11 +31135,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_63",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -31091,7 +31155,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_63",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31155,11 +31219,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_66",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_67",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31175,7 +31239,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_67",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_68",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31203,7 +31267,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_68",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_69",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31231,7 +31295,35 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_69",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_70",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_48",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_49",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_50",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 32.705,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_71",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31259,7 +31351,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_70",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_72",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31323,7 +31415,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_71",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_73",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31387,7 +31479,71 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_72",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_74",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_3",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_4",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_5",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_15",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_16",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_17",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_27",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_28",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_29",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_39",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_40",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_41",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 29.094,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_75",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31451,11 +31607,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_75",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_78",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_74",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_77",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31471,11 +31627,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_74",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_77",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_73",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_76",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -31491,7 +31647,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_73",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_76",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31555,11 +31711,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_76",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_79",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_74",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_77",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31575,7 +31731,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_77",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_80",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31603,7 +31759,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_78",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_81",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31631,7 +31787,35 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_79",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_82",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_51",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_52",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_53",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 32.861,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_83",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31659,7 +31843,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_80",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_84",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31723,7 +31907,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_81",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_85",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31787,7 +31971,71 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_82",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_86",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_6",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_7",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_8",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_18",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_19",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_20",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_30",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_31",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_32",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_42",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_43",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_44",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 27.502,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_87",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31851,11 +32099,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_85",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_90",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_84",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_89",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31871,11 +32119,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_84",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_89",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_83",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_88",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -31891,7 +32139,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_83",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_88",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31955,11 +32203,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_86",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_91",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_84",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_89",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31975,7 +32223,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_87",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_92",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32003,7 +32251,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_88",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_93",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32031,7 +32279,35 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_89",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_54",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_55",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_56",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 33.02,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_95",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32059,7 +32335,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_90",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_96",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32123,7 +32399,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_91",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_97",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32187,7 +32463,71 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_92",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_98",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_9",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_10",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_11",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_21",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_22",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_23",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_33",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_34",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_35",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_45",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_46",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_47",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 29.8,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_99",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32251,11 +32591,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_95",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_102",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_101",
                                 "data source feature": "rq"
                             }
                         ]
@@ -32271,11 +32611,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_101",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_93",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_100",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -32291,7 +32631,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_93",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_100",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32355,11 +32695,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_96",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_103",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_101",
                                 "data source feature": "rq"
                             }
                         ]
@@ -32375,7 +32715,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_97",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_104",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32403,7 +32743,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_98",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_105",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32431,7 +32771,35 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_99",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_106",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_57",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_58",
+                                "data source feature": "cycle threshold result"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_59",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "ct mean",
+                    "calculated datum": {
+                        "value": 32.862,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_107",
                     "data source aggregate document": {
                         "data source document": [
                             {


### PR DESCRIPTION
- Add missing ct mean calculated data documents to relative std curve experiments in AppBio Quantstudio