### PR TITLE
chore: add CTL ImmunoSpot and Gen5 image to available adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ We have chosen to have this library output ASM since JSON is easy to read and co
 
 We currently have parser support for the following instruments:
   - Agilent Gen5
+  - Agilent Gen5 Image
   - Applied Bio AbsoluteQ
   - Applied Bio QuantStudio RT-PCR
   - Applied Bio QuantStudio Design & Analysis
@@ -19,6 +20,7 @@ We currently have parser support for the following instruments:
   - Beckman PharmSpec
   - Bio-Rad Bio-Plex Manager
   - ChemoMetec Nucleoview
+  - CTL ImmunoSpot
   - Luminex xPONENT
   - Molecular Devices SoftMax Pro
   - NovaBio Flex2


### PR DESCRIPTION
Add `CTL ImmunoSpot` and `Agilent Gen5 Image` to list of available adapters
