### PR TITLE
fix: use optical-imaging as default device type on gen5-image adapter

### DIFF
--- a/src/allotropy/parsers/agilent_gen5_image/agilent_gen5_image_parser.py
+++ b/src/allotropy/parsers/agilent_gen5_image/agilent_gen5_image_parser.py
@@ -35,6 +35,7 @@ from allotropy.parsers.agilent_gen5_image.agilent_gen5_image_structure import (
 )
 from allotropy.parsers.agilent_gen5_image.constants import (
     DEFAULT_SOFTWARE_NAME,
+    DETECTION_TYPE,
     DEVICE_TYPE,
     MULTIPLATE_FILE_ERROR,
     NO_PLATE_DATA_ERROR,
@@ -173,7 +174,7 @@ class AgilentGen5ImageParser(VendorParser):
                             device_control_document=[
                                 OpticalImagingDeviceControlDocumentItem(
                                     device_type=DEVICE_TYPE,
-                                    detection_type=read_section.image_mode.value,
+                                    detection_type=DETECTION_TYPE,
                                     # This setting won't get reported at the moment since Gen5 only reports it
                                     # in micrometers and we don't do conversions on the adapters at the moment
                                     # detector_distance_setting__plate_reader_=get_instance_or_none(

--- a/src/allotropy/parsers/agilent_gen5_image/constants.py
+++ b/src/allotropy/parsers/agilent_gen5_image/constants.py
@@ -25,6 +25,7 @@ HEADER_PREFIXES = frozenset(
 
 DEFAULT_SOFTWARE_NAME = "Gen5 Image"
 DEVICE_TYPE = "Imager"
+DETECTION_TYPE = "optical-imaging"
 
 AUTOFOCUS_STRINGS = frozenset(
     {

--- a/tests/parsers/agilent_gen5_image/testdata/96-Well Trevigen CometAssayCometChip Imaging and Analysis Sample File 23Nov15.json
+++ b/tests/parsers/agilent_gen5_image/testdata/96-Well Trevigen CometAssayCometChip Imaging and Analysis Sample File 23Nov15.json
@@ -16,7 +16,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -55,7 +55,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -251,7 +251,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -290,7 +290,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -486,7 +486,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -525,7 +525,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -721,7 +721,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -760,7 +760,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -956,7 +956,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -995,7 +995,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1191,7 +1191,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1230,7 +1230,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1426,7 +1426,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1465,7 +1465,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1661,7 +1661,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1700,7 +1700,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1896,7 +1896,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1935,7 +1935,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2131,7 +2131,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2170,7 +2170,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2366,7 +2366,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2405,7 +2405,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2601,7 +2601,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2640,7 +2640,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2836,7 +2836,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2875,7 +2875,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3071,7 +3071,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3110,7 +3110,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3306,7 +3306,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3345,7 +3345,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3541,7 +3541,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3580,7 +3580,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3776,7 +3776,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3815,7 +3815,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4011,7 +4011,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4050,7 +4050,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4246,7 +4246,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4285,7 +4285,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4481,7 +4481,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4520,7 +4520,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4716,7 +4716,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4755,7 +4755,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4951,7 +4951,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4990,7 +4990,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5186,7 +5186,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5225,7 +5225,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5421,7 +5421,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5460,7 +5460,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5656,7 +5656,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5695,7 +5695,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5891,7 +5891,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5930,7 +5930,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6126,7 +6126,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6165,7 +6165,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6361,7 +6361,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6400,7 +6400,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6596,7 +6596,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6635,7 +6635,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6831,7 +6831,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6870,7 +6870,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7066,7 +7066,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7105,7 +7105,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7301,7 +7301,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7340,7 +7340,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7536,7 +7536,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7575,7 +7575,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7771,7 +7771,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7810,7 +7810,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8006,7 +8006,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8045,7 +8045,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8241,7 +8241,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8280,7 +8280,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8476,7 +8476,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8515,7 +8515,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8711,7 +8711,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8750,7 +8750,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8946,7 +8946,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8985,7 +8985,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9181,7 +9181,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9220,7 +9220,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9416,7 +9416,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9455,7 +9455,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9651,7 +9651,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9690,7 +9690,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9886,7 +9886,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9925,7 +9925,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10121,7 +10121,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10160,7 +10160,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10356,7 +10356,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10395,7 +10395,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10591,7 +10591,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10630,7 +10630,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10826,7 +10826,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10865,7 +10865,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11061,7 +11061,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11100,7 +11100,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11296,7 +11296,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11335,7 +11335,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11531,7 +11531,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11570,7 +11570,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11766,7 +11766,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11805,7 +11805,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12001,7 +12001,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12040,7 +12040,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12236,7 +12236,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12275,7 +12275,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12471,7 +12471,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12510,7 +12510,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12706,7 +12706,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12745,7 +12745,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12941,7 +12941,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12980,7 +12980,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13176,7 +13176,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13215,7 +13215,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13411,7 +13411,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13450,7 +13450,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13646,7 +13646,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13685,7 +13685,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13881,7 +13881,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13920,7 +13920,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14116,7 +14116,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14155,7 +14155,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14351,7 +14351,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14390,7 +14390,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14586,7 +14586,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14625,7 +14625,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14821,7 +14821,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14860,7 +14860,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15056,7 +15056,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15095,7 +15095,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15291,7 +15291,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15330,7 +15330,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15526,7 +15526,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15565,7 +15565,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15761,7 +15761,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15800,7 +15800,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15996,7 +15996,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16035,7 +16035,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16231,7 +16231,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16270,7 +16270,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16466,7 +16466,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16505,7 +16505,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16701,7 +16701,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16740,7 +16740,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16936,7 +16936,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16975,7 +16975,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -17171,7 +17171,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -17210,7 +17210,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -17406,7 +17406,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -17445,7 +17445,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -17641,7 +17641,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -17680,7 +17680,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -17876,7 +17876,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -17915,7 +17915,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -18111,7 +18111,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -18150,7 +18150,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -18346,7 +18346,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -18385,7 +18385,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -18581,7 +18581,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -18620,7 +18620,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -18816,7 +18816,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -18855,7 +18855,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -19051,7 +19051,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -19090,7 +19090,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -19286,7 +19286,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -19325,7 +19325,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -19521,7 +19521,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -19560,7 +19560,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -19756,7 +19756,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -19795,7 +19795,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -19991,7 +19991,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -20030,7 +20030,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -20226,7 +20226,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -20265,7 +20265,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -20461,7 +20461,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -20500,7 +20500,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -20696,7 +20696,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -20735,7 +20735,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -20931,7 +20931,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -20970,7 +20970,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -21166,7 +21166,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -21205,7 +21205,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -21401,7 +21401,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -21440,7 +21440,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -21636,7 +21636,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -21675,7 +21675,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -21871,7 +21871,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -21910,7 +21910,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -22106,7 +22106,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -22145,7 +22145,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -22341,7 +22341,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "0",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -22380,7 +22380,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "1",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -22573,7 +22573,7 @@
             "software name": "Gen5 Image",
             "software version": "3.12.08",
             "ASM converter name": "allotropy",
-            "ASM converter version": "0.1.29"
+            "ASM converter version": "0.1.30"
         }
     }
 }

--- a/tests/parsers/agilent_gen5_image/testdata/Cell_Count_DAPI_GFP.json
+++ b/tests/parsers/agilent_gen5_image/testdata/Cell_Count_DAPI_GFP.json
@@ -16,7 +16,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -59,7 +59,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -191,7 +191,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -234,7 +234,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -366,7 +366,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -409,7 +409,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -541,7 +541,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -584,7 +584,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -716,7 +716,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -759,7 +759,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -891,7 +891,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -934,7 +934,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1066,7 +1066,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -1109,7 +1109,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1241,7 +1241,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -1284,7 +1284,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1416,7 +1416,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -1459,7 +1459,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1591,7 +1591,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -1634,7 +1634,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1766,7 +1766,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -1809,7 +1809,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -1941,7 +1941,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -1984,7 +1984,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2116,7 +2116,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -2159,7 +2159,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2291,7 +2291,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -2334,7 +2334,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2466,7 +2466,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -2509,7 +2509,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2641,7 +2641,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -2684,7 +2684,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2816,7 +2816,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -2859,7 +2859,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -2991,7 +2991,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -3034,7 +3034,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3166,7 +3166,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -3209,7 +3209,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3341,7 +3341,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -3384,7 +3384,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3516,7 +3516,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -3559,7 +3559,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3691,7 +3691,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -3734,7 +3734,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -3866,7 +3866,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -3909,7 +3909,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4041,7 +4041,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -4084,7 +4084,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4216,7 +4216,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -4259,7 +4259,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4391,7 +4391,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -4434,7 +4434,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4566,7 +4566,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -4609,7 +4609,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4741,7 +4741,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -4784,7 +4784,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -4916,7 +4916,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -4959,7 +4959,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5091,7 +5091,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -5134,7 +5134,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5266,7 +5266,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -5309,7 +5309,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5441,7 +5441,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -5484,7 +5484,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5616,7 +5616,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -5659,7 +5659,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5791,7 +5791,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -5834,7 +5834,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -5966,7 +5966,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -6009,7 +6009,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6141,7 +6141,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -6184,7 +6184,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6316,7 +6316,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -6359,7 +6359,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6491,7 +6491,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -6534,7 +6534,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6666,7 +6666,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -6709,7 +6709,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -6841,7 +6841,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -6884,7 +6884,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7016,7 +7016,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -7059,7 +7059,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7191,7 +7191,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -7234,7 +7234,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7366,7 +7366,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -7409,7 +7409,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7541,7 +7541,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -7584,7 +7584,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7716,7 +7716,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -7759,7 +7759,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -7891,7 +7891,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -7934,7 +7934,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8066,7 +8066,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -8109,7 +8109,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8241,7 +8241,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -8284,7 +8284,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8416,7 +8416,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -8459,7 +8459,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8591,7 +8591,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -8634,7 +8634,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8766,7 +8766,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -8809,7 +8809,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -8941,7 +8941,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -8984,7 +8984,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9116,7 +9116,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -9159,7 +9159,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9291,7 +9291,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -9334,7 +9334,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9466,7 +9466,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -9509,7 +9509,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9641,7 +9641,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -9684,7 +9684,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9816,7 +9816,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -9859,7 +9859,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -9991,7 +9991,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -10034,7 +10034,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10166,7 +10166,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -10209,7 +10209,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10341,7 +10341,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -10384,7 +10384,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10516,7 +10516,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -10559,7 +10559,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10691,7 +10691,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -10734,7 +10734,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -10866,7 +10866,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -10909,7 +10909,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11041,7 +11041,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -11084,7 +11084,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11216,7 +11216,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -11259,7 +11259,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11391,7 +11391,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -11434,7 +11434,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11566,7 +11566,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -11609,7 +11609,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11741,7 +11741,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -11784,7 +11784,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -11916,7 +11916,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -11959,7 +11959,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12091,7 +12091,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -12134,7 +12134,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12266,7 +12266,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -12309,7 +12309,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12441,7 +12441,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -12484,7 +12484,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12616,7 +12616,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -12659,7 +12659,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12791,7 +12791,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -12834,7 +12834,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -12966,7 +12966,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -13009,7 +13009,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13141,7 +13141,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -13184,7 +13184,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13316,7 +13316,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -13359,7 +13359,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13491,7 +13491,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -13534,7 +13534,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13666,7 +13666,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -13709,7 +13709,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -13841,7 +13841,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -13884,7 +13884,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14016,7 +14016,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -14059,7 +14059,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14191,7 +14191,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -14234,7 +14234,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14366,7 +14366,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -14409,7 +14409,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14541,7 +14541,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -14584,7 +14584,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14716,7 +14716,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -14759,7 +14759,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -14891,7 +14891,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -14934,7 +14934,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15066,7 +15066,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -15109,7 +15109,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15241,7 +15241,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -15284,7 +15284,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15416,7 +15416,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -15459,7 +15459,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15591,7 +15591,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -15634,7 +15634,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15766,7 +15766,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -15809,7 +15809,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -15941,7 +15941,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -15984,7 +15984,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16116,7 +16116,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -16159,7 +16159,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16291,7 +16291,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -16334,7 +16334,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16466,7 +16466,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -16509,7 +16509,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16641,7 +16641,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 377.0,
@@ -16684,7 +16684,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Montage",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "24",
                                         "excitation wavelength setting": {
                                             "value": 469.0,
@@ -16813,7 +16813,7 @@
             "software name": "Gen5 Image",
             "software version": "3.12.08",
             "ASM converter name": "allotropy",
-            "ASM converter version": "0.1.29"
+            "ASM converter version": "0.1.30"
         }
     }
 }

--- a/tests/parsers/agilent_gen5_image/testdata/HeLa 96well Colony 11pt Doxorubicin UprBF_TAB.json
+++ b/tests/parsers/agilent_gen5_image/testdata/HeLa 96well Colony 11pt Doxorubicin UprBF_TAB.json
@@ -16,7 +16,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -143,7 +143,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -270,7 +270,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -397,7 +397,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -524,7 +524,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -651,7 +651,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -778,7 +778,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -905,7 +905,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -1032,7 +1032,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -1159,7 +1159,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -1286,7 +1286,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -1413,7 +1413,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -1540,7 +1540,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -1667,7 +1667,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -1794,7 +1794,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -1921,7 +1921,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -2048,7 +2048,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -2175,7 +2175,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -2302,7 +2302,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -2429,7 +2429,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -2556,7 +2556,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -2683,7 +2683,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -2810,7 +2810,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -2937,7 +2937,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -3064,7 +3064,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -3191,7 +3191,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -3318,7 +3318,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -3445,7 +3445,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -3572,7 +3572,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -3699,7 +3699,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -3826,7 +3826,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -3953,7 +3953,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -4080,7 +4080,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -4207,7 +4207,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -4334,7 +4334,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -4461,7 +4461,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -4588,7 +4588,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -4715,7 +4715,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -4842,7 +4842,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -4969,7 +4969,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -5096,7 +5096,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -5223,7 +5223,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -5350,7 +5350,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -5477,7 +5477,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -5604,7 +5604,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -5731,7 +5731,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -5858,7 +5858,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -5985,7 +5985,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -6112,7 +6112,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -6239,7 +6239,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -6366,7 +6366,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -6493,7 +6493,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -6620,7 +6620,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -6747,7 +6747,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -6874,7 +6874,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -7001,7 +7001,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -7128,7 +7128,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -7255,7 +7255,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -7382,7 +7382,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -7509,7 +7509,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -7636,7 +7636,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -7763,7 +7763,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -7890,7 +7890,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -8017,7 +8017,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -8144,7 +8144,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -8271,7 +8271,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -8398,7 +8398,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -8525,7 +8525,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -8652,7 +8652,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -8779,7 +8779,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -8906,7 +8906,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -9033,7 +9033,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -9160,7 +9160,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -9287,7 +9287,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -9414,7 +9414,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -9541,7 +9541,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -9668,7 +9668,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -9795,7 +9795,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -9922,7 +9922,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -10049,7 +10049,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -10176,7 +10176,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -10303,7 +10303,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -10430,7 +10430,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -10557,7 +10557,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -10684,7 +10684,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -10811,7 +10811,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -10938,7 +10938,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -11065,7 +11065,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -11192,7 +11192,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -11319,7 +11319,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -11446,7 +11446,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -11573,7 +11573,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -11700,7 +11700,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -11827,7 +11827,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -11954,7 +11954,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,
@@ -12081,7 +12081,7 @@
                                 "device control document": [
                                     {
                                         "device type": "Imager",
-                                        "detection type": "Image Single Image",
+                                        "detection type": "optical-imaging",
                                         "detector gain setting": "5",
                                         "magnification setting": {
                                             "value": 2.0,


### PR DESCRIPTION
Use optical-imaging as default device type on gen5-image adapter