### PR TITLE
remove inner calculated data documents from AppBio Quantstudio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove duplicated quantity mean calculated data documents from AppBio Quantstudio adapter
 
 ### Changed
+- Remove inner calculated data documents from AppBio Quantstudio
 
 ### Deprecated
 

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_calculated_documents.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_calculated_documents.py
@@ -25,14 +25,10 @@ def build_quantity(well_item: WellItem) -> Optional[CalculatedDocument]:
     if (quantity := well_item.result.quantity) is None:
         return None
 
-    # quantity calc docs should not be included in calculated aggregate document
-    # so they are marked as already iterated on creation
-
     return CalculatedDocument(
         uuid=random_uuid_str(),
         name="quantity",
         value=quantity,
-        iterated=True,
         data_sources=[
             DataSource(feature="cycle threshold result", reference=well_item),
         ],

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_data_creator.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_data_creator.py
@@ -1,5 +1,4 @@
 from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_calculated_documents import (
-    build_quantity,
     iter_calculated_data_documents,
 )
 from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_structure import (
@@ -49,10 +48,6 @@ def create_data(reader: LinesReader) -> Data:
                 well_item,
                 header.experiment_type,
             )
-
-        for well_item in well.items.values():
-            if quantity := build_quantity(well_item):
-                well.add_calculated_document(quantity)
 
     endogenous_control = (
         try_str_from_series_or_none(results_metadata, "Endogenous Control") or ""

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
@@ -95,9 +95,6 @@ class AppBioQuantStudioParser(VendorParser):
                                 for well_item in well.items.values()
                             ],
                         ),
-                        calculated_data_aggregate_document=self.get_inner_calculated_data_aggregate_document(
-                            well
-                        ),
                     )
                     for well in data.wells
                 ],
@@ -105,35 +102,6 @@ class AppBioQuantStudioParser(VendorParser):
                     data
                 ),
             )
-        )
-
-    def get_inner_calculated_data_aggregate_document(
-        self, well: Well
-    ) -> Optional[TCalculatedDataAggregateDocument]:
-        if not well.calculated_documents:
-            return None
-
-        return TCalculatedDataAggregateDocument(
-            calculated_data_document=[
-                CalculatedDataDocumentItem(
-                    calculated_data_identifier=calculated_document.uuid,
-                    data_source_aggregate_document=DataSourceAggregateDocument(
-                        data_source_document=[
-                            DataSourceDocumentItem(
-                                data_source_identifier=data_source.reference.uuid,
-                                data_source_feature=data_source.feature,
-                            )
-                            for data_source in calculated_document.data_sources
-                        ],
-                    ),
-                    calculated_data_name=calculated_document.name,
-                    calculated_data_description=None,
-                    calculated_datum=TQuantityValueUnitless(
-                        value=calculated_document.value
-                    ),
-                )
-                for calculated_document in well.calculated_documents
-            ],
         )
 
     def get_outer_calculated_data_aggregate_document(

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_structure.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_structure.py
@@ -253,7 +253,6 @@ class Well:
     items: dict[str, WellItem]
     _multicomponent_data: Optional[MulticomponentData] = None
     _melt_curve_raw_data: Optional[MeltCurveRawData] = None
-    _calculated_documents: Optional[list[CalculatedDocument]] = None
 
     def get_well_item(self, target: str) -> WellItem:
         well_item = self.items.get(target)
@@ -277,15 +276,6 @@ class Well:
     @melt_curve_raw_data.setter
     def melt_curve_raw_data(self, melt_curve_raw_data: MeltCurveRawData) -> None:
         self._melt_curve_raw_data = melt_curve_raw_data
-
-    @property
-    def calculated_documents(self) -> list[CalculatedDocument]:
-        return self._calculated_documents if self._calculated_documents else []
-
-    def add_calculated_document(self, calculated_document: CalculatedDocument) -> None:
-        if not self._calculated_documents:
-            self._calculated_documents = []
-        self._calculated_documents.append(calculated_document)
 
     @staticmethod
     def create_genotyping(identifier: int, well_data: pd.Series[str]) -> Well:

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_data.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_data.py
@@ -1365,7 +1365,7 @@ def get_rel_std_curve_data() -> Data:
                     identifier=37,
                     items={
                         "RNaseP": WellItem(
-                            uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
+                            uuid="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
                             identifier=37,
                             target_dna_description="RNaseP",
                             sample_identifier="800",
@@ -1411,69 +1411,12 @@ def get_rel_std_curve_data() -> Data:
                     },
                     _multicomponent_data=None,
                     _melt_curve_raw_data=None,
-                    _calculated_documents=[
-                        CalculatedDocument(
-                            uuid="91feb1d5-89e6-442e-a11c-d4b4f2821537",
-                            name="quantity",
-                            value=794.91,
-                            data_sources=[
-                                DataSource(
-                                    feature="cycle threshold result",
-                                    reference=WellItem(
-                                        uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
-                                        identifier=37,
-                                        target_dna_description="RNaseP",
-                                        sample_identifier="800",
-                                        reporter_dye_setting="FAM",
-                                        position="D1",
-                                        well_location_identifier="D1",
-                                        quencher_dye_setting="NFQ-MGB",
-                                        sample_role_type="UNKNOWN",
-                                        _amplification_data=AmplificationData(
-                                            total_cycle_number_setting=1.0,
-                                            cycle=[1],
-                                            rn=[0.627],
-                                            delta_rn=[0.001],
-                                        ),
-                                        _result=Result(
-                                            cycle_threshold_value_setting=0.133,
-                                            cycle_threshold_result=30.155,
-                                            automatic_cycle_threshold_enabled_setting=True,
-                                            automatic_baseline_determination_enabled_setting=True,
-                                            normalized_reporter_result=None,
-                                            baseline_corrected_reporter_result=None,
-                                            genotyping_determination_result=None,
-                                            genotyping_determination_method_setting=None,
-                                            quantity=794.91,
-                                            quantity_mean=818.012,
-                                            quantity_sd=29.535,
-                                            ct_mean=30.115,
-                                            ct_sd=0.051,
-                                            delta_ct_mean=None,
-                                            delta_ct_se=None,
-                                            delta_delta_ct=None,
-                                            rq=0.798,
-                                            rq_min=0.658,
-                                            rq_max=0.967,
-                                            rn_mean=None,
-                                            rn_sd=None,
-                                            y_intercept=39.662,
-                                            r_squared=0.999,
-                                            slope=-3.278,
-                                            efficiency=101.866,
-                                        ),
-                                    ),
-                                )
-                            ],
-                            iterated=True,
-                        )
-                    ],
                 ),
                 Well(
                     identifier=38,
                     items={
                         "RNaseP": WellItem(
-                            uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
+                            uuid="f112727d-c267-4061-b51e-a0784a112afe",
                             identifier=38,
                             target_dna_description="RNaseP",
                             sample_identifier="800",
@@ -1519,63 +1462,6 @@ def get_rel_std_curve_data() -> Data:
                     },
                     _multicomponent_data=None,
                     _melt_curve_raw_data=None,
-                    _calculated_documents=[
-                        CalculatedDocument(
-                            uuid="8f82e615-af30-474c-9e27-a53bc146013c",
-                            name="quantity",
-                            value=769.776,
-                            data_sources=[
-                                DataSource(
-                                    feature="cycle threshold result",
-                                    reference=WellItem(
-                                        uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
-                                        identifier=38,
-                                        target_dna_description="RNaseP",
-                                        sample_identifier="800",
-                                        reporter_dye_setting="FAM",
-                                        position="D2",
-                                        well_location_identifier="D2",
-                                        quencher_dye_setting="NFQ-MGB",
-                                        sample_role_type="UNKNOWN",
-                                        _amplification_data=AmplificationData(
-                                            total_cycle_number_setting=1.0,
-                                            cycle=[1],
-                                            rn=[0.612],
-                                            delta_rn=[-0.001],
-                                        ),
-                                        _result=Result(
-                                            cycle_threshold_value_setting=0.133,
-                                            cycle_threshold_result=30.2,
-                                            automatic_cycle_threshold_enabled_setting=True,
-                                            automatic_baseline_determination_enabled_setting=True,
-                                            normalized_reporter_result=None,
-                                            baseline_corrected_reporter_result=None,
-                                            genotyping_determination_result=None,
-                                            genotyping_determination_method_setting=None,
-                                            quantity=769.776,
-                                            quantity_mean=818.012,
-                                            quantity_sd=29.535,
-                                            ct_mean=30.115,
-                                            ct_sd=0.051,
-                                            delta_ct_mean=None,
-                                            delta_ct_se=None,
-                                            delta_delta_ct=None,
-                                            rq=0.798,
-                                            rq_min=0.658,
-                                            rq_max=0.967,
-                                            rn_mean=None,
-                                            rn_sd=None,
-                                            y_intercept=39.662,
-                                            r_squared=0.999,
-                                            slope=-3.278,
-                                            efficiency=101.866,
-                                        ),
-                                    ),
-                                )
-                            ],
-                            iterated=True,
-                        )
-                    ],
                 ),
             ]
         ),
@@ -1584,21 +1470,21 @@ def get_rel_std_curve_data() -> Data:
         reference_sample="800",
         calculated_documents=[
             CalculatedDocument(
-                uuid="70047607-9164-4e29-a1ea-296e36df4f20",
+                uuid="5c16ac3d-02de-4d5b-b42e-707fb2043d95",
                 name="quantity mean",
                 value=818.012,
                 data_sources=[
                     DataSource(
                         feature="quantity",
                         reference=CalculatedDocument(
-                            uuid="91feb1d5-89e6-442e-a11c-d4b4f2821537",
+                            uuid="61d96780-4aa9-4d24-8ff5-491ccd325502",
                             name="quantity",
                             value=794.91,
                             data_sources=[
                                 DataSource(
                                     feature="cycle threshold result",
                                     reference=WellItem(
-                                        uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
+                                        uuid="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
                                         identifier=37,
                                         target_dna_description="RNaseP",
                                         sample_identifier="800",
@@ -1649,14 +1535,14 @@ def get_rel_std_curve_data() -> Data:
                     DataSource(
                         feature="quantity",
                         reference=CalculatedDocument(
-                            uuid="8f82e615-af30-474c-9e27-a53bc146013c",
+                            uuid="c9f7ba93-faff-465c-b1b6-baa049cab34f",
                             name="quantity",
                             value=769.776,
                             data_sources=[
                                 DataSource(
                                     feature="cycle threshold result",
                                     reference=WellItem(
-                                        uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
+                                        uuid="f112727d-c267-4061-b51e-a0784a112afe",
                                         identifier=38,
                                         target_dna_description="RNaseP",
                                         sample_identifier="800",
@@ -1708,21 +1594,131 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
-                uuid="6df2e5ab-b601-4d4a-81a0-a439fd923e6d",
+                uuid="61d96780-4aa9-4d24-8ff5-491ccd325502",
+                name="quantity",
+                value=794.91,
+                data_sources=[
+                    DataSource(
+                        feature="cycle threshold result",
+                        reference=WellItem(
+                            uuid="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
+                            identifier=37,
+                            target_dna_description="RNaseP",
+                            sample_identifier="800",
+                            reporter_dye_setting="FAM",
+                            position="D1",
+                            well_location_identifier="D1",
+                            quencher_dye_setting="NFQ-MGB",
+                            sample_role_type="UNKNOWN",
+                            _amplification_data=AmplificationData(
+                                total_cycle_number_setting=1.0,
+                                cycle=[1],
+                                rn=[0.627],
+                                delta_rn=[0.001],
+                            ),
+                            _result=Result(
+                                cycle_threshold_value_setting=0.133,
+                                cycle_threshold_result=30.155,
+                                automatic_cycle_threshold_enabled_setting=True,
+                                automatic_baseline_determination_enabled_setting=True,
+                                normalized_reporter_result=None,
+                                baseline_corrected_reporter_result=None,
+                                genotyping_determination_result=None,
+                                genotyping_determination_method_setting=None,
+                                quantity=794.91,
+                                quantity_mean=818.012,
+                                quantity_sd=29.535,
+                                ct_mean=30.115,
+                                ct_sd=0.051,
+                                delta_ct_mean=None,
+                                delta_ct_se=None,
+                                delta_delta_ct=None,
+                                rq=0.798,
+                                rq_min=0.658,
+                                rq_max=0.967,
+                                rn_mean=None,
+                                rn_sd=None,
+                                y_intercept=39.662,
+                                r_squared=0.999,
+                                slope=-3.278,
+                                efficiency=101.866,
+                            ),
+                        ),
+                    )
+                ],
+                iterated=True,
+            ),
+            CalculatedDocument(
+                uuid="c9f7ba93-faff-465c-b1b6-baa049cab34f",
+                name="quantity",
+                value=769.776,
+                data_sources=[
+                    DataSource(
+                        feature="cycle threshold result",
+                        reference=WellItem(
+                            uuid="f112727d-c267-4061-b51e-a0784a112afe",
+                            identifier=38,
+                            target_dna_description="RNaseP",
+                            sample_identifier="800",
+                            reporter_dye_setting="FAM",
+                            position="D2",
+                            well_location_identifier="D2",
+                            quencher_dye_setting="NFQ-MGB",
+                            sample_role_type="UNKNOWN",
+                            _amplification_data=AmplificationData(
+                                total_cycle_number_setting=1.0,
+                                cycle=[1],
+                                rn=[0.612],
+                                delta_rn=[-0.001],
+                            ),
+                            _result=Result(
+                                cycle_threshold_value_setting=0.133,
+                                cycle_threshold_result=30.2,
+                                automatic_cycle_threshold_enabled_setting=True,
+                                automatic_baseline_determination_enabled_setting=True,
+                                normalized_reporter_result=None,
+                                baseline_corrected_reporter_result=None,
+                                genotyping_determination_result=None,
+                                genotyping_determination_method_setting=None,
+                                quantity=769.776,
+                                quantity_mean=818.012,
+                                quantity_sd=29.535,
+                                ct_mean=30.115,
+                                ct_sd=0.051,
+                                delta_ct_mean=None,
+                                delta_ct_se=None,
+                                delta_delta_ct=None,
+                                rq=0.798,
+                                rq_min=0.658,
+                                rq_max=0.967,
+                                rn_mean=None,
+                                rn_sd=None,
+                                y_intercept=39.662,
+                                r_squared=0.999,
+                                slope=-3.278,
+                                efficiency=101.866,
+                            ),
+                        ),
+                    )
+                ],
+                iterated=True,
+            ),
+            CalculatedDocument(
+                uuid="4da4ba6b-cb9d-471b-b810-fdc46f57528e",
                 name="quantity sd",
                 value=29.535,
                 data_sources=[
                     DataSource(
                         feature="quantity",
                         reference=CalculatedDocument(
-                            uuid="91feb1d5-89e6-442e-a11c-d4b4f2821537",
+                            uuid="61d96780-4aa9-4d24-8ff5-491ccd325502",
                             name="quantity",
                             value=794.91,
                             data_sources=[
                                 DataSource(
                                     feature="cycle threshold result",
                                     reference=WellItem(
-                                        uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
+                                        uuid="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
                                         identifier=37,
                                         target_dna_description="RNaseP",
                                         sample_identifier="800",
@@ -1773,14 +1769,14 @@ def get_rel_std_curve_data() -> Data:
                     DataSource(
                         feature="quantity",
                         reference=CalculatedDocument(
-                            uuid="8f82e615-af30-474c-9e27-a53bc146013c",
+                            uuid="c9f7ba93-faff-465c-b1b6-baa049cab34f",
                             name="quantity",
                             value=769.776,
                             data_sources=[
                                 DataSource(
                                     feature="cycle threshold result",
                                     reference=WellItem(
-                                        uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
+                                        uuid="f112727d-c267-4061-b51e-a0784a112afe",
                                         identifier=38,
                                         target_dna_description="RNaseP",
                                         sample_identifier="800",
@@ -1832,14 +1828,14 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
-                uuid="4ab1f957-95f5-45c5-a5a2-fd6f44a37136",
+                uuid="a59289c2-e71a-4d72-972d-258e3ac2e78e",
                 name="ct mean",
                 value=30.115,
                 data_sources=[
                     DataSource(
                         feature="cycle threshold result",
                         reference=WellItem(
-                            uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
+                            uuid="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
                             identifier=37,
                             target_dna_description="RNaseP",
                             sample_identifier="800",
@@ -1886,7 +1882,7 @@ def get_rel_std_curve_data() -> Data:
                     DataSource(
                         feature="cycle threshold result",
                         reference=WellItem(
-                            uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
+                            uuid="f112727d-c267-4061-b51e-a0784a112afe",
                             identifier=38,
                             target_dna_description="RNaseP",
                             sample_identifier="800",
@@ -1934,14 +1930,14 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
-                uuid="11bacdaa-3ee7-49d1-8882-ce67ea01a3aa",
+                uuid="99f04b2e-4463-4666-b20d-d8f1de2f62e5",
                 name="ct sd",
                 value=0.051,
                 data_sources=[
                     DataSource(
                         feature="cycle threshold result",
                         reference=WellItem(
-                            uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
+                            uuid="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
                             identifier=37,
                             target_dna_description="RNaseP",
                             sample_identifier="800",
@@ -1988,7 +1984,7 @@ def get_rel_std_curve_data() -> Data:
                     DataSource(
                         feature="cycle threshold result",
                         reference=WellItem(
-                            uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
+                            uuid="f112727d-c267-4061-b51e-a0784a112afe",
                             identifier=38,
                             target_dna_description="RNaseP",
                             sample_identifier="800",
@@ -2036,35 +2032,35 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
-                uuid="ceeae020-7f7a-43ee-975b-08044ef67826",
+                uuid="095631c4-1c21-412d-acc1-3a67984dbbf2",
                 name="rq min",
                 value=0.658,
                 data_sources=[
                     DataSource(
                         feature="rq",
                         reference=CalculatedDocument(
-                            uuid="bfe26da2-72cb-411b-8abb-44e5d2f19d8c",
+                            uuid="d0dc238e-13a6-4057-b1ae-c8d30145805b",
                             name="rq",
                             value=0.798,
                             data_sources=[
                                 DataSource(
                                     feature="quantity mean",
                                     reference=CalculatedDocument(
-                                        uuid="70047607-9164-4e29-a1ea-296e36df4f20",
+                                        uuid="5c16ac3d-02de-4d5b-b42e-707fb2043d95",
                                         name="quantity mean",
                                         value=818.012,
                                         data_sources=[
                                             DataSource(
                                                 feature="quantity",
                                                 reference=CalculatedDocument(
-                                                    uuid="91feb1d5-89e6-442e-a11c-d4b4f2821537",
+                                                    uuid="61d96780-4aa9-4d24-8ff5-491ccd325502",
                                                     name="quantity",
                                                     value=794.91,
                                                     data_sources=[
                                                         DataSource(
                                                             feature="cycle threshold result",
                                                             reference=WellItem(
-                                                                uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
+                                                                uuid="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
                                                                 identifier=37,
                                                                 target_dna_description="RNaseP",
                                                                 sample_identifier="800",
@@ -2115,14 +2111,14 @@ def get_rel_std_curve_data() -> Data:
                                             DataSource(
                                                 feature="quantity",
                                                 reference=CalculatedDocument(
-                                                    uuid="8f82e615-af30-474c-9e27-a53bc146013c",
+                                                    uuid="c9f7ba93-faff-465c-b1b6-baa049cab34f",
                                                     name="quantity",
                                                     value=769.776,
                                                     data_sources=[
                                                         DataSource(
                                                             feature="cycle threshold result",
                                                             reference=WellItem(
-                                                                uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
+                                                                uuid="f112727d-c267-4061-b51e-a0784a112afe",
                                                                 identifier=38,
                                                                 target_dna_description="RNaseP",
                                                                 sample_identifier="800",
@@ -2182,28 +2178,28 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
-                uuid="bfe26da2-72cb-411b-8abb-44e5d2f19d8c",
+                uuid="d0dc238e-13a6-4057-b1ae-c8d30145805b",
                 name="rq",
                 value=0.798,
                 data_sources=[
                     DataSource(
                         feature="quantity mean",
                         reference=CalculatedDocument(
-                            uuid="70047607-9164-4e29-a1ea-296e36df4f20",
+                            uuid="5c16ac3d-02de-4d5b-b42e-707fb2043d95",
                             name="quantity mean",
                             value=818.012,
                             data_sources=[
                                 DataSource(
                                     feature="quantity",
                                     reference=CalculatedDocument(
-                                        uuid="91feb1d5-89e6-442e-a11c-d4b4f2821537",
+                                        uuid="61d96780-4aa9-4d24-8ff5-491ccd325502",
                                         name="quantity",
                                         value=794.91,
                                         data_sources=[
                                             DataSource(
                                                 feature="cycle threshold result",
                                                 reference=WellItem(
-                                                    uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
+                                                    uuid="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
                                                     identifier=37,
                                                     target_dna_description="RNaseP",
                                                     sample_identifier="800",
@@ -2254,14 +2250,14 @@ def get_rel_std_curve_data() -> Data:
                                 DataSource(
                                     feature="quantity",
                                     reference=CalculatedDocument(
-                                        uuid="8f82e615-af30-474c-9e27-a53bc146013c",
+                                        uuid="c9f7ba93-faff-465c-b1b6-baa049cab34f",
                                         name="quantity",
                                         value=769.776,
                                         data_sources=[
                                             DataSource(
                                                 feature="cycle threshold result",
                                                 reference=WellItem(
-                                                    uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
+                                                    uuid="f112727d-c267-4061-b51e-a0784a112afe",
                                                     identifier=38,
                                                     target_dna_description="RNaseP",
                                                     sample_identifier="800",
@@ -2317,35 +2313,35 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
-                uuid="84342a87-b7b4-4966-8066-663ab490adbb",
+                uuid="4db4a552-e3c5-49fc-ab02-759245c01a48",
                 name="rq max",
                 value=0.967,
                 data_sources=[
                     DataSource(
                         feature="rq",
                         reference=CalculatedDocument(
-                            uuid="bfe26da2-72cb-411b-8abb-44e5d2f19d8c",
+                            uuid="d0dc238e-13a6-4057-b1ae-c8d30145805b",
                             name="rq",
                             value=0.798,
                             data_sources=[
                                 DataSource(
                                     feature="quantity mean",
                                     reference=CalculatedDocument(
-                                        uuid="70047607-9164-4e29-a1ea-296e36df4f20",
+                                        uuid="5c16ac3d-02de-4d5b-b42e-707fb2043d95",
                                         name="quantity mean",
                                         value=818.012,
                                         data_sources=[
                                             DataSource(
                                                 feature="quantity",
                                                 reference=CalculatedDocument(
-                                                    uuid="91feb1d5-89e6-442e-a11c-d4b4f2821537",
+                                                    uuid="61d96780-4aa9-4d24-8ff5-491ccd325502",
                                                     name="quantity",
                                                     value=794.91,
                                                     data_sources=[
                                                         DataSource(
                                                             feature="cycle threshold result",
                                                             reference=WellItem(
-                                                                uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
+                                                                uuid="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
                                                                 identifier=37,
                                                                 target_dna_description="RNaseP",
                                                                 sample_identifier="800",
@@ -2396,14 +2392,14 @@ def get_rel_std_curve_data() -> Data:
                                             DataSource(
                                                 feature="quantity",
                                                 reference=CalculatedDocument(
-                                                    uuid="8f82e615-af30-474c-9e27-a53bc146013c",
+                                                    uuid="c9f7ba93-faff-465c-b1b6-baa049cab34f",
                                                     name="quantity",
                                                     value=769.776,
                                                     data_sources=[
                                                         DataSource(
                                                             feature="cycle threshold result",
                                                             reference=WellItem(
-                                                                uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
+                                                                uuid="f112727d-c267-4061-b51e-a0784a112afe",
                                                                 identifier=38,
                                                                 target_dna_description="RNaseP",
                                                                 sample_identifier="800",
@@ -2490,7 +2486,7 @@ def get_rel_std_curve_model() -> Model:
                         ),
                         measurement_document=[
                             MeasurementDocumentItem(
-                                measurement_identifier="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
+                                measurement_identifier="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
                                 measurement_time="2010-10-20T02:23:34-04:00",
                                 target_DNA_description="RNaseP",
                                 sample_document=SampleDocument(
@@ -2625,30 +2621,7 @@ def get_rel_std_curve_model() -> Model:
                     ),
                     analyst=None,
                     submitter=None,
-                    calculated_data_aggregate_document=TCalculatedDataAggregateDocument(
-                        calculated_data_document=[
-                            CalculatedDataDocumentItem(
-                                calculated_data_identifier="91feb1d5-89e6-442e-a11c-d4b4f2821537",
-                                data_source_aggregate_document=DataSourceAggregateDocument(
-                                    data_source_document=[
-                                        DataSourceDocumentItem(
-                                            data_source_identifier="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
-                                            data_source_feature="cycle threshold result",
-                                        )
-                                    ]
-                                ),
-                                data_processing_document=None,
-                                calculated_data_name="quantity",
-                                calculated_data_description=None,
-                                calculated_datum=TQuantityValueUnitless(
-                                    value=794.91,
-                                    unit="(unitless)",
-                                    has_statistic_datum_role=None,
-                                    field_type=None,
-                                ),
-                            )
-                        ]
-                    ),
+                    calculated_data_aggregate_document=None,
                 ),
                 QPCRDocumentItem(
                     measurement_aggregate_document=MeasurementAggregateDocument(
@@ -2660,7 +2633,7 @@ def get_rel_std_curve_model() -> Model:
                         ),
                         measurement_document=[
                             MeasurementDocumentItem(
-                                measurement_identifier="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
+                                measurement_identifier="f112727d-c267-4061-b51e-a0784a112afe",
                                 measurement_time="2010-10-20T02:23:34-04:00",
                                 target_DNA_description="RNaseP",
                                 sample_document=SampleDocument(
@@ -2795,30 +2768,7 @@ def get_rel_std_curve_model() -> Model:
                     ),
                     analyst=None,
                     submitter=None,
-                    calculated_data_aggregate_document=TCalculatedDataAggregateDocument(
-                        calculated_data_document=[
-                            CalculatedDataDocumentItem(
-                                calculated_data_identifier="8f82e615-af30-474c-9e27-a53bc146013c",
-                                data_source_aggregate_document=DataSourceAggregateDocument(
-                                    data_source_document=[
-                                        DataSourceDocumentItem(
-                                            data_source_identifier="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
-                                            data_source_feature="cycle threshold result",
-                                        )
-                                    ]
-                                ),
-                                data_processing_document=None,
-                                calculated_data_name="quantity",
-                                calculated_data_description=None,
-                                calculated_datum=TQuantityValueUnitless(
-                                    value=769.776,
-                                    unit="(unitless)",
-                                    has_statistic_datum_role=None,
-                                    field_type=None,
-                                ),
-                            )
-                        ]
-                    ),
+                    calculated_data_aggregate_document=None,
                 ),
             ],
             data_system_document=DataSystemDocument(
@@ -2833,15 +2783,15 @@ def get_rel_std_curve_model() -> Model:
             calculated_data_aggregate_document=TCalculatedDataAggregateDocument(
                 calculated_data_document=[
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="70047607-9164-4e29-a1ea-296e36df4f20",
+                        calculated_data_identifier="5c16ac3d-02de-4d5b-b42e-707fb2043d95",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="91feb1d5-89e6-442e-a11c-d4b4f2821537",
+                                    data_source_identifier="61d96780-4aa9-4d24-8ff5-491ccd325502",
                                     data_source_feature="quantity",
                                 ),
                                 DataSourceDocumentItem(
-                                    data_source_identifier="8f82e615-af30-474c-9e27-a53bc146013c",
+                                    data_source_identifier="c9f7ba93-faff-465c-b1b6-baa049cab34f",
                                     data_source_feature="quantity",
                                 ),
                             ]
@@ -2860,15 +2810,61 @@ def get_rel_std_curve_model() -> Model:
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="6df2e5ab-b601-4d4a-81a0-a439fd923e6d",
+                        calculated_data_identifier="61d96780-4aa9-4d24-8ff5-491ccd325502",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="91feb1d5-89e6-442e-a11c-d4b4f2821537",
+                                    data_source_identifier="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
+                                    data_source_feature="cycle threshold result",
+                                )
+                            ]
+                        ),
+                        data_processing_document=DataProcessingDocument1(
+                            reference_DNA_description="RNaseP",
+                            reference_sample_description="800",
+                        ),
+                        calculated_data_name="quantity",
+                        calculated_data_description=None,
+                        calculated_datum=TQuantityValueUnitless(
+                            value=794.91,
+                            unit="(unitless)",
+                            has_statistic_datum_role=None,
+                            field_type=None,
+                        ),
+                    ),
+                    CalculatedDataDocumentItem(
+                        calculated_data_identifier="c9f7ba93-faff-465c-b1b6-baa049cab34f",
+                        data_source_aggregate_document=DataSourceAggregateDocument(
+                            data_source_document=[
+                                DataSourceDocumentItem(
+                                    data_source_identifier="f112727d-c267-4061-b51e-a0784a112afe",
+                                    data_source_feature="cycle threshold result",
+                                )
+                            ]
+                        ),
+                        data_processing_document=DataProcessingDocument1(
+                            reference_DNA_description="RNaseP",
+                            reference_sample_description="800",
+                        ),
+                        calculated_data_name="quantity",
+                        calculated_data_description=None,
+                        calculated_datum=TQuantityValueUnitless(
+                            value=769.776,
+                            unit="(unitless)",
+                            has_statistic_datum_role=None,
+                            field_type=None,
+                        ),
+                    ),
+                    CalculatedDataDocumentItem(
+                        calculated_data_identifier="4da4ba6b-cb9d-471b-b810-fdc46f57528e",
+                        data_source_aggregate_document=DataSourceAggregateDocument(
+                            data_source_document=[
+                                DataSourceDocumentItem(
+                                    data_source_identifier="61d96780-4aa9-4d24-8ff5-491ccd325502",
                                     data_source_feature="quantity",
                                 ),
                                 DataSourceDocumentItem(
-                                    data_source_identifier="8f82e615-af30-474c-9e27-a53bc146013c",
+                                    data_source_identifier="c9f7ba93-faff-465c-b1b6-baa049cab34f",
                                     data_source_feature="quantity",
                                 ),
                             ]
@@ -2887,15 +2883,15 @@ def get_rel_std_curve_model() -> Model:
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="4ab1f957-95f5-45c5-a5a2-fd6f44a37136",
+                        calculated_data_identifier="a59289c2-e71a-4d72-972d-258e3ac2e78e",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
+                                    data_source_identifier="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
                                     data_source_feature="cycle threshold result",
                                 ),
                                 DataSourceDocumentItem(
-                                    data_source_identifier="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
+                                    data_source_identifier="f112727d-c267-4061-b51e-a0784a112afe",
                                     data_source_feature="cycle threshold result",
                                 ),
                             ]
@@ -2914,15 +2910,15 @@ def get_rel_std_curve_model() -> Model:
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="11bacdaa-3ee7-49d1-8882-ce67ea01a3aa",
+                        calculated_data_identifier="99f04b2e-4463-4666-b20d-d8f1de2f62e5",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
+                                    data_source_identifier="3387cf01-0e74-4636-8c1c-cfe840d7aff8",
                                     data_source_feature="cycle threshold result",
                                 ),
                                 DataSourceDocumentItem(
-                                    data_source_identifier="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
+                                    data_source_identifier="f112727d-c267-4061-b51e-a0784a112afe",
                                     data_source_feature="cycle threshold result",
                                 ),
                             ]
@@ -2941,11 +2937,11 @@ def get_rel_std_curve_model() -> Model:
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="ceeae020-7f7a-43ee-975b-08044ef67826",
+                        calculated_data_identifier="095631c4-1c21-412d-acc1-3a67984dbbf2",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="bfe26da2-72cb-411b-8abb-44e5d2f19d8c",
+                                    data_source_identifier="d0dc238e-13a6-4057-b1ae-c8d30145805b",
                                     data_source_feature="rq",
                                 )
                             ]
@@ -2964,11 +2960,11 @@ def get_rel_std_curve_model() -> Model:
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="bfe26da2-72cb-411b-8abb-44e5d2f19d8c",
+                        calculated_data_identifier="d0dc238e-13a6-4057-b1ae-c8d30145805b",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="70047607-9164-4e29-a1ea-296e36df4f20",
+                                    data_source_identifier="5c16ac3d-02de-4d5b-b42e-707fb2043d95",
                                     data_source_feature="quantity mean",
                                 )
                             ]
@@ -2987,11 +2983,11 @@ def get_rel_std_curve_model() -> Model:
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="84342a87-b7b4-4966-8066-663ab490adbb",
+                        calculated_data_identifier="4db4a552-e3c5-49fc-ab02-759245c01a48",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="bfe26da2-72cb-411b-8abb-44e5d2f19d8c",
+                                    data_source_identifier="d0dc238e-13a6-4057-b1ae-c8d30145805b",
                                     data_source_feature="rq",
                                 )
                             ]

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_structure_test.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_structure_test.py
@@ -33,9 +33,6 @@ from tests.parsers.appbio_quantstudio.appbio_quantstudio_data import (
 
 def rm_uuid(data: Data) -> Data:
     for well in data.wells:
-        for doc in well.calculated_documents:
-            rm_uuid_calc_doc(doc)
-
         for well_item in well.items.values():
             well_item.uuid = ""
 

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example04.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example04.json
@@ -279,26 +279,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_72",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_0",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5720.562,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -574,26 +554,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_73",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_1",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5605.765,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -869,26 +829,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_74",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_2",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5389.334,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -1164,26 +1104,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_75",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_3",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5159.019,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -1459,26 +1379,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_76",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_4",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5220.032,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -1754,26 +1654,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_77",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_5",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5376.875,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -2049,26 +1929,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_78",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_6",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5241.258,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -2344,26 +2204,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_79",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_7",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5136.925,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -2639,26 +2479,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_80",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_8",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5426.119,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -2934,26 +2754,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_81",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_9",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5095.661,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -3229,26 +3029,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_82",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_10",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5301.124,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -3524,26 +3304,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_83",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_11",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5351.417,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -3819,26 +3579,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_84",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_12",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5719.471,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -4114,26 +3854,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_85",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_13",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5353.252,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -4409,26 +4129,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_86",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_14",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5441.977,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -4704,26 +4404,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_87",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_15",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5402.7,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -4999,26 +4679,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_88",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_16",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5486.921,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -5294,26 +4954,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_89",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_17",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5202.281,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -5589,26 +5229,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_90",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_18",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5922.898,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -5884,26 +5504,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_91",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_19",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 4800.535,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -6179,26 +5779,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_92",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_20",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5197.387,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -6474,26 +6054,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_93",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_21",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5105.289,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -6769,26 +6329,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_22",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5156.682,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -7064,26 +6604,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_95",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_23",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5542.041,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -7359,26 +6879,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_96",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_24",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5312.311,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -7654,26 +7154,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_97",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_25",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5456.18,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -7949,26 +7429,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_98",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_26",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5360.045,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -8244,26 +7704,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_99",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_27",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5338.692,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -8539,26 +7979,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_100",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_28",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 4981.401,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -8834,26 +8254,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_101",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_29",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5206.95,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -9129,26 +8529,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_102",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_30",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5154.774,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -9424,26 +8804,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_103",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_31",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5181.402,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -9719,26 +9079,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_104",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_32",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 4883.166,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -10014,26 +9354,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_105",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_33",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5343.414,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -10309,26 +9629,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_106",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_34",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5502.799,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -10604,26 +9904,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_107",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_35",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5248.666,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -10899,26 +10179,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_108",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_36",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10413.57,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -11194,26 +10454,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_109",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_37",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10467.553,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -11489,26 +10729,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_110",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_38",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10329.035,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -11784,26 +11004,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_111",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_39",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 9830.831,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -12079,26 +11279,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_112",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_40",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10076.018,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -12374,26 +11554,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_113",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_41",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10449.429,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -12669,26 +11829,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_114",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_42",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 9880.754,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -12964,26 +12104,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_115",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_43",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 9834.214,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -13259,26 +12379,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_116",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_44",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10203.616,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -13554,26 +12654,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_117",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_45",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10953.017,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -13849,26 +12929,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_118",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_46",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10770.02,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -14144,26 +13204,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_119",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_47",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10143.039,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -14439,26 +13479,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_120",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_48",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 11244.815,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -14734,26 +13754,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_121",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_49",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10485.342,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -15029,26 +14029,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_122",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_50",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10620.054,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -15324,26 +14304,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_123",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_51",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10381.717,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -15619,26 +14579,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_52",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10538.396,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -15914,26 +14854,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_125",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_53",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10104.77,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -16209,26 +15129,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_126",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_54",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10126.725,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -16504,26 +15404,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_127",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_55",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10351.962,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -16799,26 +15679,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_128",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_56",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10863.552,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -17094,26 +15954,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_129",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_57",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10507.838,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -17389,26 +16229,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_130",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_58",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 11540.118,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -17684,26 +16504,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_131",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_59",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10891.368,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -17979,26 +16779,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_132",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_60",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 11109.704,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -18274,26 +17054,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_133",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_61",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 11127.255,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -18569,26 +17329,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_134",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_62",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10457.639,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -18864,26 +17604,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_135",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_63",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10283.093,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -19159,26 +17879,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_136",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10716.078,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -19454,26 +18154,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_137",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10184.203,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -19749,26 +18429,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_138",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_66",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10253.355,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -20044,26 +18704,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_139",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_67",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10346.373,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -20339,26 +18979,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_140",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_68",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10410.922,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -20634,26 +19254,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_141",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_69",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10571.266,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -20929,26 +19529,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_142",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_70",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10508.083,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -21224,26 +19804,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_71",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 10449.293,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             }
         ],
@@ -21254,12 +19814,12 @@
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.29"
         },
         "calculated data aggregate document": {
             "calculated data document": [
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_108",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -21415,7 +19975,583 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_145",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_72",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_0",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5720.562,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_73",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_1",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5605.765,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_74",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_2",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5389.334,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_75",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_3",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5159.019,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_76",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_4",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5220.032,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_77",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_5",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5376.875,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_78",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_6",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5241.258,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_79",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_7",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5136.925,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_80",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_8",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5426.119,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_81",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_9",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5095.661,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_82",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_10",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5301.124,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_83",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_11",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5351.417,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_84",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_12",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5719.471,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_85",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_13",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5353.252,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_86",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_14",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5441.977,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_87",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_15",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5402.7,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_88",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_16",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5486.921,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_89",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_17",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5202.281,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_90",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_18",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5922.898,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_91",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_19",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 4800.535,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_92",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_20",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5197.387,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_93",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_21",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5105.289,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_22",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5156.682,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_95",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_23",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5542.041,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_96",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_24",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5312.311,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_97",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_25",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5456.18,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_98",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_26",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5360.045,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_99",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_27",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5338.692,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_100",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_28",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 4981.401,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_101",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_29",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5206.95,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_102",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_30",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5154.774,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_103",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_31",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5181.402,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_104",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_32",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 4883.166,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_105",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_33",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5343.414,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_106",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_34",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5502.799,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_107",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_35",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5248.666,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_109",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -21571,7 +20707,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_110",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -21727,7 +20863,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_147",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_111",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -21887,22 +21023,6 @@
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_108",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_109",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_110",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_111",
-                                "data source feature": "quantity"
-                            },
-                            {
                                 "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_112",
                                 "data source feature": "quantity"
                             },
@@ -22028,6 +21148,22 @@
                             },
                             {
                                 "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_145",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_147",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -22039,25 +21175,585 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_112",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_108",
-                                "data source feature": "quantity"
-                            },
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_36",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10413.57,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_113",
+                    "data source aggregate document": {
+                        "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_109",
-                                "data source feature": "quantity"
-                            },
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_37",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10467.553,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_114",
+                    "data source aggregate document": {
+                        "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_110",
-                                "data source feature": "quantity"
-                            },
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_38",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10329.035,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_115",
+                    "data source aggregate document": {
+                        "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_111",
-                                "data source feature": "quantity"
-                            },
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_39",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 9830.831,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_116",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_40",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10076.018,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_117",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_41",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10449.429,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_118",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_42",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 9880.754,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_119",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_43",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 9834.214,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_120",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_44",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10203.616,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_121",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_45",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10953.017,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_122",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_46",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10770.02,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_123",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_47",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10143.039,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_48",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 11244.815,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_125",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_49",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10485.342,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_126",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_50",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10620.054,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_127",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_51",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10381.717,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_128",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_52",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10538.396,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_129",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_53",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10104.77,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_130",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_54",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10126.725,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_131",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_55",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10351.962,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_132",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_56",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10863.552,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_133",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_57",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10507.838,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_134",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_58",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 11540.118,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_135",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_59",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10891.368,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_136",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_60",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 11109.704,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_137",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_61",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 11127.255,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_138",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_62",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10457.639,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_139",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_63",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10283.093,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_140",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10716.078,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_141",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10184.203,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_142",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_66",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10253.355,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_67",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10346.373,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_68",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10410.922,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_145",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_69",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10571.266,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_70",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10508.083,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_147",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_71",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 10449.293,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
+                    "data source aggregate document": {
+                        "data source document": [
                             {
                                 "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_112",
                                 "data source feature": "quantity"
@@ -22184,6 +21880,22 @@
                             },
                             {
                                 "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_145",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_147",
                                 "data source feature": "quantity"
                             }
                         ]

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example07.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example07.json
@@ -498,26 +498,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_60",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_0",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 793.779,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -1012,26 +992,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_61",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_1",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 800.063,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -1526,26 +1486,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_62",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_2",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 759.282,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -2040,26 +1980,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_63",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_3",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1621.158,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -2554,26 +2474,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_4",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1588.345,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -3068,26 +2968,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_5",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1589.757,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -3582,26 +3462,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_66",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_6",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5154.896,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -4096,26 +3956,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_67",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_7",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5107.668,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -4610,26 +4450,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_68",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_8",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5109.615,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -5124,26 +4944,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_69",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_9",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1043.592,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -5638,26 +5438,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_70",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_10",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 924.858,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -6152,26 +5932,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_71",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_11",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1020.466,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -6666,26 +6426,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_72",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_12",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 825.079,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -7180,26 +6920,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_73",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_13",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 795.482,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -7694,26 +7414,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_74",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_14",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 795.632,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -8208,26 +7908,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_75",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_15",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1675.998,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -8722,26 +8402,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_76",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_16",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1660.096,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -9236,26 +8896,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_77",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_17",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1679.275,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -9750,26 +9390,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_78",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_18",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5133.758,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -10264,26 +9884,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_79",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_19",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5093.878,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -10778,26 +10378,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_80",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_20",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5030.613,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -11292,26 +10872,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_81",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_21",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 934.588,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -11806,26 +11366,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_82",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_22",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 985.324,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -12320,26 +11860,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_83",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_23",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1008.065,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -12834,26 +12354,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_84",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_24",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 841.041,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -13348,26 +12848,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_85",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_25",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 798.189,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -13862,26 +13342,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_86",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_26",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 790.272,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -14376,26 +13836,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_87",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_27",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1604.835,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -14890,26 +14330,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_88",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_28",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1688.032,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -15404,26 +14824,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_89",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_29",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1612.591,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -15918,26 +15318,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_90",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_30",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5014.847,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -16432,26 +15812,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_91",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_31",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5004.382,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -16946,26 +16306,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_92",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_32",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 4885.676,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -17460,26 +16800,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_93",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_33",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 968.798,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -17974,26 +17294,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_34",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 953.047,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -18488,26 +17788,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_95",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_35",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 994.151,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -19002,26 +18282,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_96",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_36",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 853.826,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -19516,26 +18776,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_97",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_37",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 822.239,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -20030,26 +19270,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_98",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_38",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 731.169,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -20544,26 +19764,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_99",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_39",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1633.148,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -21058,26 +20258,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_100",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_40",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1641.499,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -21572,26 +20752,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_101",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_41",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1577.354,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -22086,26 +21246,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_102",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_42",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 4947.226,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -22600,26 +21740,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_103",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_43",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 4986.594,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -23114,26 +22234,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_104",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_44",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5253.593,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -23628,26 +22728,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_105",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_45",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 972.242,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -24142,26 +23222,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_106",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_46",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1026.703,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -24656,26 +23716,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_107",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_47",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 1018.621,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -25170,26 +24210,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_108",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_48",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 506.711,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -25684,26 +24704,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_109",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_49",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 500.057,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -26198,26 +25198,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_110",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_50",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 458.853,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -26712,26 +25692,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_111",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_51",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 399.936,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -27226,26 +26186,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_112",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_52",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 460.243,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -27740,26 +26680,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_113",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_53",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 483.791,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -28254,26 +27174,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_114",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_54",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 357.569,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -28768,26 +27668,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_115",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_55",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 441.414,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -29282,26 +28162,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_116",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_56",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 429.043,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -29796,26 +28656,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_117",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_57",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 470.355,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -30310,26 +29150,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_118",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_58",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 400.862,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -30824,26 +29644,6 @@
                     "experimental data identifier": "QuantStudio96-Well Relative Standard Curve Example 2",
                     "experiment type": "relative standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_119",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_59",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 471.361,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             }
         ],
@@ -30859,7 +29659,7 @@
         "calculated data aggregate document": {
             "calculated data document": [
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_120",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_72",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -30875,39 +29675,39 @@
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_72",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_63",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_73",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_74",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_84",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_66",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_85",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_67",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_86",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_68",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_96",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_69",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_97",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_70",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_98",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_71",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -30923,7 +29723,247 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_121",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_60",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_0",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 793.779,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_61",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_1",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 800.063,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_62",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_2",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 759.282,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_63",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_12",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 825.079,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_13",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 795.482,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_14",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 795.632,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_66",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_24",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 841.041,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_67",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_25",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 798.189,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_68",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_26",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 790.272,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_69",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_36",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 853.826,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_70",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_37",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 822.239,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_71",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_38",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 731.169,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_73",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -30939,39 +29979,39 @@
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_72",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_63",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_73",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_74",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_84",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_66",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_85",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_67",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_86",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_68",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_96",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_69",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_97",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_70",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_98",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_71",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -30987,7 +30027,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_122",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_74",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31051,7 +30091,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_123",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_75",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31115,11 +30155,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_125",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_77",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_76",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31135,11 +30175,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_76",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_120",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_72",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -31155,11 +30195,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_126",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_78",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_76",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31175,19 +30215,19 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_127",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_82",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_108",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_79",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_109",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_80",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_110",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_81",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -31203,19 +30243,79 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_128",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_79",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_108",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_48",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 506.711,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_80",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_49",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 500.057,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_81",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_50",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 458.853,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_83",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_79",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_109",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_80",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_110",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_81",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -31231,7 +30331,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_129",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_84",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31259,7 +30359,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_130",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_85",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31287,31 +30387,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_131",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_98",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_63",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_75",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_76",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_77",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_86",
                                 "data source feature": "quantity"
                             },
                             {
@@ -31327,15 +30407,35 @@
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_99",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_90",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_100",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_91",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_101",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_92",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_93",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_95",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_96",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_97",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -31351,31 +30451,251 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_132",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_86",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_63",
-                                "data source feature": "quantity"
-                            },
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_3",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1621.158,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_87",
+                    "data source aggregate document": {
+                        "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
-                                "data source feature": "quantity"
-                            },
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_4",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1588.345,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_88",
+                    "data source aggregate document": {
+                        "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
-                                "data source feature": "quantity"
-                            },
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_5",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1589.757,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_89",
+                    "data source aggregate document": {
+                        "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_75",
-                                "data source feature": "quantity"
-                            },
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_15",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1675.998,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_90",
+                    "data source aggregate document": {
+                        "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_76",
-                                "data source feature": "quantity"
-                            },
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_16",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1660.096,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_91",
+                    "data source aggregate document": {
+                        "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_77",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_17",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1679.275,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_92",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_27",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1604.835,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_93",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_28",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1688.032,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_29",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1612.591,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_95",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_39",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1633.148,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_96",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_40",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1641.499,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_97",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_41",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1577.354,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_99",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_86",
                                 "data source feature": "quantity"
                             },
                             {
@@ -31391,15 +30711,35 @@
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_99",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_90",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_100",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_91",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_101",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_92",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_93",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_95",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_96",
+                                "data source feature": "quantity"
+                            },
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_97",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -31415,7 +30755,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_133",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_100",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31479,7 +30819,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_134",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_101",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31543,11 +30883,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_136",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_103",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_135",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_102",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31563,11 +30903,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_135",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_102",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_131",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_98",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -31583,11 +30923,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_137",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_104",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_135",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_102",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31603,19 +30943,19 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_138",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_108",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_111",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_105",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_112",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_106",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_113",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_107",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -31631,19 +30971,79 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_139",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_105",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_111",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_51",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 399.936,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_106",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_52",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 460.243,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_107",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_53",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 483.791,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_109",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_105",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_112",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_106",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_113",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_107",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -31659,7 +31059,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_140",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_110",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31687,7 +31087,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_141",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_111",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31715,55 +31115,55 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_142",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_66",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_112",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_67",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_113",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_68",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_114",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_78",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_115",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_79",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_116",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_80",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_117",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_90",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_118",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_91",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_119",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_92",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_120",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_102",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_121",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_103",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_122",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_104",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_123",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -31779,55 +31179,295 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_112",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_66",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_6",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5154.896,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_113",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_7",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5107.668,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_114",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_8",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5109.615,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_115",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_18",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5133.758,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_116",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_19",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5093.878,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_117",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_20",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5030.613,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_118",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_30",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5014.847,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_119",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_31",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5004.382,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_120",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_32",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 4885.676,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_121",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_42",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 4947.226,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_122",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_43",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 4986.594,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_123",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_44",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5253.593,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_125",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_112",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_67",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_113",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_68",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_114",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_78",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_115",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_79",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_116",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_80",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_117",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_90",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_118",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_91",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_119",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_92",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_120",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_102",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_121",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_103",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_122",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_104",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_123",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -31843,7 +31483,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_126",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31907,7 +31547,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_145",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_127",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31971,11 +31611,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_147",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_129",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_128",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31991,11 +31631,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_128",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_142",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -32011,11 +31651,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_148",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_130",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_128",
                                 "data source feature": "rq"
                             }
                         ]
@@ -32031,19 +31671,19 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_134",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_114",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_131",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_115",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_132",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_116",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_133",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -32059,19 +31699,79 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_150",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_131",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_114",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_54",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 357.569,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_132",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_55",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 441.414,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_133",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_56",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 429.043,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_135",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_131",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_115",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_132",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_116",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_133",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -32087,7 +31787,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_151",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_136",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32115,7 +31815,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_152",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_137",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32143,55 +31843,55 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_153",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_150",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_69",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_138",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_70",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_139",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_71",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_140",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_81",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_141",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_82",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_142",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_83",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_93",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_145",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_95",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_105",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_147",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_106",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_148",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_107",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -32207,55 +31907,295 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_154",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_138",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_69",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_9",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1043.592,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_139",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_10",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 924.858,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_140",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_11",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1020.466,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_141",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_21",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 934.588,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_142",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_22",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 985.324,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_23",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1008.065,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_33",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 968.798,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_145",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_34",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 953.047,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_35",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 994.151,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_147",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_45",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 972.242,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_148",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_46",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1026.703,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_47",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 1018.621,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_151",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_138",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_70",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_139",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_71",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_140",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_81",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_141",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_82",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_142",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_83",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_93",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_145",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_95",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_105",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_147",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_106",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_148",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_107",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -32271,7 +32211,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_155",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_152",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32335,7 +32275,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_156",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_153",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32399,11 +32339,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_158",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_155",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_157",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_154",
                                 "data source feature": "rq"
                             }
                         ]
@@ -32419,11 +32359,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_157",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_154",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_153",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_150",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -32439,11 +32379,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_159",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_156",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_157",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_154",
                                 "data source feature": "rq"
                             }
                         ]
@@ -32463,15 +32403,15 @@
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_117",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_157",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_118",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_158",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_119",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_159",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -32487,19 +32427,79 @@
                     }
                 },
                 {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_157",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_57",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 470.355,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_158",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_58",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 400.862,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_159",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_59",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "data processing document": {
+                        "reference DNA description": "IPC",
+                        "reference sample description": "1000"
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 471.361,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
                     "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_161",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_117",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_157",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_118",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_158",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_119",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_159",
                                 "data source feature": "quantity"
                             }
                         ]

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_multiple_cal_doc_wells.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_multiple_cal_doc_wells.json
@@ -229,42 +229,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_4",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_0",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5720.562,
-                                "unit": "(unitless)"
-                            }
-                        },
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_5",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_1",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5720.562,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             },
             {
@@ -490,42 +454,6 @@
                     "experimental data identifier": "QuantStudio 96-Well Standard Curve Example",
                     "experiment type": "standard curve qPCR experiment",
                     "container type": "qPCR reaction block"
-                },
-                "calculated data aggregate document": {
-                    "calculated data document": [
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_6",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_2",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5605.765,
-                                "unit": "(unitless)"
-                            }
-                        },
-                        {
-                            "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_7",
-                            "data source aggregate document": {
-                                "data source document": [
-                                    {
-                                        "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_3",
-                                        "data source feature": "cycle threshold result"
-                                    }
-                                ]
-                            },
-                            "calculated data name": "quantity",
-                            "calculated datum": {
-                                "value": 5605.765,
-                                "unit": "(unitless)"
-                            }
-                        }
-                    ]
                 }
             }
         ],
@@ -536,12 +464,12 @@
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.29"
         },
         "calculated data aggregate document": {
             "calculated data document": [
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_8",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_6",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -549,7 +477,7 @@
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_6",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_5",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -561,7 +489,39 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_9",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_4",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_0",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5720.562,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_5",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_2",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5605.765,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_7",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -569,7 +529,7 @@
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_6",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_5",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -581,7 +541,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_10",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_8",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -601,7 +561,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_11",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_9",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -625,11 +585,11 @@
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_5",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_10",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_7",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_11",
                                 "data source feature": "quantity"
                             }
                         ]
@@ -641,15 +601,47 @@
                     }
                 },
                 {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_10",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_1",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5720.562,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_11",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_3",
+                                "data source feature": "cycle threshold result"
+                            }
+                        ]
+                    },
+                    "calculated data name": "quantity",
+                    "calculated datum": {
+                        "value": 5605.765,
+                        "unit": "(unitless)"
+                    }
+                },
+                {
                     "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_13",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_5",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_10",
                                 "data source feature": "quantity"
                             },
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_7",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_11",
                                 "data source feature": "quantity"
                             }
                         ]


### PR DESCRIPTION
- remove inner calculated data documents from AppBio Quantstudio

This change requires the refactor of the PCR CSV converter. This task is already being developed.