### PR TITLE
Add .idea/copilot/chatSessions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,7 @@ cython_debug/
 # *.ipr
 
 # Plugin files
+.idea/copilot/chatSessions/**
 .idea/csv-editor.xml
 
 # CMake


### PR DESCRIPTION
Ignore so PyCharm users don't accidentally commit.

Chat sessions started persisting as of the version released 2024-03-04:
https://plugins.jetbrains.com/plugin/17718-github-copilot/versions/stable/498299