### PR TITLE
test: Allow test util to write new test output and improve error messages

### DIFF
--- a/src/allotropy/testing/utils.py
+++ b/src/allotropy/testing/utils.py
@@ -82,7 +82,6 @@ def _validate_identifiers(asm: DictType) -> None:
 def _assert_allotrope_dicts_equal(
     expected: DictType,
     actual: DictType,
-    print_verbose_deep_diff: bool = False,  # noqa: FBT001, FBT002
 ) -> None:
     expected_replaced = _replace_asm_converter_name_and_version(expected)
 
@@ -92,9 +91,9 @@ def _assert_allotrope_dicts_equal(
         ignore_type_in_groups=[(float, np.float64)],
         ignore_nan_inequality=True,
     )
-    if print_verbose_deep_diff:
-        print(ddiff)  # noqa: T201
-    assert not ddiff  # noqa: S101
+    if ddiff:
+        msg = f"allotropy output != expected: \n{ddiff.pretty()}"
+        raise AssertionError(msg)
 
 
 class TestIdGenerator:
@@ -138,7 +137,6 @@ def validate_contents(
     allotrope_dict: DictType,
     expected_file: str,
     write_actual_to_expected_on_fail: bool = False,  # noqa: FBT001, FBT002
-    print_verbose_deep_diff: bool = False,  # noqa: FBT001, FBT002
 ) -> None:
     """Use the newly created allotrope_dict to validate the contents inside expected_file."""
     # Ensure that allotrope_dict can be written via json.dump()
@@ -155,9 +153,15 @@ def validate_contents(
         with open(expected_file) as f:
             expected_dict = json.load(f)
         _assert_allotrope_dicts_equal(
-            expected_dict, allotrope_dict, print_verbose_deep_diff
+            expected_dict, allotrope_dict
         )
-    except Exception:
+    except Exception as e:
         if write_actual_to_expected_on_fail:
             _write_actual_to_expected(allotrope_dict, expected_file)
+            if isinstance(e, FileNotFoundError):
+                msg = f"Missing expected output file '{expected_file}', writing expected output because 'write_actual_to_expected_on_fail=True'"
+                raise AssertionError(msg) from e
+            if isinstance(e, AssertionError) and "allotropy output != expected:" in str(e):
+                msg = f"Mismatch between actual and expected for '{expected_file}', writing expected output because 'write_actual_to_expected_on_fail=True'\n\n{e}"
+                raise AssertionError(msg) from e
         raise

--- a/src/allotropy/testing/utils.py
+++ b/src/allotropy/testing/utils.py
@@ -152,16 +152,16 @@ def validate_contents(
     try:
         with open(expected_file) as f:
             expected_dict = json.load(f)
-        _assert_allotrope_dicts_equal(
-            expected_dict, allotrope_dict
-        )
+        _assert_allotrope_dicts_equal(expected_dict, allotrope_dict)
     except Exception as e:
         if write_actual_to_expected_on_fail:
             _write_actual_to_expected(allotrope_dict, expected_file)
             if isinstance(e, FileNotFoundError):
                 msg = f"Missing expected output file '{expected_file}', writing expected output because 'write_actual_to_expected_on_fail=True'"
                 raise AssertionError(msg) from e
-            if isinstance(e, AssertionError) and "allotropy output != expected:" in str(e):
+            if isinstance(e, AssertionError) and "allotropy output != expected:" in str(
+                e
+            ):
                 msg = f"Mismatch between actual and expected for '{expected_file}', writing expected output because 'write_actual_to_expected_on_fail=True'\n\n{e}"
                 raise AssertionError(msg) from e
         raise

--- a/src/allotropy/testing/utils.py
+++ b/src/allotropy/testing/utils.py
@@ -141,9 +141,6 @@ def validate_contents(
     print_verbose_deep_diff: bool = False,  # noqa: FBT001, FBT002
 ) -> None:
     """Use the newly created allotrope_dict to validate the contents inside expected_file."""
-    with open(expected_file) as f:
-        expected_dict = json.load(f)
-
     # Ensure that allotrope_dict can be written via json.dump()
     with tempfile.TemporaryFile(mode="w+") as tmp:
         json.dump(allotrope_dict, tmp)
@@ -155,6 +152,8 @@ def validate_contents(
     _validate_identifiers(allotrope_dict)
 
     try:
+        with open(expected_file) as f:
+            expected_dict = json.load(f)
         _assert_allotrope_dicts_equal(
             expected_dict, allotrope_dict, print_verbose_deep_diff
         )

--- a/tests/parsers/biorad_bioplex_manager/biorad_bioplex_manager_parser_test.py
+++ b/tests/parsers/biorad_bioplex_manager/biorad_bioplex_manager_parser_test.py
@@ -14,9 +14,4 @@ def test_parse_biorad_bioplex_to_asm_contents(output_file: str) -> None:
     test_filepath = f"tests/parsers/biorad_bioplex_manager/testdata/{output_file}"
     expected_filepath = test_filepath.replace(".xml", ".json")
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE, encoding="UTF-8")
-    validate_contents(
-        allotrope_dict=allotrope_dict,
-        expected_file=expected_filepath,
-        write_actual_to_expected_on_fail=False,
-        print_verbose_deep_diff=False,
-    )
+    validate_contents(allotrope_dict=allotrope_dict, expected_file=expected_filepath)

--- a/tests/parsers/methodical_mind/methodical_mind_parser_test.py
+++ b/tests/parsers/methodical_mind/methodical_mind_parser_test.py
@@ -17,9 +17,4 @@ def test_parse_biorad_bioplex_to_asm_contents(output_file: str) -> None:
     test_filepath = f"tests/parsers/methodical_mind/testdata/{output_file}"
     expected_filepath = test_filepath.replace(".txt", ".json")
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
-    validate_contents(
-        allotrope_dict=allotrope_dict,
-        expected_file=expected_filepath,
-        write_actual_to_expected_on_fail=False,
-        print_verbose_deep_diff=False,
-    )
+    validate_contents(allotrope_dict=allotrope_dict, expected_file=expected_filepath)


### PR DESCRIPTION
This PR makes a couple upgrades to test_util:

- Allow writing a missing test file if `write_actual_to_expected_on_fail=True`. The standard way we add new test cases it to turn on `write_actual_to_expected_on_fail` and run to generate the test output. But, before you had to make a dummy file or the test util would fail due to the missing file. Fix that.
- Improve test util error messages:
    - When overwriting file, write a helpful message
    - Use DeepDiff.pretty() to write human readable messages for deepdiff
    - Remove optional verbose message now that error is more readable.