### PR TITLE
feat: Update converter to keep None values for required fields and remove redundant util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Allow no target DNA reference in AppBio Quantstudio design and anlysis
-
 - Standardize use of "N/A" for strings where a non-applicable value is necessary
+- Update `None` filtering to preserve required keys when converting model to dictionary
+
 ### Deprecated
 
 ### Removed

--- a/src/allotropy/allotrope/converter.py
+++ b/src/allotropy/allotrope/converter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import asdict, fields, is_dataclass, make_dataclass
+from dataclasses import asdict, fields, is_dataclass, make_dataclass, MISSING
 from types import UnionType
 from typing import Any, Callable, cast, get_args, get_origin, TypeVar, Union
 
@@ -234,17 +234,29 @@ def structure_custom_information_document(val: dict[str, Any], name: str) -> Any
     )
 
 
-# Special should_omit check for allowing an empty value for 'value' keys, controlled by should_allow_empty_value_field
-def should_omit_allow_empty_value_field(k: str, v: Any) -> bool:
-    return v is None and k != "value"
+def _create_should_omit_function(
+    cls: Any, parent_cls: Any | None = None, field_name: str | None = None
+) -> Callable[[str, Any], bool]:
+    required_keys = {a.name for a in fields(cls) if a.default == MISSING}
+
+    def should_omit(k: str, v: Any) -> bool:
+        if k in required_keys:
+            return False
+        if field_name in EMPTY_VALUE_CLASS_AND_FIELD.get(parent_cls, set()):
+            return v is None and k != "value"
+        return v is None
+
+    return should_omit
 
 
 def unstructure_custom_information_document(model: Any) -> dict[str, Any]:
+    should_omit = _create_should_omit_function(model)
+
     def dict_factory(kv_pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
         return {
             _convert_model_key_to_dict_key(key): value
             for key, value in kv_pairs
-            if not should_omit_allow_empty_value_field(key, value)
+            if not should_omit(key, value)
         }
 
     return asdict(model, dict_factory=dict_factory)
@@ -310,20 +322,14 @@ EMPTY_VALUE_CLASS_AND_FIELD = {
 }
 
 
-def should_allow_empty_value_field(cls: Any, key: str) -> bool:
-    return key in EMPTY_VALUE_CLASS_AND_FIELD.get(cls, set())
-
-
 def register_unstructure_hooks(converter: Converter) -> None:
-    # Default check for omitting values skips if value is None
-    def should_omit(_: str, v: Any) -> bool:
-        return v is None
-
     unstructure_fn_cache = {}
 
     def unstructure_dataclass_fn(
-        cls: Any, should_omit: Callable[[str, Any], bool] = should_omit
+        cls: Any, parent_cls: Any | None = None, field_name: str | None = None
     ) -> Callable[[Any], dict[str, Any]]:
+        should_omit = _create_should_omit_function(cls, parent_cls, field_name)
+
         def unstructure(obj: Any) -> Any:
             # Break out of dataclass recursion by calling back to converter.unstructure
             if not is_dataclass(obj):
@@ -342,9 +348,9 @@ def register_unstructure_hooks(converter: Converter) -> None:
                 )
             return dataclass_dict
 
-        # This custom unstructure function overrides the unstruct_hook when we should should_allow_empty_value_field.
-        # We need to do this at this level because we need to know both the parent class and the field name at the
-        # same time.
+        # This custom unstructure function overrides the unstruct_hook. We need to do this at this level
+        # because we need to know both the parent class and the field name at the same time to create the
+        # should_omit function.
         def make_unstructure_fn(subcls: Any) -> Callable[[Any], dict[str, Any]]:
             if (cls, subcls) not in unstructure_fn_cache:
                 unstructure_fn_cache[(cls, subcls)] = make_dict_unstructure_fn(
@@ -352,11 +358,7 @@ def register_unstructure_hooks(converter: Converter) -> None:
                     converter,
                     **{
                         a.name: override(
-                            unstruct_hook=unstructure_dataclass_fn(
-                                subcls, should_omit_allow_empty_value_field
-                            )
-                            if should_allow_empty_value_field(cls, a.name)
-                            else None
+                            unstruct_hook=unstructure_dataclass_fn(subcls, cls, a.name)
                         )
                         for a in fields(cls)
                     },

--- a/src/allotropy/parsers/biorad_bioplex_manager/biorad_bioplex_manager_parser.py
+++ b/src/allotropy/parsers/biorad_bioplex_manager/biorad_bioplex_manager_parser.py
@@ -60,10 +60,7 @@ from allotropy.parsers.biorad_bioplex_manager.constants import (
 )
 from allotropy.parsers.release_state import ReleaseState
 from allotropy.parsers.utils.uuids import random_uuid_str
-from allotropy.parsers.utils.values import (
-    get_val_from_xml,
-    remove_none_fields_from_data_class,
-)
+from allotropy.parsers.utils.values import get_val_from_xml
 from allotropy.parsers.vendor_parser import VendorParser
 
 
@@ -202,14 +199,12 @@ class BioradBioplexParser(VendorParser):
 
     @staticmethod
     def _get_sample_document(sample: SampleDocumentStructure, well_name: str) -> Any:
-        sample_doc = SampleDocument(
+        return SampleDocument(
             description=sample.description,
             sample_identifier=sample.sample_identifier,
             location_identifier=well_name,
             sample_role_type=sample.sample_type,
         )
-        final_sample_doc = remove_none_fields_from_data_class(sample_doc)
-        return final_sample_doc
 
     @staticmethod
     def _get_device_control_aggregate(
@@ -231,12 +226,8 @@ class BioradBioplexParser(VendorParser):
             if device_well_settings.minimum_assay_bead_count_setting is not None
             else None,
         )
-
-        clean_device_control_doc_item = remove_none_fields_from_data_class(
-            device_control_doc_item
-        )
         return DeviceControlAggregateDocument(
-            device_control_document=[clean_device_control_doc_item]
+            device_control_document=[device_control_doc_item]
         )
 
     @staticmethod

--- a/src/allotropy/parsers/utils/values.py
+++ b/src/allotropy/parsers/utils/values.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import fields
 import math
 import re
 from typing import Any, TypeVar
@@ -268,22 +267,3 @@ def get_attrib_from_xml(
     except KeyError as e:
         msg = f"Unable to find '{attrib_name}' in {xml_element.attrib}"
         raise AllotropeConversionError(msg) from e
-
-
-def remove_none_fields_from_data_class(
-    cls_instance: Any,
-) -> Any:
-
-    data_class_fields = fields(cls_instance.__class__)
-
-    # get all non-none fields
-    non_none_fields = {
-        field.name: getattr(cls_instance, field.name)
-        for field in data_class_fields
-        if (getattr(cls_instance, field.name) is not None or field.default is not None)
-    }
-
-    # Create a new instance with non-None fields
-    updated_instance = cls_instance.__class__(**non_none_fields)
-
-    return updated_instance

--- a/tests/allotrope/converter_test.py
+++ b/tests/allotrope/converter_test.py
@@ -1,3 +1,5 @@
+from dataclasses import field, make_dataclass
+
 from allotropy.allotrope.converter import (
     add_custom_information_document,
     structure,
@@ -84,6 +86,39 @@ def test_omits_null_values_except_for_specified_classes() -> None:
         "molar concentration": {"unit": "mmol/L", "value": None},
     }
     assert structure(asm_dict, AnalyteDocumentItem) == item
+
+
+def test_remove_none_fields_from_data_class_optional_none() -> None:
+    test_data_class = make_dataclass(
+        "test_data_class",
+        [
+            ("sample_id", str),
+            ("volume", int),
+            ("scientist", str | None, field(default=None)),  # type: ignore
+        ],
+    )
+    test_class = test_data_class(sample_id="abc", volume=5, scientist=None)
+    asm_dict = unstructure(test_class)
+    assert asm_dict == {
+        "sample id": "abc",
+        "volume": 5,
+    }
+    assert structure(asm_dict, test_data_class) == test_class
+
+
+def test_remove_none_fields_from_data_class_with_required_none() -> None:
+    test_data_class = make_dataclass(
+        "test_data_class",
+        [("sample_id", str), ("volume", int), ("scientist", str | None)],  # type: ignore
+    )
+    test_class = test_data_class(sample_id="abc", volume=5, scientist=None)
+    asm_dict = unstructure(test_class)
+    assert asm_dict == {
+        "sample id": "abc",
+        "volume": 5,
+        "scientist": None,
+    }
+    assert structure(asm_dict, test_data_class) == test_class
 
 
 def test_custom_information_document() -> None:

--- a/tests/parsers/utils/values_test.py
+++ b/tests/parsers/utils/values_test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import field, make_dataclass
 from xml.etree import ElementTree
 
 import pytest
@@ -12,7 +11,6 @@ from allotropy.parsers.utils.values import (
     get_val_from_xml,
     get_val_from_xml_or_none,
     natural_sort_key,
-    remove_none_fields_from_data_class,
     try_float,
     try_float_or_none,
     try_int,
@@ -242,33 +240,4 @@ def test_get_val_from_xml_or_none() -> None:
             xml_object=test_xml, tag_name="RunSettings", tag_name_2="DilutionFactor"
         )
         is None
-    )
-
-
-def test_remove_none_fields_from_data_class_optional_none() -> None:
-
-    # Test that we remove the None
-    test_data_class = make_dataclass(
-        "test_data_class",
-        [
-            ("sample_id", str),
-            ("volume", int),
-            ("scientist", str | None, field(default=None)),  # type: ignore
-        ],
-    )
-    test_class = test_data_class(sample_id="abc", volume=5, scientist=None)
-    assert remove_none_fields_from_data_class(test_class) == test_data_class(
-        sample_id="abc", volume=5
-    )
-
-
-def test_remove_none_fields_from_data_class_with_required_none() -> None:
-    # Test that we do not remove the None when it's required
-    test_data_class = make_dataclass(
-        "test_data_class",
-        [("sample_id", str), ("volume", int), ("scientist", str | None)],  # type: ignore
-    )
-    test_class = test_data_class(sample_id="abc", volume=5, scientist=None)
-    assert remove_none_fields_from_data_class(test_class) == test_data_class(
-        sample_id="abc", volume=5, scientist=None
     )


### PR DESCRIPTION
This PR updates custom logic for omitting keys in the converter.

It is updated to *not* omit `None` keys when they are for a required field.

The PR also removes a util that was previously doing this in a special case, since it is now general behavior.