### PR TITLE
feat: Add library function to allow adding a CustomInformationDocument to an ASM model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added utility to add a custom information document to an ASM model
+
 ### Fixed
 
 - Updated schema cleaner to handle utf-8 characters in unit schema urls

--- a/src/allotropy/allotrope/converter.py
+++ b/src/allotropy/allotrope/converter.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import fields, is_dataclass, make_dataclass
+from dataclasses import asdict, fields, is_dataclass, make_dataclass
 from types import UnionType
-from typing import Any, Callable, cast, get_args, get_origin, Union
+from typing import Any, Callable, cast, get_args, get_origin, TypeVar, Union
 
 from cattrs import Converter
 from cattrs.errors import ClassValidationError
@@ -88,6 +88,15 @@ PRIMITIVE_TYPES = (
     np.float64,
     np.int64,
 )
+
+ModelClass = TypeVar("ModelClass")
+
+
+def add_custom_information_document(
+    model: ModelClass, custom_info_doc: dict[str, Any]
+) -> ModelClass:
+    model.custom_information_document = structure_custom_information_document(custom_info_doc, "custom information document")  # type: ignore
+    return model
 
 
 def _convert_model_key_to_dict_key(key: str) -> str:
@@ -282,11 +291,16 @@ def register_unstructure_hooks(converter: Converter) -> None:
             if not is_dataclass(obj):
                 return converter.unstructure(obj)
 
-            return {
+            dataclass_dict = {
                 _convert_model_key_to_dict_key(k): v
                 for k, v in make_unstructure_fn(type(obj))(obj).items()
                 if not should_omit(k, v)
             }
+            if hasattr(obj, "custom_information_document"):
+                dataclass_dict["custom information document"] = asdict(
+                    obj.custom_information_document
+                )
+            return dataclass_dict
 
         # This custom unstructure function overrides the unstruct_hook when we should should_allow_empty_value_field.
         # We need to do this at this level because we need to know both the parent class and the field name at the

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
@@ -49,8 +49,8 @@ class ExampleWeylandYutaniParser(VendorParser):
             raise AllotropeConversionError(msg)
 
         custom_info = {
-            "peak amount": {"value": 10, "unit": "mL"},
-            "peak calibration coefficient 0": 1.0,
+            "custom value": {"value": 10, "unit": "mL"},
+            "custom metadata": "Some extra piece of info",
         }
         return Model(
             measurement_aggregate_document=add_custom_information_document(

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
@@ -1,3 +1,4 @@
+from allotropy.allotrope.converter import add_custom_information_document
 from allotropy.allotrope.models.adm.fluorescence.benchling._2023._09.fluorescence import (
     ContainerType,
     DeviceControlAggregateDocument,
@@ -47,19 +48,26 @@ class ExampleWeylandYutaniParser(VendorParser):
             msg = "Unable to determine the number of wells in the plate."
             raise AllotropeConversionError(msg)
 
+        custom_info = {
+            "peak amount": {"value": 10, "unit": "mL"},
+            "peak calibration coefficient 0": 1.0,
+        }
         return Model(
-            measurement_aggregate_document=MeasurementAggregateDocument(
-                measurement_identifier=random_uuid_str(),
-                measurement_time=self._get_measurement_time(data),
-                analytical_method_identifier=data.basic_assay_info.protocol_id,
-                experimental_data_identifier=data.basic_assay_info.assay_id,
-                container_type=ContainerType.well_plate,
-                plate_well_count=TQuantityValueNumber(value=data.number_of_wells),
-                device_system_document=DeviceSystemDocument(
-                    model_number=data.instrument.serial_number,
-                    device_identifier=data.instrument.nickname,
+            measurement_aggregate_document=add_custom_information_document(
+                MeasurementAggregateDocument(
+                    measurement_identifier=random_uuid_str(),
+                    measurement_time=self._get_measurement_time(data),
+                    analytical_method_identifier=data.basic_assay_info.protocol_id,
+                    experimental_data_identifier=data.basic_assay_info.assay_id,
+                    container_type=ContainerType.well_plate,
+                    plate_well_count=TQuantityValueNumber(value=data.number_of_wells),
+                    device_system_document=DeviceSystemDocument(
+                        model_number=data.instrument.serial_number,
+                        device_identifier=data.instrument.nickname,
+                    ),
+                    measurement_document=self._get_measurement_document(data),
                 ),
-                measurement_document=self._get_measurement_document(data),
+                custom_info,
             )
         )
 

--- a/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_checksum_correct.json
+++ b/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_checksum_correct.json
@@ -1,4 +1,5 @@
 {
+    "$asm.manifest": "http://purl.allotrope.org/manifests/fluorescence/BENCHLING/2023/09/fluorescence.manifest",
     "measurement aggregate document": {
         "measurement identifier": "EXAMPLE_WEYLAND_YUTANI_TEST_ID_0",
         "plate well count": {
@@ -334,7 +335,13 @@
         "device system document": {
             "device identifier": "",
             "model number": ""
+        },
+        "custom information document": {
+            "peak_amount": {
+                "value": 10,
+                "unit": "mL"
+            },
+            "peak_calibration_coefficient_0": 1.0
         }
-    },
-    "$asm.manifest": "http://purl.allotrope.org/manifests/fluorescence/BENCHLING/2023/09/fluorescence.manifest"
+    }
 }

--- a/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_checksum_correct.json
+++ b/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_checksum_correct.json
@@ -337,11 +337,11 @@
             "model number": ""
         },
         "custom information document": {
-            "peak_amount": {
+            "custom_value": {
                 "value": 10,
                 "unit": "mL"
             },
-            "peak_calibration_coefficient_0": 1.0
+            "custom_metadata": "Some extra piece of info"
         }
     }
 }

--- a/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_simple_correct.json
+++ b/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_simple_correct.json
@@ -1,4 +1,5 @@
 {
+    "$asm.manifest": "http://purl.allotrope.org/manifests/fluorescence/BENCHLING/2023/09/fluorescence.manifest",
     "measurement aggregate document": {
         "measurement identifier": "EXAMPLE_WEYLAND_YUTANI_TEST_ID_0",
         "plate well count": {
@@ -334,7 +335,13 @@
         "device system document": {
             "device identifier": "",
             "model number": ""
+        },
+        "custom information document": {
+            "peak_amount": {
+                "value": 10,
+                "unit": "mL"
+            },
+            "peak_calibration_coefficient_0": 1.0
         }
-    },
-    "$asm.manifest": "http://purl.allotrope.org/manifests/fluorescence/BENCHLING/2023/09/fluorescence.manifest"
+    }
 }

--- a/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_simple_correct.json
+++ b/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_simple_correct.json
@@ -337,11 +337,11 @@
             "model number": ""
         },
         "custom information document": {
-            "peak_amount": {
+            "custom_value": {
                 "value": 10,
                 "unit": "mL"
             },
-            "peak_calibration_coefficient_0": 1.0
+            "custom_metadata": "Some extra piece of info"
         }
     }
 }


### PR DESCRIPTION
`CustomInformationDocument` allows us to attach extra information that is not currently represented in the ASM schema.

The converter library already has a utility for serializing `CustomInformationDocument`, but there was no utility for adding a one to a model.

This PR adds that function, along with an example usage in `ExampleWeylandYutaniParser`.