### PR TITLE
chore: Clean up warnings seen in tests

### DIFF
--- a/src/allotropy/parsers/agilent_gen5_image/agilent_gen5_image_parser.py
+++ b/src/allotropy/parsers/agilent_gen5_image/agilent_gen5_image_parser.py
@@ -183,7 +183,7 @@ class AgilentGen5ImageParser(VendorParser):
                                 OpticalImagingDeviceControlDocumentItem(
                                     device_type=DEVICE_TYPE,
                                     detection_type=DETECTION_TYPE,
-                                    # This setting won't get reported at the moment since Gen5 only reports it
+                                    # TODO: this setting won't get reported at the moment since Gen5 only reports it
                                     # in micrometers and we don't do conversions on the adapters at the moment
                                     # detector_distance_setting__plate_reader_=get_instance_or_none(
                                     #     TQuantityValueMillimeter,

--- a/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_parser.py
@@ -1,3 +1,6 @@
+import re
+import warnings
+
 import pandas as pd
 
 from allotropy.allotrope.models.adm.pcr.benchling._2023._09.qpcr import (
@@ -65,9 +68,12 @@ class AppBioQuantStudioDesignandanalysisParser(VendorParser):
         return ReleaseState.RECOMMENDED
 
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Model:
-        raw_contents = pd.read_excel(
-            named_file_contents.contents, header=None, sheet_name=None
-        )
+        # We can get a warning that the workbook does not have a default style. We are OK with this, so suppress.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=UserWarning, module=re.escape("openpyxl.styles.stylesheet"))
+            raw_contents = pd.read_excel(
+                named_file_contents.contents, header=None, sheet_name=None
+            )
         contents = DesignQuantstudioContents(raw_contents)
         data = create_data(contents)
         return self._get_model(data, named_file_contents.original_file_name)

--- a/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_parser.py
@@ -70,7 +70,11 @@ class AppBioQuantStudioDesignandanalysisParser(VendorParser):
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Model:
         # We can get a warning that the workbook does not have a default style. We are OK with this, so suppress.
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning, module=re.escape("openpyxl.styles.stylesheet"))
+            warnings.filterwarnings(
+                "ignore",
+                category=UserWarning,
+                module=re.escape("openpyxl.styles.stylesheet"),
+            )
             raw_contents = pd.read_excel(
                 named_file_contents.contents, header=None, sheet_name=None
             )

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
@@ -53,7 +53,7 @@ _PROPERTY_LOOKUP = {
 def _get_value(data_frame: pd.DataFrame, row: int, column: str) -> Any | None:
     if column not in data_frame.columns:
         return None
-    return data_frame[column][row]
+    return data_frame[column].iloc[row]
 
 
 def get_property_from_sample(

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_reader.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_reader.py
@@ -9,12 +9,11 @@ class NucleoviewReader:
     def read(cls, contents: IOType) -> pd.DataFrame:
         df = read_csv(
             contents,
-            skipfooter=1,
             sep=";",
             usecols=[0, 1],
             skipinitialspace=True,
             index_col=False,
-        ).dropna(axis=0, how="all")
+        )[:-1].dropna(axis=0, how="all")
 
         # add a common index to all rows for our group by and pivot
         df["group_by"] = ["Group1"] * len(df)

--- a/src/allotropy/parsers/methodical_mind/methodical_mind_structure.py
+++ b/src/allotropy/parsers/methodical_mind/methodical_mind_structure.py
@@ -138,9 +138,9 @@ class PlateData:
             spot_index_counter += 1
             # Skip the first column since it's the well names (no luminescence values)
             for col in plate_df.columns[1:]:
-                if pd.notna(row[0]):
+                if pd.notna(row.iloc[0]):
                     # This is the row well name-- A, B, C, etc.
-                    well_row = row[0].strip()
+                    well_row = row.iloc[0].strip()
                     # If we've detected a new well row, reset the spot index counter
                     spot_index_counter = 1
                 location_name = well_row + col.strip() + "_" + str(spot_index_counter)

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
@@ -210,10 +210,11 @@ class GroupData:
             msg="Unable to find group block name.",
         ).removeprefix("Group: ")
 
-        data = assert_not_none(
-            reader.pop_csv_block_as_df(sep="\t", header=0),
-            msg="Unable to find group block data.",
-        ).replace(r"^\s+$", None, regex=True)
+        with pd.option_context("future.no_silent_downcasting", True):  # noqa: FBT003
+            data = assert_not_none(
+                reader.pop_csv_block_as_df(sep="\t", header=0),
+                msg="Unable to find group block data.",
+            ).replace(r"^\s+$", None, regex=True)
 
         assert_not_none(
             data.get("Sample"),

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
@@ -363,7 +363,7 @@ class BasicAssayInfo:
             "Basic assay information",
         )
         data = data.T
-        data.iloc[0].replace(":.*", "", regex=True, inplace=True)
+        data.iloc[0] = data.iloc[0].replace(":.*", "", regex=True)
         series = df_to_series(data)
         return BasicAssayInfo(
             try_str_from_series_or_none(series, "Protocol ID"),

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_parser_test.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_parser_test.py
@@ -35,7 +35,6 @@ OUTPUT_FILES = (
 VENDOR_TYPE = Vendor.APPBIO_QUANTSTUDIO
 
 
-@pytest.mark.quantstudio
 @pytest.mark.parametrize("output_file", OUTPUT_FILES)
 def test_parse_appbio_quantstudio_to_asm_contents(output_file: str) -> None:
     test_filepath = f"tests/parsers/appbio_quantstudio/testdata/{output_file}.txt"
@@ -46,7 +45,6 @@ def test_parse_appbio_quantstudio_to_asm_contents(output_file: str) -> None:
 
 
 @pytest.mark.short
-@pytest.mark.quantstudio
 @pytest.mark.parametrize(
     "file_name,data,model",
     [

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_structure_test.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_structure_test.py
@@ -58,7 +58,6 @@ def _read_to_lines(io_: IOType, encoding: str | None = None) -> list[str]:
 
 
 @pytest.mark.short
-@pytest.mark.quantstudio
 def test_header_builder_returns_header_instance() -> None:
     header_contents = get_raw_header_contents()
 
@@ -66,7 +65,6 @@ def test_header_builder_returns_header_instance() -> None:
     assert isinstance(Header.create(LinesReader(lines)), Header)
 
 
-@pytest.mark.quantstudio
 def test_header_builder() -> None:
     device_identifier = "device1"
     model_number = "123"
@@ -107,7 +105,6 @@ def test_header_builder() -> None:
 
 
 @pytest.mark.short
-@pytest.mark.quantstudio
 @pytest.mark.parametrize(
     "parameter,expected_error",
     [
@@ -130,7 +127,6 @@ def test_header_builder_required_parameter_none_then_raise(
 
 
 @pytest.mark.short
-@pytest.mark.quantstudio
 def test_header_builder_plate_well_count() -> None:
     header_contents = get_raw_header_contents(plate_well_count="96 plates")
     lines = _read_to_lines(header_contents)
@@ -164,7 +160,6 @@ def test_header_builder_plate_well_count() -> None:
 
 
 @pytest.mark.short
-@pytest.mark.quantstudio
 def test_header_builder_no_header_then_raise() -> None:
     header_contents = get_raw_header_contents(raw_text="")
     lines = _read_to_lines(header_contents, encoding="UTF-8")
@@ -177,7 +172,6 @@ def test_header_builder_no_header_then_raise() -> None:
 
 
 @pytest.mark.short
-@pytest.mark.quantstudio
 def test_results_builder() -> None:
 
     data = pd.DataFrame(
@@ -209,7 +203,6 @@ def test_results_builder() -> None:
 
 
 @pytest.mark.short
-@pytest.mark.quantstudio
 @pytest.mark.parametrize(
     "test_filepath,expected_data",
     [

--- a/tests/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_parser_test.py
+++ b/tests/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_parser_test.py
@@ -28,7 +28,6 @@ OUTPUT_FILES = (
 VENDOR_TYPE = Vendor.APPBIO_QUANTSTUDIO_DESIGNANDANALYSIS
 
 
-@pytest.mark.design_quantstudio
 @pytest.mark.parametrize("output_file", OUTPUT_FILES)
 def test_parse_appbio_quantstudio_to_asm_contents(output_file: str) -> None:
     test_filepath = f"tests/parsers/appbio_quantstudio_designandanalysis/testdata/{output_file}.xlsx"

--- a/tests/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_structure_test.py
+++ b/tests/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_structure_test.py
@@ -14,13 +14,11 @@ from allotropy.parsers.appbio_quantstudio_designandanalysis.appbio_quantstudio_d
 )
 
 
-@pytest.mark.design_quantstudio
 def test_header_builder_returns_header_instance() -> None:
     header_contents = get_raw_header_contents()
     assert isinstance(Header.create(header_contents), Header)
 
 
-@pytest.mark.design_quantstudio
 def test_header_builder() -> None:
     measurement_time = "2010-10-01 01:44:54 AM EDT"
     device_identifier = "device1"
@@ -67,7 +65,6 @@ def test_header_builder() -> None:
     )
 
 
-@pytest.mark.design_quantstudio
 @pytest.mark.parametrize(
     "parameter,expected_error",
     [
@@ -87,7 +84,6 @@ def test_header_builder_required_parameter_none_then_raise(
         Header.create(header_contents)
 
 
-@pytest.mark.design_quantstudio
 def test_header_builder_invalid_plate_well_count() -> None:
     header_contents = get_raw_header_contents(plate_well_count="0 plates")
 
@@ -95,13 +91,11 @@ def test_header_builder_invalid_plate_well_count() -> None:
         Header.create(header_contents)
 
 
-@pytest.mark.design_quantstudio
 def test_header_builder_no_header_then_raise() -> None:
     with pytest.raises(AllotropeConversionError):
         Header.create(pd.Series())
 
 
-@pytest.mark.design_quantstudio
 def test_results_builder() -> None:
     contents = DesignQuantstudioContents(
         {

--- a/tests/parsers/ctl_immunospot/to_allotrope_test.py
+++ b/tests/parsers/ctl_immunospot/to_allotrope_test.py
@@ -5,7 +5,6 @@ from allotropy.parser_factory import Vendor
 from allotropy.testing.utils import from_file, validate_contents
 
 
-@pytest.mark.immunospot
 @pytest.mark.parametrize(
     "file_name",
     [

--- a/tests/parsers/mabtech_apex/mabtech_apex_to_allotrope_test.py
+++ b/tests/parsers/mabtech_apex/mabtech_apex_to_allotrope_test.py
@@ -6,7 +6,6 @@ from allotropy.testing.utils import from_file, validate_contents
 VENDOR_TYPE = Vendor.MABTECH_APEX
 
 
-@pytest.mark.mabtech
 @pytest.mark.parametrize(
     "output_file",
     ["mabtech_apex_example_single_plate"],

--- a/tests/parsers/revvity_kaleido/to_allotrope_test.py
+++ b/tests/parsers/revvity_kaleido/to_allotrope_test.py
@@ -7,7 +7,6 @@ from allotropy.testing.utils import from_file, validate_contents
 VENDOR_TYPE = Vendor.REVVITY_KALEIDO
 
 
-@pytest.mark.kaleido
 @pytest.mark.parametrize(
     "file_name",
     [


### PR DESCRIPTION
Reduced warnings while running unit tests from 142 -> 9

Specifically:

1. Remove per-parser pytest marks. It was agreed these weren't needed since you can filter test by directory
2. Suppress warning while reading excel files without style sheet
3. Index pandas dataframe using `iloc` (future proofing)
4. Remove use of `skipfooter` by manually dropping last line in dataframe instead (future proofing)
5. Opt-in to future behavior of not automatically downcasting in pd.replace

The remaining warnings are related to duplicated names in schema class generator script that should hopefully go away with modularized schemas :D 