### PR TITLE
feat: Add ability to add custom dataclasses as custom information document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added utility to add a custom information document to an ASM model
+- Added utility to add both dict and dataclass custom information document to an ASM model
 
 ### Fixed
 

--- a/src/allotropy/allotrope/converter.py
+++ b/src/allotropy/allotrope/converter.py
@@ -93,9 +93,15 @@ ModelClass = TypeVar("ModelClass")
 
 
 def add_custom_information_document(
-    model: ModelClass, custom_info_doc: dict[str, Any]
+    model: ModelClass, custom_info_doc: Any
 ) -> ModelClass:
-    model.custom_information_document = structure_custom_information_document(custom_info_doc, "custom information document")  # type: ignore
+    if isinstance(custom_info_doc, dict):
+        model.custom_information_document = structure_custom_information_document(custom_info_doc, "custom information document")  # type: ignore
+    elif is_dataclass(custom_info_doc):
+        model.custom_information_document = custom_info_doc
+    else:
+        msg = "Invalid custom_info_doc"
+        raise ValueError(msg)
     return model
 
 

--- a/src/allotropy/allotrope/converter.py
+++ b/src/allotropy/allotrope/converter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict, fields, is_dataclass, make_dataclass
 from types import UnionType
 from typing import Any, Callable, cast, get_args, get_origin, TypeVar, Union
@@ -95,13 +95,15 @@ ModelClass = TypeVar("ModelClass")
 def add_custom_information_document(
     model: ModelClass, custom_info_doc: Any
 ) -> ModelClass:
+
     if isinstance(custom_info_doc, dict):
-        model.custom_information_document = structure_custom_information_document(custom_info_doc, "custom information document")  # type: ignore
-    elif is_dataclass(custom_info_doc):
-        model.custom_information_document = custom_info_doc
-    else:
+        custom_info_doc = structure_custom_information_document(
+            custom_info_doc, "custom information document"
+        )
+    if not is_dataclass(custom_info_doc):
         msg = "Invalid custom_info_doc"
         raise ValueError(msg)
+    model.custom_information_document = custom_info_doc  # type: ignore
     return model
 
 
@@ -214,6 +216,22 @@ def structure_custom_information_document(val: dict[str, Any], name: str) -> Any
     )
 
 
+# Special should_omit check for allowing an empty value for 'value' keys, controlled by should_allow_empty_value_field
+def should_omit_allow_empty_value_field(k: str, v: Any) -> bool:
+    return v is None and k != "value"
+
+
+def unstructure_custom_information_document(model: Any) -> dict[str, Any]:
+    def dict_factory(kv_pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
+        return {
+            _convert_model_key_to_dict_key(key): value
+            for key, value in kv_pairs
+            if not should_omit_allow_empty_value_field(key, value)
+        }
+
+    return asdict(model, dict_factory=dict_factory)
+
+
 def register_dataclass_hooks(converter: Converter) -> None:
     def dataclass_structure_fn(cls: Any) -> Callable[[Any, Any], Any | None]:
         structure_fn = make_dict_structure_fn(
@@ -283,10 +301,6 @@ def register_unstructure_hooks(converter: Converter) -> None:
     def should_omit(_: str, v: Any) -> bool:
         return v is None
 
-    # Special should_omit check for allowing an empty value for 'value' keys, controlled by should_allow_empty_value_field
-    def should_omit_allow_empty_value_field(k: str, v: Any) -> bool:
-        return v is None and k != "value"
-
     unstructure_fn_cache = {}
 
     def unstructure_dataclass_fn(
@@ -303,7 +317,9 @@ def register_unstructure_hooks(converter: Converter) -> None:
                 if not should_omit(k, v)
             }
             if hasattr(obj, "custom_information_document"):
-                dataclass_dict["custom information document"] = asdict(
+                dataclass_dict[
+                    "custom information document"
+                ] = unstructure_custom_information_document(
                     obj.custom_information_document
                 )
             return dataclass_dict

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from allotropy.allotrope.converter import add_custom_information_document
 from allotropy.allotrope.models.adm.fluorescence.benchling._2023._09.fluorescence import (
     ContainerType,
@@ -26,6 +28,12 @@ from allotropy.parsers.lines_reader import CsvReader, read_to_lines
 from allotropy.parsers.release_state import ReleaseState
 from allotropy.parsers.utils.uuids import random_uuid_str
 from allotropy.parsers.vendor_parser import VendorParser
+
+
+@dataclass(kw_only=True)
+class MyCustomInfoDoc:
+    extra_information: str
+    extra_value: TQuantityValueNumber
 
 
 class ExampleWeylandYutaniParser(VendorParser):
@@ -61,9 +69,15 @@ class ExampleWeylandYutaniParser(VendorParser):
                     experimental_data_identifier=data.basic_assay_info.assay_id,
                     container_type=ContainerType.well_plate,
                     plate_well_count=TQuantityValueNumber(value=data.number_of_wells),
-                    device_system_document=DeviceSystemDocument(
-                        model_number=data.instrument.serial_number,
-                        device_identifier=data.instrument.nickname,
+                    device_system_document=add_custom_information_document(
+                        DeviceSystemDocument(
+                            model_number=data.instrument.serial_number,
+                            device_identifier=data.instrument.nickname,
+                        ),
+                        MyCustomInfoDoc(
+                            extra_information="My extra information",
+                            extra_value=TQuantityValueNumber(value=100),
+                        ),
                     ),
                     measurement_document=self._get_measurement_document(data),
                 ),

--- a/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_checksum_correct.json
+++ b/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_checksum_correct.json
@@ -336,21 +336,19 @@
             "device identifier": "",
             "model number": "",
             "custom information document": {
-                "extra_information": "My extra information",
-                "extra_value": {
+                "extra information": "My extra information",
+                "extra value": {
                     "value": 100,
-                    "unit": "#",
-                    "has_statistic_datum_role": null,
-                    "field_type": null
+                    "unit": "#"
                 }
             }
         },
         "custom information document": {
-            "custom_value": {
+            "custom value": {
                 "value": 10,
                 "unit": "mL"
             },
-            "custom_metadata": "Some extra piece of info"
+            "custom metadata": "Some extra piece of info"
         }
     }
 }

--- a/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_checksum_correct.json
+++ b/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_checksum_correct.json
@@ -334,7 +334,16 @@
         "container type": "well plate",
         "device system document": {
             "device identifier": "",
-            "model number": ""
+            "model number": "",
+            "custom information document": {
+                "extra_information": "My extra information",
+                "extra_value": {
+                    "value": 100,
+                    "unit": "#",
+                    "has_statistic_datum_role": null,
+                    "field_type": null
+                }
+            }
         },
         "custom information document": {
             "custom_value": {

--- a/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_simple_correct.json
+++ b/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_simple_correct.json
@@ -336,21 +336,19 @@
             "device identifier": "",
             "model number": "",
             "custom information document": {
-                "extra_information": "My extra information",
-                "extra_value": {
+                "extra information": "My extra information",
+                "extra value": {
                     "value": 100,
-                    "unit": "#",
-                    "has_statistic_datum_role": null,
-                    "field_type": null
+                    "unit": "#"
                 }
             }
         },
         "custom information document": {
-            "custom_value": {
+            "custom value": {
                 "value": 10,
                 "unit": "mL"
             },
-            "custom_metadata": "Some extra piece of info"
+            "custom metadata": "Some extra piece of info"
         }
     }
 }

--- a/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_simple_correct.json
+++ b/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_simple_correct.json
@@ -334,7 +334,16 @@
         "container type": "well plate",
         "device system document": {
             "device identifier": "",
-            "model number": ""
+            "model number": "",
+            "custom information document": {
+                "extra_information": "My extra information",
+                "extra_value": {
+                    "value": 100,
+                    "unit": "#",
+                    "has_statistic_datum_role": null,
+                    "field_type": null
+                }
+            }
         },
         "custom information document": {
             "custom_value": {


### PR DESCRIPTION
The first addition allowed adding a dictionary of extra information as a custom information document.

This change allows adding a custom dataclass as a custom information document, making for cleaner code.

Also fixes a bug in the original where dict key names were having underscores removed.