### PR TITLE
fix: Remove assert in validate_contents

### DIFF
--- a/src/allotropy/testing/utils.py
+++ b/src/allotropy/testing/utils.py
@@ -111,6 +111,3 @@ def validate_contents(
         if write_actual_to_expected_on_fail:
             _write_actual_to_expected(allotrope_dict, expected_file)
         raise
-
-    # Ensure that tests fail if the param is set to True. We never want to commit with a True value.
-    assert not write_actual_to_expected_on_fail  # noqa: S101


### PR DESCRIPTION
This check was added to ensure that someone does not accidentally commit a test with `write_actual_to_expected_on_fail`.

While that makes sense, it makes this function very frustrating/confusing to use in the middle of a unit test, as you have to set/unset the value and can't share the flag's use in other functions.