### PR TITLE
add cache to calculated data constructors in AppBio Quantstudio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Remove duplicated ct sd and ct se calculated data documents in Quantstudio Design and Analysis adapter
+- Remove duplicated quantity mean calculated data documents from AppBio Quantstudio adapter
 
 ### Changed
 - Update multianalyte model minimum_assay_bead_count to be of type "number" insetead of "unitless"

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_calculated_documents.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_calculated_documents.py
@@ -39,6 +39,7 @@ def build_quantity(well_item: WellItem) -> Optional[CalculatedDocument]:
     )
 
 
+@cache
 def build_quantity_mean(
     view_data: ViewData[WellItem], sample: str, target: str
 ) -> Optional[CalculatedDocument]:
@@ -67,6 +68,7 @@ def build_quantity_mean(
     )
 
 
+@cache
 def build_quantity_sd(
     view_data: ViewData[WellItem], sample: str, target: str
 ) -> Optional[CalculatedDocument]:
@@ -114,6 +116,7 @@ def build_ct_mean(
     )
 
 
+@cache
 def build_ct_sd(
     view_data: ViewData[WellItem], sample: str, target: str
 ) -> Optional[CalculatedDocument]:
@@ -168,6 +171,7 @@ def build_delta_ct_mean(
     )
 
 
+@cache
 def build_delta_ct_se(
     view_data: ViewData[WellItem], sample: str, target: str, r_target: str
 ) -> Optional[CalculatedDocument]:
@@ -194,6 +198,7 @@ def build_delta_ct_se(
     )
 
 
+@cache
 def build_delta_delta_ct(
     view_data: ViewData[WellItem],
     sample: str,
@@ -261,6 +266,7 @@ def build_rq(
     )
 
 
+@cache
 def build_rq_min(
     view_data: ViewData[WellItem],
     sample: str,
@@ -289,6 +295,7 @@ def build_rq_min(
     )
 
 
+@cache
 def build_rq_max(
     view_data: ViewData[WellItem],
     sample: str,
@@ -344,6 +351,7 @@ def build_relative_rq(
     )
 
 
+@cache
 def build_relative_rq_min(
     view_data: ViewData[WellItem],
     sample: str,
@@ -370,6 +378,7 @@ def build_relative_rq_min(
     )
 
 
+@cache
 def build_relative_rq_max(
     view_data: ViewData[WellItem],
     sample: str,
@@ -396,6 +405,7 @@ def build_relative_rq_max(
     )
 
 
+@cache
 def build_rn_mean(
     view_data: ViewData[WellItem], sample: str, target: str
 ) -> Optional[CalculatedDocument]:
@@ -414,6 +424,7 @@ def build_rn_mean(
     )
 
 
+@cache
 def build_rn_sd(
     view_data: ViewData[WellItem], sample: str, target: str
 ) -> Optional[CalculatedDocument]:
@@ -432,6 +443,7 @@ def build_rn_sd(
     )
 
 
+@cache
 def build_y_intercept(
     view_data: ViewData[WellItem], target: str
 ) -> Optional[CalculatedDocument]:
@@ -450,6 +462,7 @@ def build_y_intercept(
     )
 
 
+@cache
 def build_r_squared(
     view_data: ViewData[WellItem], target: str
 ) -> Optional[CalculatedDocument]:
@@ -468,6 +481,7 @@ def build_r_squared(
     )
 
 
+@cache
 def build_slope(
     view_data: ViewData[WellItem], target: str
 ) -> Optional[CalculatedDocument]:
@@ -486,6 +500,7 @@ def build_slope(
     )
 
 
+@cache
 def build_efficiency(
     view_data: ViewData[WellItem], target: str
 ) -> Optional[CalculatedDocument]:

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_data.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_data.py
@@ -1365,7 +1365,7 @@ def get_rel_std_curve_data() -> Data:
                     identifier=37,
                     items={
                         "RNaseP": WellItem(
-                            uuid="2b290825-2a40-4768-a21f-a8a603c32c85",
+                            uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                             identifier=37,
                             target_dna_description="RNaseP",
                             sample_identifier="800",
@@ -1413,14 +1413,14 @@ def get_rel_std_curve_data() -> Data:
                     _melt_curve_raw_data=None,
                     _calculated_documents=[
                         CalculatedDocument(
-                            uuid="94cf744d-d243-47bd-a723-aca6c6517af5",
+                            uuid="91feb1d5-89e6-442e-a11c-d4b4f2821537",
                             name="quantity",
                             value=794.91,
                             data_sources=[
                                 DataSource(
                                     feature="cycle threshold result",
                                     reference=WellItem(
-                                        uuid="2b290825-2a40-4768-a21f-a8a603c32c85",
+                                        uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                                         identifier=37,
                                         target_dna_description="RNaseP",
                                         sample_identifier="800",
@@ -1466,14 +1466,14 @@ def get_rel_std_curve_data() -> Data:
                                 )
                             ],
                             iterated=True,
-                        ),
+                        )
                     ],
                 ),
                 Well(
                     identifier=38,
                     items={
                         "RNaseP": WellItem(
-                            uuid="42788e09-e972-4c9b-b8d0-7263e07371fa",
+                            uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                             identifier=38,
                             target_dna_description="RNaseP",
                             sample_identifier="800",
@@ -1521,14 +1521,14 @@ def get_rel_std_curve_data() -> Data:
                     _melt_curve_raw_data=None,
                     _calculated_documents=[
                         CalculatedDocument(
-                            uuid="51066bef-10b0-4782-a8c9-ee7383fe3256",
+                            uuid="8f82e615-af30-474c-9e27-a53bc146013c",
                             name="quantity",
                             value=769.776,
                             data_sources=[
                                 DataSource(
                                     feature="cycle threshold result",
                                     reference=WellItem(
-                                        uuid="42788e09-e972-4c9b-b8d0-7263e07371fa",
+                                        uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                                         identifier=38,
                                         target_dna_description="RNaseP",
                                         sample_identifier="800",
@@ -1584,21 +1584,21 @@ def get_rel_std_curve_data() -> Data:
         reference_sample="800",
         calculated_documents=[
             CalculatedDocument(
-                uuid="9b24577d-08bf-4312-8d1e-13feea315b0f",
+                uuid="70047607-9164-4e29-a1ea-296e36df4f20",
                 name="quantity mean",
                 value=818.012,
                 data_sources=[
                     DataSource(
                         feature="quantity",
                         reference=CalculatedDocument(
-                            uuid="94cf744d-d243-47bd-a723-aca6c6517af5",
+                            uuid="91feb1d5-89e6-442e-a11c-d4b4f2821537",
                             name="quantity",
                             value=794.91,
                             data_sources=[
                                 DataSource(
                                     feature="cycle threshold result",
                                     reference=WellItem(
-                                        uuid="2b290825-2a40-4768-a21f-a8a603c32c85",
+                                        uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                                         identifier=37,
                                         target_dna_description="RNaseP",
                                         sample_identifier="800",
@@ -1649,14 +1649,14 @@ def get_rel_std_curve_data() -> Data:
                     DataSource(
                         feature="quantity",
                         reference=CalculatedDocument(
-                            uuid="51066bef-10b0-4782-a8c9-ee7383fe3256",
+                            uuid="8f82e615-af30-474c-9e27-a53bc146013c",
                             name="quantity",
                             value=769.776,
                             data_sources=[
                                 DataSource(
                                     feature="cycle threshold result",
                                     reference=WellItem(
-                                        uuid="42788e09-e972-4c9b-b8d0-7263e07371fa",
+                                        uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                                         identifier=38,
                                         target_dna_description="RNaseP",
                                         sample_identifier="800",
@@ -1708,21 +1708,21 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
-                uuid="7434c27a-11d2-41d4-b20d-7407b8dec622",
+                uuid="6df2e5ab-b601-4d4a-81a0-a439fd923e6d",
                 name="quantity sd",
                 value=29.535,
                 data_sources=[
                     DataSource(
                         feature="quantity",
                         reference=CalculatedDocument(
-                            uuid="94cf744d-d243-47bd-a723-aca6c6517af5",
+                            uuid="91feb1d5-89e6-442e-a11c-d4b4f2821537",
                             name="quantity",
                             value=794.91,
                             data_sources=[
                                 DataSource(
                                     feature="cycle threshold result",
                                     reference=WellItem(
-                                        uuid="2b290825-2a40-4768-a21f-a8a603c32c85",
+                                        uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                                         identifier=37,
                                         target_dna_description="RNaseP",
                                         sample_identifier="800",
@@ -1773,14 +1773,14 @@ def get_rel_std_curve_data() -> Data:
                     DataSource(
                         feature="quantity",
                         reference=CalculatedDocument(
-                            uuid="51066bef-10b0-4782-a8c9-ee7383fe3256",
+                            uuid="8f82e615-af30-474c-9e27-a53bc146013c",
                             name="quantity",
                             value=769.776,
                             data_sources=[
                                 DataSource(
                                     feature="cycle threshold result",
                                     reference=WellItem(
-                                        uuid="42788e09-e972-4c9b-b8d0-7263e07371fa",
+                                        uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                                         identifier=38,
                                         target_dna_description="RNaseP",
                                         sample_identifier="800",
@@ -1832,14 +1832,14 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
-                uuid="be28fba1-d101-4cfc-b62b-9e31e833e261",
+                uuid="4ab1f957-95f5-45c5-a5a2-fd6f44a37136",
                 name="ct mean",
                 value=30.115,
                 data_sources=[
                     DataSource(
                         feature="cycle threshold result",
                         reference=WellItem(
-                            uuid="90476d22-abb1-4ad1-ad79-350d8726e90e",
+                            uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                             identifier=37,
                             target_dna_description="RNaseP",
                             sample_identifier="800",
@@ -1886,7 +1886,7 @@ def get_rel_std_curve_data() -> Data:
                     DataSource(
                         feature="cycle threshold result",
                         reference=WellItem(
-                            uuid="ad05b7ea-33f8-4d50-a8f4-6e13f4eb386c",
+                            uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                             identifier=38,
                             target_dna_description="RNaseP",
                             sample_identifier="800",
@@ -1934,14 +1934,14 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
-                uuid="88749c03-5cdb-49c1-b829-092e95e863ff",
+                uuid="11bacdaa-3ee7-49d1-8882-ce67ea01a3aa",
                 name="ct sd",
                 value=0.051,
                 data_sources=[
                     DataSource(
                         feature="cycle threshold result",
                         reference=WellItem(
-                            uuid="2b290825-2a40-4768-a21f-a8a603c32c85",
+                            uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                             identifier=37,
                             target_dna_description="RNaseP",
                             sample_identifier="800",
@@ -1988,7 +1988,7 @@ def get_rel_std_curve_data() -> Data:
                     DataSource(
                         feature="cycle threshold result",
                         reference=WellItem(
-                            uuid="42788e09-e972-4c9b-b8d0-7263e07371fa",
+                            uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                             identifier=38,
                             target_dna_description="RNaseP",
                             sample_identifier="800",
@@ -2036,35 +2036,35 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
-                uuid="75798875-017f-4026-9131-5d7661e01213",
+                uuid="ceeae020-7f7a-43ee-975b-08044ef67826",
                 name="rq min",
                 value=0.658,
                 data_sources=[
                     DataSource(
                         feature="rq",
                         reference=CalculatedDocument(
-                            uuid="4606bf27-7d50-4ef0-a643-6d105b080057",
+                            uuid="bfe26da2-72cb-411b-8abb-44e5d2f19d8c",
                             name="rq",
                             value=0.798,
                             data_sources=[
                                 DataSource(
                                     feature="quantity mean",
                                     reference=CalculatedDocument(
-                                        uuid="0eb90790-c6a6-476e-b5cb-8b0c6a3e62f2",
+                                        uuid="70047607-9164-4e29-a1ea-296e36df4f20",
                                         name="quantity mean",
                                         value=818.012,
                                         data_sources=[
                                             DataSource(
                                                 feature="quantity",
                                                 reference=CalculatedDocument(
-                                                    uuid="94cf744d-d243-47bd-a723-aca6c6517af5",
+                                                    uuid="91feb1d5-89e6-442e-a11c-d4b4f2821537",
                                                     name="quantity",
                                                     value=794.91,
                                                     data_sources=[
                                                         DataSource(
                                                             feature="cycle threshold result",
                                                             reference=WellItem(
-                                                                uuid="2b290825-2a40-4768-a21f-a8a603c32c85",
+                                                                uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                                                                 identifier=37,
                                                                 target_dna_description="RNaseP",
                                                                 sample_identifier="800",
@@ -2115,14 +2115,14 @@ def get_rel_std_curve_data() -> Data:
                                             DataSource(
                                                 feature="quantity",
                                                 reference=CalculatedDocument(
-                                                    uuid="51066bef-10b0-4782-a8c9-ee7383fe3256",
+                                                    uuid="8f82e615-af30-474c-9e27-a53bc146013c",
                                                     name="quantity",
                                                     value=769.776,
                                                     data_sources=[
                                                         DataSource(
                                                             feature="cycle threshold result",
                                                             reference=WellItem(
-                                                                uuid="42788e09-e972-4c9b-b8d0-7263e07371fa",
+                                                                uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                                                                 identifier=38,
                                                                 target_dna_description="RNaseP",
                                                                 sample_identifier="800",
@@ -2182,28 +2182,28 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
-                uuid="4606bf27-7d50-4ef0-a643-6d105b080057",
+                uuid="bfe26da2-72cb-411b-8abb-44e5d2f19d8c",
                 name="rq",
                 value=0.798,
                 data_sources=[
                     DataSource(
                         feature="quantity mean",
                         reference=CalculatedDocument(
-                            uuid="0eb90790-c6a6-476e-b5cb-8b0c6a3e62f2",
+                            uuid="70047607-9164-4e29-a1ea-296e36df4f20",
                             name="quantity mean",
                             value=818.012,
                             data_sources=[
                                 DataSource(
                                     feature="quantity",
                                     reference=CalculatedDocument(
-                                        uuid="94cf744d-d243-47bd-a723-aca6c6517af5",
+                                        uuid="91feb1d5-89e6-442e-a11c-d4b4f2821537",
                                         name="quantity",
                                         value=794.91,
                                         data_sources=[
                                             DataSource(
                                                 feature="cycle threshold result",
                                                 reference=WellItem(
-                                                    uuid="2b290825-2a40-4768-a21f-a8a603c32c85",
+                                                    uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                                                     identifier=37,
                                                     target_dna_description="RNaseP",
                                                     sample_identifier="800",
@@ -2254,14 +2254,14 @@ def get_rel_std_curve_data() -> Data:
                                 DataSource(
                                     feature="quantity",
                                     reference=CalculatedDocument(
-                                        uuid="51066bef-10b0-4782-a8c9-ee7383fe3256",
+                                        uuid="8f82e615-af30-474c-9e27-a53bc146013c",
                                         name="quantity",
                                         value=769.776,
                                         data_sources=[
                                             DataSource(
                                                 feature="cycle threshold result",
                                                 reference=WellItem(
-                                                    uuid="42788e09-e972-4c9b-b8d0-7263e07371fa",
+                                                    uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                                                     identifier=38,
                                                     target_dna_description="RNaseP",
                                                     sample_identifier="800",
@@ -2317,159 +2317,35 @@ def get_rel_std_curve_data() -> Data:
                 iterated=True,
             ),
             CalculatedDocument(
-                uuid="0eb90790-c6a6-476e-b5cb-8b0c6a3e62f2",
-                name="quantity mean",
-                value=818.012,
-                data_sources=[
-                    DataSource(
-                        feature="quantity",
-                        reference=CalculatedDocument(
-                            uuid="94cf744d-d243-47bd-a723-aca6c6517af5",
-                            name="quantity",
-                            value=794.91,
-                            data_sources=[
-                                DataSource(
-                                    feature="cycle threshold result",
-                                    reference=WellItem(
-                                        uuid="2b290825-2a40-4768-a21f-a8a603c32c85",
-                                        identifier=37,
-                                        target_dna_description="RNaseP",
-                                        sample_identifier="800",
-                                        reporter_dye_setting="FAM",
-                                        position="D1",
-                                        well_location_identifier="D1",
-                                        quencher_dye_setting="NFQ-MGB",
-                                        sample_role_type="UNKNOWN",
-                                        _amplification_data=AmplificationData(
-                                            total_cycle_number_setting=1.0,
-                                            cycle=[1],
-                                            rn=[0.627],
-                                            delta_rn=[0.001],
-                                        ),
-                                        _result=Result(
-                                            cycle_threshold_value_setting=0.133,
-                                            cycle_threshold_result=30.155,
-                                            automatic_cycle_threshold_enabled_setting=True,
-                                            automatic_baseline_determination_enabled_setting=True,
-                                            normalized_reporter_result=None,
-                                            baseline_corrected_reporter_result=None,
-                                            genotyping_determination_result=None,
-                                            genotyping_determination_method_setting=None,
-                                            quantity=794.91,
-                                            quantity_mean=818.012,
-                                            quantity_sd=29.535,
-                                            ct_mean=30.115,
-                                            ct_sd=0.051,
-                                            delta_ct_mean=None,
-                                            delta_ct_se=None,
-                                            delta_delta_ct=None,
-                                            rq=0.798,
-                                            rq_min=0.658,
-                                            rq_max=0.967,
-                                            rn_mean=None,
-                                            rn_sd=None,
-                                            y_intercept=39.662,
-                                            r_squared=0.999,
-                                            slope=-3.278,
-                                            efficiency=101.866,
-                                        ),
-                                    ),
-                                )
-                            ],
-                            iterated=True,
-                        ),
-                    ),
-                    DataSource(
-                        feature="quantity",
-                        reference=CalculatedDocument(
-                            uuid="51066bef-10b0-4782-a8c9-ee7383fe3256",
-                            name="quantity",
-                            value=769.776,
-                            data_sources=[
-                                DataSource(
-                                    feature="cycle threshold result",
-                                    reference=WellItem(
-                                        uuid="42788e09-e972-4c9b-b8d0-7263e07371fa",
-                                        identifier=38,
-                                        target_dna_description="RNaseP",
-                                        sample_identifier="800",
-                                        reporter_dye_setting="FAM",
-                                        position="D2",
-                                        well_location_identifier="D2",
-                                        quencher_dye_setting="NFQ-MGB",
-                                        sample_role_type="UNKNOWN",
-                                        _amplification_data=AmplificationData(
-                                            total_cycle_number_setting=1.0,
-                                            cycle=[1],
-                                            rn=[0.612],
-                                            delta_rn=[-0.001],
-                                        ),
-                                        _result=Result(
-                                            cycle_threshold_value_setting=0.133,
-                                            cycle_threshold_result=30.2,
-                                            automatic_cycle_threshold_enabled_setting=True,
-                                            automatic_baseline_determination_enabled_setting=True,
-                                            normalized_reporter_result=None,
-                                            baseline_corrected_reporter_result=None,
-                                            genotyping_determination_result=None,
-                                            genotyping_determination_method_setting=None,
-                                            quantity=769.776,
-                                            quantity_mean=818.012,
-                                            quantity_sd=29.535,
-                                            ct_mean=30.115,
-                                            ct_sd=0.051,
-                                            delta_ct_mean=None,
-                                            delta_ct_se=None,
-                                            delta_delta_ct=None,
-                                            rq=0.798,
-                                            rq_min=0.658,
-                                            rq_max=0.967,
-                                            rn_mean=None,
-                                            rn_sd=None,
-                                            y_intercept=39.662,
-                                            r_squared=0.999,
-                                            slope=-3.278,
-                                            efficiency=101.866,
-                                        ),
-                                    ),
-                                )
-                            ],
-                            iterated=True,
-                        ),
-                    ),
-                ],
-                iterated=True,
-            ),
-            CalculatedDocument(
-                uuid="d23ae1c4-e750-43eb-a6df-ed66d96bcd20",
+                uuid="84342a87-b7b4-4966-8066-663ab490adbb",
                 name="rq max",
                 value=0.967,
                 data_sources=[
                     DataSource(
                         feature="rq",
                         reference=CalculatedDocument(
-                            uuid="4606bf27-7d50-4ef0-a643-6d105b080057",
+                            uuid="bfe26da2-72cb-411b-8abb-44e5d2f19d8c",
                             name="rq",
                             value=0.798,
                             data_sources=[
                                 DataSource(
                                     feature="quantity mean",
                                     reference=CalculatedDocument(
-                                        uuid="0eb90790-c6a6-476e-b5cb-8b0c6a3e62f2",
+                                        uuid="70047607-9164-4e29-a1ea-296e36df4f20",
                                         name="quantity mean",
                                         value=818.012,
                                         data_sources=[
                                             DataSource(
                                                 feature="quantity",
                                                 reference=CalculatedDocument(
-                                                    uuid="94cf744d-d243-47bd-a723-aca6c6517af5",
+                                                    uuid="91feb1d5-89e6-442e-a11c-d4b4f2821537",
                                                     name="quantity",
                                                     value=794.91,
                                                     data_sources=[
                                                         DataSource(
                                                             feature="cycle threshold result",
                                                             reference=WellItem(
-                                                                uuid="2b290825-2a40-4768-a21f-a8a603c32c85",
+                                                                uuid="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                                                                 identifier=37,
                                                                 target_dna_description="RNaseP",
                                                                 sample_identifier="800",
@@ -2520,14 +2396,14 @@ def get_rel_std_curve_data() -> Data:
                                             DataSource(
                                                 feature="quantity",
                                                 reference=CalculatedDocument(
-                                                    uuid="51066bef-10b0-4782-a8c9-ee7383fe3256",
+                                                    uuid="8f82e615-af30-474c-9e27-a53bc146013c",
                                                     name="quantity",
                                                     value=769.776,
                                                     data_sources=[
                                                         DataSource(
                                                             feature="cycle threshold result",
                                                             reference=WellItem(
-                                                                uuid="42788e09-e972-4c9b-b8d0-7263e07371fa",
+                                                                uuid="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                                                                 identifier=38,
                                                                 target_dna_description="RNaseP",
                                                                 sample_identifier="800",
@@ -2608,10 +2484,13 @@ def get_rel_std_curve_model() -> Model:
                     measurement_aggregate_document=MeasurementAggregateDocument(
                         plate_well_count=TQuantityValueNumber(
                             value=96,
+                            unit="#",
+                            has_statistic_datum_role=None,
+                            field_type=None,
                         ),
                         measurement_document=[
                             MeasurementDocumentItem(
-                                measurement_identifier="2b290825-2a40-4768-a21f-a8a603c32c85",
+                                measurement_identifier="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                                 measurement_time="2010-10-20T02:23:34-04:00",
                                 target_DNA_description="RNaseP",
                                 sample_document=SampleDocument(
@@ -2632,6 +2511,9 @@ def get_rel_std_curve_model() -> Model:
                                             detection_type=None,
                                             total_cycle_number_setting=TQuantityValueNumber(
                                                 value=1.0,
+                                                unit="#",
+                                                has_statistic_datum_role=None,
+                                                field_type=None,
                                             ),
                                             denaturing_temperature_setting=None,
                                             denaturing_time_setting=None,
@@ -2651,6 +2533,9 @@ def get_rel_std_curve_model() -> Model:
                                             data_processing_document=DataProcessingDocument(
                                                 cycle_threshold_value_setting=TQuantityValueUnitless(
                                                     value=0.133,
+                                                    unit="(unitless)",
+                                                    has_statistic_datum_role=None,
+                                                    field_type=None,
                                                 ),
                                                 automatic_cycle_threshold_enabled_setting=True,
                                                 automatic_baseline_determination_enabled_setting=True,
@@ -2661,6 +2546,9 @@ def get_rel_std_curve_model() -> Model:
                                             ),
                                             cycle_threshold_result=TNullableQuantityValueUnitless(
                                                 value=30.155,
+                                                unit="(unitless)",
+                                                has_statistic_datum_role=None,
+                                                field_type=None,
                                             ),
                                             normalized_reporter_result=None,
                                             normalized_reporter_data_cube=NormalizedReporterDataCube(
@@ -2671,6 +2559,8 @@ def get_rel_std_curve_model() -> Model:
                                                             field_componentDatatype=FieldComponentDatatype.integer,
                                                             concept="cycle count",
                                                             unit="#",
+                                                            scale=None,
+                                                            field_asm_fill_value=None,
                                                         )
                                                     ],
                                                     measures=[
@@ -2678,6 +2568,8 @@ def get_rel_std_curve_model() -> Model:
                                                             field_componentDatatype=FieldComponentDatatype.double,
                                                             concept="normalized report result",
                                                             unit="(unitless)",
+                                                            scale=None,
+                                                            field_asm_fill_value=None,
                                                         )
                                                     ],
                                                 ),
@@ -2696,6 +2588,8 @@ def get_rel_std_curve_model() -> Model:
                                                             field_componentDatatype=FieldComponentDatatype.integer,
                                                             concept="cycle count",
                                                             unit="#",
+                                                            scale=None,
+                                                            field_asm_fill_value=None,
                                                         )
                                                     ],
                                                     measures=[
@@ -2703,6 +2597,8 @@ def get_rel_std_curve_model() -> Model:
                                                             field_componentDatatype=FieldComponentDatatype.double,
                                                             concept="baseline corrected reporter result",
                                                             unit="(unitless)",
+                                                            scale=None,
+                                                            field_asm_fill_value=None,
                                                         )
                                                     ],
                                                 ),
@@ -2732,11 +2628,11 @@ def get_rel_std_curve_model() -> Model:
                     calculated_data_aggregate_document=TCalculatedDataAggregateDocument(
                         calculated_data_document=[
                             CalculatedDataDocumentItem(
-                                calculated_data_identifier="94cf744d-d243-47bd-a723-aca6c6517af5",
+                                calculated_data_identifier="91feb1d5-89e6-442e-a11c-d4b4f2821537",
                                 data_source_aggregate_document=DataSourceAggregateDocument(
                                     data_source_document=[
                                         DataSourceDocumentItem(
-                                            data_source_identifier="2b290825-2a40-4768-a21f-a8a603c32c85",
+                                            data_source_identifier="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                                             data_source_feature="cycle threshold result",
                                         )
                                     ]
@@ -2746,6 +2642,9 @@ def get_rel_std_curve_model() -> Model:
                                 calculated_data_description=None,
                                 calculated_datum=TQuantityValueUnitless(
                                     value=794.91,
+                                    unit="(unitless)",
+                                    has_statistic_datum_role=None,
+                                    field_type=None,
                                 ),
                             )
                         ]
@@ -2755,10 +2654,13 @@ def get_rel_std_curve_model() -> Model:
                     measurement_aggregate_document=MeasurementAggregateDocument(
                         plate_well_count=TQuantityValueNumber(
                             value=96,
+                            unit="#",
+                            has_statistic_datum_role=None,
+                            field_type=None,
                         ),
                         measurement_document=[
                             MeasurementDocumentItem(
-                                measurement_identifier="42788e09-e972-4c9b-b8d0-7263e07371fa",
+                                measurement_identifier="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                                 measurement_time="2010-10-20T02:23:34-04:00",
                                 target_DNA_description="RNaseP",
                                 sample_document=SampleDocument(
@@ -2779,6 +2681,9 @@ def get_rel_std_curve_model() -> Model:
                                             detection_type=None,
                                             total_cycle_number_setting=TQuantityValueNumber(
                                                 value=1.0,
+                                                unit="#",
+                                                has_statistic_datum_role=None,
+                                                field_type=None,
                                             ),
                                             denaturing_temperature_setting=None,
                                             denaturing_time_setting=None,
@@ -2798,6 +2703,9 @@ def get_rel_std_curve_model() -> Model:
                                             data_processing_document=DataProcessingDocument(
                                                 cycle_threshold_value_setting=TQuantityValueUnitless(
                                                     value=0.133,
+                                                    unit="(unitless)",
+                                                    has_statistic_datum_role=None,
+                                                    field_type=None,
                                                 ),
                                                 automatic_cycle_threshold_enabled_setting=True,
                                                 automatic_baseline_determination_enabled_setting=True,
@@ -2808,6 +2716,9 @@ def get_rel_std_curve_model() -> Model:
                                             ),
                                             cycle_threshold_result=TNullableQuantityValueUnitless(
                                                 value=30.2,
+                                                unit="(unitless)",
+                                                has_statistic_datum_role=None,
+                                                field_type=None,
                                             ),
                                             normalized_reporter_result=None,
                                             normalized_reporter_data_cube=NormalizedReporterDataCube(
@@ -2818,6 +2729,8 @@ def get_rel_std_curve_model() -> Model:
                                                             field_componentDatatype=FieldComponentDatatype.integer,
                                                             concept="cycle count",
                                                             unit="#",
+                                                            scale=None,
+                                                            field_asm_fill_value=None,
                                                         )
                                                     ],
                                                     measures=[
@@ -2825,6 +2738,8 @@ def get_rel_std_curve_model() -> Model:
                                                             field_componentDatatype=FieldComponentDatatype.double,
                                                             concept="normalized report result",
                                                             unit="(unitless)",
+                                                            scale=None,
+                                                            field_asm_fill_value=None,
                                                         )
                                                     ],
                                                 ),
@@ -2843,6 +2758,8 @@ def get_rel_std_curve_model() -> Model:
                                                             field_componentDatatype=FieldComponentDatatype.integer,
                                                             concept="cycle count",
                                                             unit="#",
+                                                            scale=None,
+                                                            field_asm_fill_value=None,
                                                         )
                                                     ],
                                                     measures=[
@@ -2850,6 +2767,8 @@ def get_rel_std_curve_model() -> Model:
                                                             field_componentDatatype=FieldComponentDatatype.double,
                                                             concept="baseline corrected reporter result",
                                                             unit="(unitless)",
+                                                            scale=None,
+                                                            field_asm_fill_value=None,
                                                         )
                                                     ],
                                                 ),
@@ -2879,11 +2798,11 @@ def get_rel_std_curve_model() -> Model:
                     calculated_data_aggregate_document=TCalculatedDataAggregateDocument(
                         calculated_data_document=[
                             CalculatedDataDocumentItem(
-                                calculated_data_identifier="51066bef-10b0-4782-a8c9-ee7383fe3256",
+                                calculated_data_identifier="8f82e615-af30-474c-9e27-a53bc146013c",
                                 data_source_aggregate_document=DataSourceAggregateDocument(
                                     data_source_document=[
                                         DataSourceDocumentItem(
-                                            data_source_identifier="42788e09-e972-4c9b-b8d0-7263e07371fa",
+                                            data_source_identifier="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                                             data_source_feature="cycle threshold result",
                                         )
                                     ]
@@ -2893,6 +2812,9 @@ def get_rel_std_curve_model() -> Model:
                                 calculated_data_description=None,
                                 calculated_datum=TQuantityValueUnitless(
                                     value=769.776,
+                                    unit="(unitless)",
+                                    has_statistic_datum_role=None,
+                                    field_type=None,
                                 ),
                             )
                         ]
@@ -2906,20 +2828,20 @@ def get_rel_std_curve_model() -> Model:
                 software_name="Thermo QuantStudio",
                 software_version="1.0",
                 ASM_converter_name="allotropy",
-                ASM_converter_version=ASM_CONVERTER_VERSION,
+                ASM_converter_version="0.1.29",
             ),
             calculated_data_aggregate_document=TCalculatedDataAggregateDocument(
                 calculated_data_document=[
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="9b24577d-08bf-4312-8d1e-13feea315b0f",
+                        calculated_data_identifier="70047607-9164-4e29-a1ea-296e36df4f20",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="94cf744d-d243-47bd-a723-aca6c6517af5",
+                                    data_source_identifier="91feb1d5-89e6-442e-a11c-d4b4f2821537",
                                     data_source_feature="quantity",
                                 ),
                                 DataSourceDocumentItem(
-                                    data_source_identifier="51066bef-10b0-4782-a8c9-ee7383fe3256",
+                                    data_source_identifier="8f82e615-af30-474c-9e27-a53bc146013c",
                                     data_source_feature="quantity",
                                 ),
                             ]
@@ -2932,18 +2854,21 @@ def get_rel_std_curve_model() -> Model:
                         calculated_data_description=None,
                         calculated_datum=TQuantityValueUnitless(
                             value=818.012,
+                            unit="(unitless)",
+                            has_statistic_datum_role=None,
+                            field_type=None,
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="7434c27a-11d2-41d4-b20d-7407b8dec622",
+                        calculated_data_identifier="6df2e5ab-b601-4d4a-81a0-a439fd923e6d",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="94cf744d-d243-47bd-a723-aca6c6517af5",
+                                    data_source_identifier="91feb1d5-89e6-442e-a11c-d4b4f2821537",
                                     data_source_feature="quantity",
                                 ),
                                 DataSourceDocumentItem(
-                                    data_source_identifier="51066bef-10b0-4782-a8c9-ee7383fe3256",
+                                    data_source_identifier="8f82e615-af30-474c-9e27-a53bc146013c",
                                     data_source_feature="quantity",
                                 ),
                             ]
@@ -2956,18 +2881,21 @@ def get_rel_std_curve_model() -> Model:
                         calculated_data_description=None,
                         calculated_datum=TQuantityValueUnitless(
                             value=29.535,
+                            unit="(unitless)",
+                            has_statistic_datum_role=None,
+                            field_type=None,
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="be28fba1-d101-4cfc-b62b-9e31e833e261",
+                        calculated_data_identifier="4ab1f957-95f5-45c5-a5a2-fd6f44a37136",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="90476d22-abb1-4ad1-ad79-350d8726e90e",
+                                    data_source_identifier="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                                     data_source_feature="cycle threshold result",
                                 ),
                                 DataSourceDocumentItem(
-                                    data_source_identifier="ad05b7ea-33f8-4d50-a8f4-6e13f4eb386c",
+                                    data_source_identifier="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                                     data_source_feature="cycle threshold result",
                                 ),
                             ]
@@ -2986,15 +2914,15 @@ def get_rel_std_curve_model() -> Model:
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="88749c03-5cdb-49c1-b829-092e95e863ff",
+                        calculated_data_identifier="11bacdaa-3ee7-49d1-8882-ce67ea01a3aa",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="2b290825-2a40-4768-a21f-a8a603c32c85",
+                                    data_source_identifier="3821bf42-6ec4-4b65-b422-4e491a28f7ed",
                                     data_source_feature="cycle threshold result",
                                 ),
                                 DataSourceDocumentItem(
-                                    data_source_identifier="42788e09-e972-4c9b-b8d0-7263e07371fa",
+                                    data_source_identifier="a73095aa-c4be-4fa4-a533-56e7f7bd6826",
                                     data_source_feature="cycle threshold result",
                                 ),
                             ]
@@ -3007,14 +2935,17 @@ def get_rel_std_curve_model() -> Model:
                         calculated_data_description=None,
                         calculated_datum=TQuantityValueUnitless(
                             value=0.051,
+                            unit="(unitless)",
+                            has_statistic_datum_role=None,
+                            field_type=None,
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="75798875-017f-4026-9131-5d7661e01213",
+                        calculated_data_identifier="ceeae020-7f7a-43ee-975b-08044ef67826",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="4606bf27-7d50-4ef0-a643-6d105b080057",
+                                    data_source_identifier="bfe26da2-72cb-411b-8abb-44e5d2f19d8c",
                                     data_source_feature="rq",
                                 )
                             ]
@@ -3027,14 +2958,17 @@ def get_rel_std_curve_model() -> Model:
                         calculated_data_description=None,
                         calculated_datum=TQuantityValueUnitless(
                             value=0.658,
+                            unit="(unitless)",
+                            has_statistic_datum_role=None,
+                            field_type=None,
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="4606bf27-7d50-4ef0-a643-6d105b080057",
+                        calculated_data_identifier="bfe26da2-72cb-411b-8abb-44e5d2f19d8c",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="0eb90790-c6a6-476e-b5cb-8b0c6a3e62f2",
+                                    data_source_identifier="70047607-9164-4e29-a1ea-296e36df4f20",
                                     data_source_feature="quantity mean",
                                 )
                             ]
@@ -3047,38 +2981,17 @@ def get_rel_std_curve_model() -> Model:
                         calculated_data_description=None,
                         calculated_datum=TQuantityValueUnitless(
                             value=0.798,
+                            unit="(unitless)",
+                            has_statistic_datum_role=None,
+                            field_type=None,
                         ),
                     ),
                     CalculatedDataDocumentItem(
-                        calculated_data_identifier="0eb90790-c6a6-476e-b5cb-8b0c6a3e62f2",
+                        calculated_data_identifier="84342a87-b7b4-4966-8066-663ab490adbb",
                         data_source_aggregate_document=DataSourceAggregateDocument(
                             data_source_document=[
                                 DataSourceDocumentItem(
-                                    data_source_identifier="94cf744d-d243-47bd-a723-aca6c6517af5",
-                                    data_source_feature="quantity",
-                                ),
-                                DataSourceDocumentItem(
-                                    data_source_identifier="51066bef-10b0-4782-a8c9-ee7383fe3256",
-                                    data_source_feature="quantity",
-                                ),
-                            ]
-                        ),
-                        data_processing_document=DataProcessingDocument1(
-                            reference_DNA_description="RNaseP",
-                            reference_sample_description="800",
-                        ),
-                        calculated_data_name="quantity mean",
-                        calculated_data_description=None,
-                        calculated_datum=TQuantityValueUnitless(
-                            value=818.012,
-                        ),
-                    ),
-                    CalculatedDataDocumentItem(
-                        calculated_data_identifier="d23ae1c4-e750-43eb-a6df-ed66d96bcd20",
-                        data_source_aggregate_document=DataSourceAggregateDocument(
-                            data_source_document=[
-                                DataSourceDocumentItem(
-                                    data_source_identifier="4606bf27-7d50-4ef0-a643-6d105b080057",
+                                    data_source_identifier="bfe26da2-72cb-411b-8abb-44e5d2f19d8c",
                                     data_source_feature="rq",
                                 )
                             ]
@@ -3091,6 +3004,9 @@ def get_rel_std_curve_model() -> Model:
                         calculated_data_description=None,
                         calculated_datum=TQuantityValueUnitless(
                             value=0.967,
+                            unit="(unitless)",
+                            has_statistic_datum_role=None,
+                            field_type=None,
                         ),
                     ),
                 ]

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example07.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example07.json
@@ -30854,7 +30854,7 @@
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy",
-            "ASM converter version": "0.1.20"
+            "ASM converter version": "0.1.29"
         },
         "calculated data aggregate document": {
             "calculated data document": [
@@ -31115,11 +31115,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_126",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_125",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_125",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31135,11 +31135,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_125",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_120",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -31155,75 +31155,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_126",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_60",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_61",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_62",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_72",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_73",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_74",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_84",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_85",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_86",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_96",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_97",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_98",
-                                "data source feature": "quantity"
-                            }
-                        ]
-                    },
-                    "data processing document": {
-                        "reference DNA description": "IPC",
-                        "reference sample description": "1000"
-                    },
-                    "calculated data name": "quantity mean",
-                    "calculated datum": {
-                        "value": 800.504,
-                        "unit": "(unitless)"
-                    }
-                },
-                {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_127",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_125",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_124",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31239,7 +31175,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_128",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_127",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31267,7 +31203,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_129",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_128",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31295,7 +31231,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_130",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_129",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31323,7 +31259,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_131",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_130",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31351,7 +31287,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_132",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_131",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31415,7 +31351,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_133",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_132",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31479,7 +31415,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_134",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_133",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31543,7 +31479,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_135",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_134",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31607,11 +31543,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_138",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_136",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_137",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_135",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31627,11 +31563,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_137",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_135",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_136",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_131",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -31647,75 +31583,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_136",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_137",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_63",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_64",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_65",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_75",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_76",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_77",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_87",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_88",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_89",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_99",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_100",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_101",
-                                "data source feature": "quantity"
-                            }
-                        ]
-                    },
-                    "data processing document": {
-                        "reference DNA description": "IPC",
-                        "reference sample description": "1000"
-                    },
-                    "calculated data name": "quantity mean",
-                    "calculated datum": {
-                        "value": 1631.007,
-                        "unit": "(unitless)"
-                    }
-                },
-                {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_139",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_137",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_135",
                                 "data source feature": "rq"
                             }
                         ]
@@ -31731,7 +31603,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_140",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_138",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31759,7 +31631,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_141",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_139",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31787,7 +31659,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_142",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_140",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31815,7 +31687,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_141",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31843,7 +31715,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_142",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31907,7 +31779,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_145",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_143",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -31971,7 +31843,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_144",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32035,7 +31907,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_147",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_145",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32099,11 +31971,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_150",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_147",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
                                 "data source feature": "rq"
                             }
                         ]
@@ -32119,11 +31991,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_148",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_142",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -32143,71 +32015,7 @@
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_66",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_67",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_68",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_78",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_79",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_80",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_90",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_91",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_92",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_102",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_103",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_104",
-                                "data source feature": "quantity"
-                            }
-                        ]
-                    },
-                    "data processing document": {
-                        "reference DNA description": "IPC",
-                        "reference sample description": "1000"
-                    },
-                    "calculated data name": "quantity mean",
-                    "calculated datum": {
-                        "value": 5060.228,
-                        "unit": "(unitless)"
-                    }
-                },
-                {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_151",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_146",
                                 "data source feature": "rq"
                             }
                         ]
@@ -32223,7 +32031,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_152",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_149",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32251,7 +32059,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_153",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_150",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32279,7 +32087,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_154",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_151",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32307,7 +32115,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_155",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_152",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32335,7 +32143,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_156",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_153",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32399,7 +32207,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_157",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_154",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32463,7 +32271,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_158",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_155",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32527,7 +32335,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_159",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_156",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32591,11 +32399,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_162",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_158",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_161",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_157",
                                 "data source feature": "rq"
                             }
                         ]
@@ -32611,11 +32419,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_161",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_157",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_160",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_153",
                                 "data source feature": "quantity mean"
                             }
                         ]
@@ -32631,75 +32439,11 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_160",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_159",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_69",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_70",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_71",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_81",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_82",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_83",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_93",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_94",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_95",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_105",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_106",
-                                "data source feature": "quantity"
-                            },
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_107",
-                                "data source feature": "quantity"
-                            }
-                        ]
-                    },
-                    "data processing document": {
-                        "reference DNA description": "IPC",
-                        "reference sample description": "1000"
-                    },
-                    "calculated data name": "quantity mean",
-                    "calculated datum": {
-                        "value": 987.538,
-                        "unit": "(unitless)"
-                    }
-                },
-                {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_163",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_161",
+                                "data source identifier": "APPBIO_QUANTSTUDIO_TEST_ID_157",
                                 "data source feature": "rq"
                             }
                         ]
@@ -32715,7 +32459,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_164",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_160",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32743,7 +32487,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_165",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_161",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32771,7 +32515,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_166",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_162",
                     "data source aggregate document": {
                         "data source document": [
                             {
@@ -32799,7 +32543,7 @@
                     }
                 },
                 {
-                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_167",
+                    "calculated data identifier": "APPBIO_QUANTSTUDIO_TEST_ID_163",
                     "data source aggregate document": {
                         "data source document": [
                             {


### PR DESCRIPTION
add cache to calculated data constructors in AppBio Quantstudio

This functions are design to generate a CalculatedData object each time they are called if the data they represent is available.

The CalculatedData object contains an uuid.

So, assuming the corresponding data is available, if the function is invoked two times with the same parameters, two CalculatedData objects will be created and their only difference would be the uuid.

With the cache decorator there would not be duplicated CalculatedData objects.

This PR modifies the tests because it removes the duplicated calculated documents that were present because of the previous absence of cache in these functions.