### PR TITLE
fix luminex xponent asm structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Re-added encoding inference to Beckman VI Cell Blu adapter
 - Corrected concentration unit in Lunatic to conform to unit as reported within the source file
+- Corrected Luminex xPonent adapter to output one multi analyte profiling document per well.
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
+++ b/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
@@ -94,10 +94,10 @@ class LuminexXponentParser(VendorParser):
                                     header,
                                     data.minimum_bead_count_setting,
                                 )
-                                for measurement in data.measurement_list.measurements
                             ],
                         ),
                     )
+                    for measurement in data.measurement_list.measurements
                 ],
             ),
         )

--- a/tests/parsers/luminex_xponent/luminex_xponent_parser_test.py
+++ b/tests/parsers/luminex_xponent/luminex_xponent_parser_test.py
@@ -17,7 +17,4 @@ def test_parse_luminex_xponent_to_asm(output_file: str) -> None:
     test_filepath = f"tests/parsers/luminex_xponent/testdata/{output_file}.csv"
     expected_filepath = f"tests/parsers/luminex_xponent/testdata/{output_file}.json"
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
-    validate_contents(
-        allotrope_dict,
-        expected_filepath,
-    )
+    validate_contents(allotrope_dict, expected_filepath)

--- a/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example02.json
+++ b/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example02.json
@@ -372,7 +372,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_22",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -702,7 +717,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_44",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -1032,7 +1062,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_66",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -1362,7 +1407,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_88",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -1692,7 +1752,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_110",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -2022,7 +2097,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_132",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -2352,7 +2442,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_154",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -2682,7 +2787,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_176",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -3012,7 +3132,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_198",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -3342,7 +3477,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_220",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -3672,7 +3822,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_242",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -4002,7 +4167,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_264",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -4332,7 +4512,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_286",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -4662,7 +4857,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_308",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -4992,7 +5202,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_330",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -5322,7 +5547,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_352",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -5652,7 +5892,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_374",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -5982,7 +6237,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_396",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -6312,7 +6582,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_418",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -6642,7 +6927,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_440",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -6972,7 +7272,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_462",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -7302,7 +7617,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_484",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -7632,7 +7962,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_506",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -7962,7 +8307,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_528",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -8292,7 +8652,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_550",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -8622,7 +8997,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_572",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -8952,7 +9342,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_594",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -9282,7 +9687,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_616",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -9612,7 +10032,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_638",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -9942,7 +10377,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_660",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -10272,7 +10722,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_682",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -10602,7 +11067,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_704",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -10932,7 +11412,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_726",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -11262,7 +11757,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_748",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -11592,7 +12102,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_770",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -11922,7 +12447,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_792",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -12252,7 +12792,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_814",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -12592,7 +13147,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_836",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -12922,7 +13492,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_858",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -13252,7 +13837,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_880",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -13582,7 +14182,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_902",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -13912,7 +14527,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_924",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -14252,7 +14882,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_946",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -14582,7 +15227,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_968",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -14912,7 +15572,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_990",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -15242,7 +15917,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1012",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -15572,7 +16262,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1034",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -15902,7 +16607,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1056",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -16232,7 +16952,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1078",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -16562,7 +17297,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1100",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -16892,7 +17642,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1122",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -17222,7 +17987,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1144",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -17552,7 +18332,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1166",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -17882,7 +18677,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1188",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -18212,7 +19022,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1210",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -18542,7 +19367,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1232",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -18872,7 +19712,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1254",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -19202,7 +20057,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1276",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -19532,7 +20402,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1298",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -19862,7 +20747,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1320",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -20192,7 +21092,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1342",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -20522,7 +21437,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1364",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -20852,7 +21782,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1386",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -21182,7 +22127,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1408",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -21512,7 +22472,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1430",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -21842,7 +22817,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1452",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -22172,7 +23162,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1474",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -22502,7 +23507,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1496",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -22832,7 +23852,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1518",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -23162,7 +24197,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1540",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -23492,7 +24542,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1562",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -23822,7 +24887,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1584",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -24162,7 +25242,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1606",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -24492,7 +25587,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1628",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -24832,7 +25942,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1650",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -25162,7 +26287,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1672",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -25492,7 +26632,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1694",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -25822,7 +26977,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1716",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -26152,7 +27322,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1738",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -26482,7 +27667,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1760",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -26812,7 +28012,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1782",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -27142,7 +28357,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1804",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -27472,7 +28702,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1826",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -27802,7 +29047,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1848",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -28132,7 +29392,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1870",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -28462,7 +29737,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1892",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -28792,7 +30082,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1914",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -29122,7 +30427,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1936",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -29452,7 +30772,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1958",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -29792,7 +31127,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1980",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -30132,7 +31482,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_2002",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -30462,7 +31827,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_2024",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -30792,7 +32172,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_2046",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -31122,7 +32517,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_2068",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -31452,7 +32862,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "V116_pnUAD",
+                    "method version": "3",
+                    "experimental data identifier": "PCD00360_184221_20230517",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "nguymaip"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_2090",
                             "measurement time": "2023-05-17T18:42:29+00:00",
@@ -31802,7 +33227,7 @@
             "software name": "xPONENT",
             "software version": "4.3.229.0",
             "ASM converter name": "allotropy",
-            "ASM converter version": "0.1.24"
+            "ASM converter version": "0.1.27"
         }
     }
 }

--- a/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example03.json
+++ b/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example03.json
@@ -372,7 +372,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_22",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -702,7 +717,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_44",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -1032,7 +1062,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_66",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -1362,7 +1407,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_88",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -1692,7 +1752,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_110",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -2022,7 +2097,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_132",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -2352,7 +2442,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_154",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -2682,7 +2787,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_176",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -3012,7 +3132,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_198",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -3342,7 +3477,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_220",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -3672,7 +3822,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_242",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -4002,7 +4167,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_264",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -4332,7 +4512,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_286",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -4662,7 +4857,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_308",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -4992,7 +5202,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_330",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -5322,7 +5547,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_352",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -5652,7 +5892,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_374",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -5982,7 +6237,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_396",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -6312,7 +6582,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_418",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -6642,7 +6927,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_440",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -6972,7 +7272,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_462",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -7302,7 +7617,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_484",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -7632,7 +7962,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_506",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -7962,7 +8307,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_528",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -8292,7 +8652,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_550",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -8622,7 +8997,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_572",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -8952,7 +9342,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_594",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -9282,7 +9687,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_616",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -9612,7 +10032,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_638",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -9942,7 +10377,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_660",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -10272,7 +10722,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_682",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -10602,7 +11067,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_704",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -10932,7 +11412,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_726",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -11262,7 +11757,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_748",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -11592,7 +12102,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_770",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -11922,7 +12447,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_792",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -12252,7 +12792,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_814",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -12582,7 +13137,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_836",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -12922,7 +13492,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_858",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -13252,7 +13837,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_880",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -13582,7 +14182,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_902",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -13912,7 +14527,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_924",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -14252,7 +14882,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_946",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -14582,7 +15227,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_968",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -14912,7 +15572,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_990",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -15242,7 +15917,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1012",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -15582,7 +16272,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1034",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -15912,7 +16617,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1056",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -16252,7 +16972,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1078",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -16582,7 +17317,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1100",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -16922,7 +17672,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1122",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -17252,7 +18017,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1144",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -17592,7 +18372,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1166",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -17932,7 +18727,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1188",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -18272,7 +19082,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1210",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -18612,7 +19437,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1232",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -18942,7 +19782,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1254",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -19272,7 +20127,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1276",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -19602,7 +20472,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1298",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -19932,7 +20817,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1320",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -20262,7 +21162,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1342",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -20602,7 +21517,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1364",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -20942,7 +21872,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1386",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -21282,7 +22227,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1408",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -21612,7 +22572,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1430",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -21942,7 +22917,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1452",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -22282,7 +23272,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1474",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -22612,7 +23617,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1496",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -22942,7 +23962,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1518",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -23272,7 +24307,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1540",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -23612,7 +24662,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1562",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -23952,7 +25017,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1584",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -24282,7 +25362,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1606",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -24612,7 +25707,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1628",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -24952,7 +26062,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1650",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -25282,7 +26407,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1672",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -25612,7 +26752,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1694",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -25942,7 +27097,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1716",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -26282,7 +27452,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1738",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -26612,7 +27797,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1760",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -26952,7 +28152,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1782",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -27282,7 +28497,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1804",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -27622,7 +28852,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1826",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -27952,7 +29197,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1848",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -28292,7 +29552,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1870",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -28632,7 +29907,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1892",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -28972,7 +30262,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1914",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -29302,7 +30607,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1936",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -29632,7 +30952,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1958",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -29962,7 +31297,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_1980",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -30292,7 +31642,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_2002",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -30632,7 +31997,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_2024",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -30962,7 +32342,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_2046",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -31292,7 +32687,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_2068",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -31632,7 +33042,22 @@
                                     }
                                 ]
                             }
-                        },
+                        }
+                    ],
+                    "analytical method identifier": "foo_bar",
+                    "method version": "3",
+                    "experimental data identifier": "ABCD_123456_20230518",
+                    "container type": "well plate",
+                    "plate well count": {
+                        "value": 96.0,
+                        "unit": "#"
+                    }
+                },
+                "analyst": "waldo"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
                         {
                             "measurement identifier": "LUMINEX_XPONENT_TEST_ID_2090",
                             "measurement time": "2023-05-18T11:03:56+00:00",
@@ -31992,7 +33417,7 @@
             "software name": "xPONENT",
             "software version": "4.3.229.0",
             "ASM converter name": "allotropy",
-            "ASM converter version": "0.1.24"
+            "ASM converter version": "0.1.27"
         }
     }
 }


### PR DESCRIPTION
The xPONENT adapter should return one `multi analyte profiling document` per well, but instead it was returning one `measurement document` per well. This PR fixes the issue.