### PR TITLE
feat: Make all adapters have the asm converter name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow no target DNA reference in AppBio Quantstudio design and anlysis
 - Standardize use of "N/A" for strings where a non-applicable value is necessary
 - Update `None` filtering to preserve required keys when converting model to dictionary
-
+- Update ASM converter name field to specify the parser name instead of just "allotropy", this is intended to give better granularity on the adapter that did the conversion and not just the library version
 ### Deprecated
 
 ### Removed

--- a/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
+++ b/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
@@ -34,7 +34,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueRelativeLightUnit,
     TQuantityValueUnitless,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.agilent_gen5.agilent_gen5_structure import PlateData
@@ -101,7 +101,7 @@ class AgilentGen5Parser(VendorParser):
                     file_name=file_name,
                     software_name=DEFAULT_SOFTWARE_NAME,
                     software_version=plate_data.header_data.software_version,
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 plate_reader_document=[

--- a/src/allotropy/parsers/agilent_gen5_image/agilent_gen5_image_parser.py
+++ b/src/allotropy/parsers/agilent_gen5_image/agilent_gen5_image_parser.py
@@ -24,7 +24,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueNumber,
     TQuantityValueUnitless,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.agilent_gen5.section_reader import SectionLinesReader
@@ -72,7 +72,7 @@ class AgilentGen5ImageParser(VendorParser):
                     file_name=file_name,
                     software_name=DEFAULT_SOFTWARE_NAME,
                     software_version=plate_data.header_data.software_version,
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 plate_reader_document=[

--- a/src/allotropy/parsers/agilent_tapestation_analysis/agilent_tapestation_analysis_parser.py
+++ b/src/allotropy/parsers/agilent_tapestation_analysis/agilent_tapestation_analysis_parser.py
@@ -34,7 +34,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueUnitless,
 )
 from allotropy.allotrope.models.shared.definitions.units import UNITLESS
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.agilent_tapestation_analysis.agilent_tapestation_analysis_structure import (
     Data,
@@ -84,7 +84,7 @@ class AgilentTapestationAnalysisParser(VendorParser):
                     file_name=filename,
                     software_name=SOFTWARE_NAME,
                     software_version=metadata.software_version,
-                    ASM_converter_name=f'{ASM_CONVERTER_NAME}_{self.display_name.replace(" ", "_")}'.lower(),
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 device_system_document=DeviceSystemDocument(

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
@@ -31,7 +31,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueNumberPerMicroliter,
 )
 from allotropy.allotrope.models.shared.definitions.definitions import TQuantityValue
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.appbio_absolute_q.appbio_absolute_q_reader import AbsoluteQReader
 from allotropy.parsers.appbio_absolute_q.constants import (
@@ -91,7 +91,7 @@ class AppbioAbsoluteQParser(VendorParser):
                 data_system_document=DataSystemDocument(
                     file_name=filename,
                     software_name="QuantStudio Absolute Q Digital PCR Software",
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 dPCR_document=dpcr_document,

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
@@ -37,7 +37,7 @@ from allotropy.allotrope.models.shared.definitions.definitions import (
     TDatacubeStructure,
 )
 from allotropy.allotrope.models.shared.definitions.units import UNITLESS
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_data_creator import (
     create_data,
@@ -86,7 +86,7 @@ class AppBioQuantStudioParser(VendorParser):
                     UNC_path="",  # unknown
                     software_name="Thermo QuantStudio",
                     software_version="1.0",
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 qPCR_document=[

--- a/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_parser.py
@@ -41,7 +41,7 @@ from allotropy.allotrope.models.shared.definitions.definitions import (
     TDatacubeData,
     TDatacubeStructure,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.appbio_quantstudio_designandanalysis.appbio_quantstudio_designandanalysis_contents import (
     DesignQuantstudioContents,
@@ -98,7 +98,7 @@ class AppBioQuantStudioDesignandanalysisParser(VendorParser):
                     UNC_path="",  # unknown
                     software_name=data.header.software_name,
                     software_version=data.header.software_version,
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 qPCR_document=[

--- a/src/allotropy/parsers/beckman_pharmspec/beckman_pharmspec_parser.py
+++ b/src/allotropy/parsers/beckman_pharmspec/beckman_pharmspec_parser.py
@@ -33,7 +33,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueUnitless,
 )
 from allotropy.allotrope.models.shared.definitions.definitions import TStringValueItem
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.beckman_pharmspec.constants import PHARMSPEC_SOFTWARE_NAME
 from allotropy.parsers.release_state import ReleaseState
@@ -261,7 +261,7 @@ class PharmSpecParser(VendorParser):
                     software_version=self._get_software_version_report_string(
                         df.at[0, 2]
                     ),
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 device_system_document=DeviceSystemDocument(

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
@@ -31,6 +31,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
 )
 from allotropy.allotrope.models.shared.definitions.definitions import TQuantityValue
 from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.beckman_vi_cell_blu.constants import (
@@ -118,7 +119,7 @@ class ViCellBluParser(VendorParser):
                 data_system_document=DataSystemDocument(
                     file_name=filename,
                     software_name=VICELL_BLU_SOFTWARE_NAME,
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 cell_counting_document=self._get_cell_counting_document(data),

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
@@ -30,7 +30,6 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueUnitless,
 )
 from allotropy.allotrope.models.shared.definitions.definitions import TQuantityValue
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
 from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.named_file_contents import NamedFileContents

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
@@ -29,7 +29,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValuePercent,
     TQuantityValueUnitless,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.beckman_vi_cell_xr.constants import (
@@ -126,7 +126,7 @@ class ViCellXRParser(VendorParser):
                     file_name=filename,
                     software_name=SOFTWARE_NAME,
                     software_version=reader.file_version.value,
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 cell_counting_document=[

--- a/src/allotropy/parsers/biorad_bioplex_manager/biorad_bioplex_manager_parser.py
+++ b/src/allotropy/parsers/biorad_bioplex_manager/biorad_bioplex_manager_parser.py
@@ -42,7 +42,6 @@ from allotropy.parsers.biorad_bioplex_manager.biorad_bioplex_manager_structure i
     WellSystemLevelMetadata,
 )
 from allotropy.parsers.biorad_bioplex_manager.constants import (
-    ASM_CONVERTER_NAME,
     BEAD_REGIONS,
     CONTAINER_TYPE,
     DESCRIPTION_TAG,
@@ -114,7 +113,9 @@ class BioradBioplexParser(VendorParser):
             multi_analyte_profiling_aggregate_document=MultiAnalyteProfilingAggregateDocument(
                 device_system_document=device_document,
                 data_system_document=self._get_data_system_document(
-                    software_version=software_version_value, file_name=filename
+                    software_version=software_version_value,
+                    file_name=filename,
+                    asm_converter_name=self.get_asm_converter_name(),
                 ),
                 multi_analyte_profiling_document=multi_docs,
             ),
@@ -132,12 +133,12 @@ class BioradBioplexParser(VendorParser):
 
     @staticmethod
     def _get_data_system_document(
-        software_version: str, file_name: str
+        software_version: str, file_name: str, asm_converter_name: str
     ) -> DataSystemDocument:
         return DataSystemDocument(
             software_name=SOFTWARE_NAME,
             software_version=software_version,
-            ASM_converter_name=ASM_CONVERTER_NAME,
+            ASM_converter_name=asm_converter_name,
             ASM_converter_version=ASM_CONVERTER_VERSION,
             file_name=file_name,
         )

--- a/src/allotropy/parsers/biorad_bioplex_manager/biorad_bioplex_manager_parser.py
+++ b/src/allotropy/parsers/biorad_bioplex_manager/biorad_bioplex_manager_parser.py
@@ -112,10 +112,12 @@ class BioradBioplexParser(VendorParser):
             field_asm_manifest="http://purl.allotrope.org/manifests/multi-analyte-profiling/BENCHLING/2024/01/multi-analyte-profiling.manifest",
             multi_analyte_profiling_aggregate_document=MultiAnalyteProfilingAggregateDocument(
                 device_system_document=device_document,
-                data_system_document=self._get_data_system_document(
+                data_system_document=DataSystemDocument(
+                    software_name=SOFTWARE_NAME,
                     software_version=software_version_value,
+                    ASM_converter_name=self.get_asm_converter_name(),
+                    ASM_converter_version=ASM_CONVERTER_VERSION,
                     file_name=filename,
-                    asm_converter_name=self.get_asm_converter_name(),
                 ),
                 multi_analyte_profiling_document=multi_docs,
             ),
@@ -129,18 +131,6 @@ class BioradBioplexParser(VendorParser):
             equipment_serial_number=well_system_metadata.serial_number,
             firmware_version=well_system_metadata.controller_version,
             product_manufacturer=PRODUCT_MANUFACTURER,
-        )
-
-    @staticmethod
-    def _get_data_system_document(
-        software_version: str, file_name: str, asm_converter_name: str
-    ) -> DataSystemDocument:
-        return DataSystemDocument(
-            software_name=SOFTWARE_NAME,
-            software_version=software_version,
-            ASM_converter_name=asm_converter_name,
-            ASM_converter_version=ASM_CONVERTER_VERSION,
-            file_name=file_name,
         )
 
     def get_measurement_document_aggregate(

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
@@ -26,6 +26,11 @@ from allotropy.allotrope.models.shared.definitions.custom import (
 )
 from allotropy.allotrope.models.shared.definitions.definitions import TDateTimeValue
 from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.allotrope.models.shared.definitions.definitions import (
+    InvalidJsonFloat,
+    TDateTimeValue,
+)
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.chemometec_nucleoview.constants import (
     DEFAULT_ANALYST,
@@ -101,7 +106,7 @@ class ChemometecNucleoviewParser(VendorParser):
                 data_system_document=DataSystemDocument(
                     file_name=filename,
                     software_name=NUCLEOCOUNTER_SOFTWARE_NAME,
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                     software_version=_get_value(data, 0, "Application SW version"),
                 ),

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
@@ -24,10 +24,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValuePercent,
     TQuantityValueUnitless,
 )
-from allotropy.allotrope.models.shared.definitions.definitions import TDateTimeValue
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
 from allotropy.allotrope.models.shared.definitions.definitions import (
-    InvalidJsonFloat,
     TDateTimeValue,
 )
 from allotropy.constants import ASM_CONVERTER_VERSION

--- a/src/allotropy/parsers/ctl_immunospot/ctl_immunospot_parser.py
+++ b/src/allotropy/parsers/ctl_immunospot/ctl_immunospot_parser.py
@@ -19,7 +19,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueNumber,
     TQuantityValueUnitless,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.ctl_immunospot.ctl_immunospot_structure import Data, Well
 from allotropy.parsers.lines_reader import LinesReader, read_to_lines
@@ -79,7 +79,7 @@ class CtlImmunospotParser(VendorParser):
             UNC_path=data.device_info.unc_path,
             software_name=data.device_info.software_name,
             software_version=data.device_info.software_version,
-            ASM_converter_name=ASM_CONVERTER_NAME,
+            ASM_converter_name=self.get_asm_converter_name(),
             ASM_converter_version=ASM_CONVERTER_VERSION,
         )
 

--- a/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
+++ b/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
@@ -25,7 +25,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
 from allotropy.allotrope.models.shared.definitions.definitions import (
     TStatisticDatumRole,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.lines_reader import CsvReader, read_to_lines
 from allotropy.parsers.luminex_xponent.luminex_xponent_structure import (
@@ -83,7 +83,7 @@ class LuminexXponentParser(VendorParser):
                     file_name=file_name,
                     software_name=DEFAULT_SOFTWARE_NAME,
                     software_version=header.software_version,
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 multi_analyte_profiling_document=[

--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_parser.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_parser.py
@@ -22,7 +22,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueNumber,
     TQuantityValueUnitless,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.constants import NOT_APPLICABLE
 from allotropy.parsers.mabtech_apex.mabtech_apex_contents import MabtechApexContents
@@ -68,7 +68,7 @@ class MabtechApexParser(VendorParser):
                     UNC_path=data.unc_path,
                     software_name="Apex",
                     software_version=data.software_version,
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 plate_reader_document=[

--- a/src/allotropy/parsers/methodical_mind/methodical_mind_parser.py
+++ b/src/allotropy/parsers/methodical_mind/methodical_mind_parser.py
@@ -17,7 +17,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueNumber,
     TQuantityValueRelativeLightUnit,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.constants import NOT_APPLICABLE
 from allotropy.parsers.lines_reader import CsvReader, read_to_lines
@@ -77,7 +77,7 @@ class MethodicalMindParser(VendorParser):
             UNC_path=combined_data.file_name,
             software_name=combined_data.version,
             software_version=combined_data.version,
-            ASM_converter_name=ASM_CONVERTER_NAME,
+            ASM_converter_name=self.get_asm_converter_name(),
             ASM_converter_version=ASM_CONVERTER_VERSION,
         )
 

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
@@ -36,7 +36,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
 )
 from allotropy.allotrope.models.shared.definitions.definitions import TQuantityValue
 from allotropy.allotrope.models.shared.definitions.units import UNITLESS
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.exceptions import (
     AllotropeConversionError,
 )
@@ -98,7 +98,7 @@ class SoftmaxproParser(VendorParser):
                 data_system_document=DataSystemDocument(
                     file_name=file_name,
                     software_name="SoftMax Pro",
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 plate_reader_document=[

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
@@ -39,6 +39,12 @@ from allotropy.allotrope.models.shared.definitions.custom import (
 )
 from allotropy.allotrope.models.shared.definitions.definitions import TDateTimeValue
 from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.allotrope.models.shared.definitions.definitions import (
+    TDateTimeValue,
+    TQuantityValue,
+)
+from allotropy.allotrope.models.shared.definitions.units import UNITLESS
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.lines_reader import CsvReader, read_to_lines
@@ -109,7 +115,7 @@ class PerkinElmerEnvisionParser(VendorParser):
                     file_name=filename,
                     software_name=data.software.software_name,
                     software_version=data.software.software_version,
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 device_system_document=DeviceSystemDocument(

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
@@ -37,13 +37,9 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueRelativeLightUnit,
     TQuantityValueUnitless,
 )
-from allotropy.allotrope.models.shared.definitions.definitions import TDateTimeValue
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
 from allotropy.allotrope.models.shared.definitions.definitions import (
     TDateTimeValue,
-    TQuantityValue,
 )
-from allotropy.allotrope.models.shared.definitions.units import UNITLESS
 from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.named_file_contents import NamedFileContents

--- a/src/allotropy/parsers/qiacuity_dpcr/qiacuity_dpcr_parser.py
+++ b/src/allotropy/parsers/qiacuity_dpcr/qiacuity_dpcr_parser.py
@@ -22,7 +22,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueNumberPerMicroliter,
     TQuantityValueUnitless,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.qiacuity_dpcr.qiacuity_dpcr_reader import QiacuitydPCRReader
@@ -133,7 +133,7 @@ class QiacuitydPCRParser(VendorParser):
         data_system_document = DataSystemDocument(
             file_name=file_name,
             software_name=SOFTWARE_NAME,
-            ASM_converter_name=ASM_CONVERTER_NAME,
+            ASM_converter_name=self.get_asm_converter_name(),
             ASM_converter_version=ASM_CONVERTER_VERSION,
         )
         return data_system_document

--- a/src/allotropy/parsers/revvity_kaleido/kaleido_parser.py
+++ b/src/allotropy/parsers/revvity_kaleido/kaleido_parser.py
@@ -41,7 +41,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueRelativeLightUnit,
     TQuantityValueUnitless,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.lines_reader import CsvReader, read_to_lines
@@ -281,7 +281,7 @@ class KaleidoParser(VendorParser):
             file_name=file_name,
             software_name="Kaleido",
             software_version=version,
-            ASM_converter_name=ASM_CONVERTER_NAME,
+            ASM_converter_name=self.get_asm_converter_name(),
             ASM_converter_version=ASM_CONVERTER_VERSION,
         )
 

--- a/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
+++ b/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
@@ -36,8 +36,6 @@ from allotropy.allotrope.models.shared.definitions.definitions import (
     InvalidJsonFloat,
     JsonFloat,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
-from allotropy.allotrope.models.shared.definitions.units import UNITLESS
 from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.constants import NOT_APPLICABLE

--- a/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
+++ b/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
@@ -37,6 +37,8 @@ from allotropy.allotrope.models.shared.definitions.definitions import (
     JsonFloat,
 )
 from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.allotrope.models.shared.definitions.units import UNITLESS
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.constants import NOT_APPLICABLE
 from allotropy.parsers.release_state import ReleaseState
@@ -132,7 +134,7 @@ class NanodropEightParser(VendorParser):
                 ),
                 data_system_document=DataSystemDocument(
                     file_name=filename,
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 device_system_document=DeviceSystemDocument(

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_parser.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_parser.py
@@ -26,7 +26,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
 )
 from allotropy.allotrope.models.shared.definitions.definitions import TQuantityValue
 from allotropy.allotrope.pandas_util import read_csv
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.release_state import ReleaseState
 from allotropy.parsers.unchained_labs_lunatic.unchained_labs_lunatic_structure import (
@@ -65,7 +65,7 @@ class UnchainedLabsLunaticParser(VendorParser):
                 data_system_document=DataSystemDocument(
                     file_name=filename,
                     software_name="Lunatic and Stunner Analysis",
-                    ASM_converter_name=ASM_CONVERTER_NAME,
+                    ASM_converter_name=self.get_asm_converter_name(),
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                 ),
                 plate_reader_document=[

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -4,6 +4,7 @@ from typing import Any
 from pandas import Timestamp
 
 from allotropy.allotrope.models.shared.definitions.definitions import TDateTimeValue
+from allotropy.constants import ASM_CONVERTER_NAME
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.release_state import ReleaseState
 from allotropy.parsers.utils.timestamp_parser import TimestampParser
@@ -33,6 +34,10 @@ class VendorParser(ABC):
     @abstractmethod
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Any:
         raise NotImplementedError
+
+    def get_asm_converter_name(self) -> str:
+        """Returns the ASM converter name for this parser."""
+        return f'{ASM_CONVERTER_NAME}_{self.display_name.replace(" ", "_")}'.lower()
 
     def _get_date_time(self, time: str) -> TDateTimeValue:
         assert_not_none(time, "time")

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -37,7 +37,7 @@ class VendorParser(ABC):
 
     def get_asm_converter_name(self) -> str:
         """Returns the ASM converter name for this parser."""
-        return f'{ASM_CONVERTER_NAME}_{self.display_name.replace(" ", "_")}'.lower()
+        return f'{ASM_CONVERTER_NAME}_{self.display_name.replace(" ", "_").replace("-", "_")}'.lower()
 
     def _get_date_time(self, time: str) -> TDateTimeValue:
         assert_not_none(time, "time")

--- a/src/allotropy/testing/utils.py
+++ b/src/allotropy/testing/utils.py
@@ -21,15 +21,17 @@ from allotropy.to_allotrope import allotrope_from_file
 DictType = Mapping[str, Any]
 
 
-def _replace_asm_converter_name_and_version(allotrope_dict: DictType) -> DictType:
+def _replace_asm_converter_name_and_version(
+    allotrope_dict: DictType, vendor_type: Vendor
+) -> DictType:
     new_dict = dict(allotrope_dict)
+    vendor = Vendor(vendor_type).get_parser()
     for key, value in new_dict.items():
         if key == "data system document":
-            # TODO: Commenting this out until BNCH-93726 is completed.
-            # value["ASM converter name"] = ASM_CONVERTER_NAME
+            value["ASM converter name"] = vendor.get_asm_converter_name()
             value["ASM converter version"] = ASM_CONVERTER_VERSION
         if isinstance(value, dict):
-            _replace_asm_converter_name_and_version(value)
+            _replace_asm_converter_name_and_version(value, vendor_type)
 
     return new_dict
 
@@ -83,8 +85,9 @@ def _validate_identifiers(asm: DictType) -> None:
 def _assert_allotrope_dicts_equal(
     expected: DictType,
     actual: DictType,
+    vendor_type: Vendor,
 ) -> None:
-    expected_replaced = _replace_asm_converter_name_and_version(expected)
+    expected_replaced = _replace_asm_converter_name_and_version(expected, vendor_type)
 
     ddiff = DeepDiff(
         expected_replaced,
@@ -145,6 +148,7 @@ def _write_actual_to_expected(
 def validate_contents(
     allotrope_dict: DictType,
     expected_file: Path | str,
+    vendor_type: Vendor,
     write_actual_to_expected_on_fail: bool = False,  # noqa: FBT001, FBT002
 ) -> None:
     """Use the newly created allotrope_dict to validate the contents inside expected_file."""
@@ -161,7 +165,7 @@ def validate_contents(
     try:
         with open(expected_file) as f:
             expected_dict = json.load(f)
-        _assert_allotrope_dicts_equal(expected_dict, allotrope_dict)
+        _assert_allotrope_dicts_equal(expected_dict, allotrope_dict, vendor_type)
     except Exception as e:
         if write_actual_to_expected_on_fail:
             _write_actual_to_expected(allotrope_dict, expected_file)

--- a/tests/parsers/agilent_gen5/to_allotrope_test.py
+++ b/tests/parsers/agilent_gen5/to_allotrope_test.py
@@ -33,7 +33,7 @@ def test_to_allotrope_absorbance_no_pm_in_time() -> None:
         "file name"
     ] = "endpoint_pathlength_correct_singleplate.txt"
 
-    validate_contents(allotrope_dict, expected_filepath)
+    validate_contents(allotrope_dict, expected_filepath, VENDOR_TYPE)
 
 
 @pytest.mark.parametrize(

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_data.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_data.py
@@ -55,7 +55,7 @@ from allotropy.parsers.utils.calculated_data_documents.definition import (
     DataSource,
 )
 
-ASM_CONVERTER_NAME = "allotropy_appbio_quantstudio_rt-pcr"
+ASM_CONVERTER_NAME = "allotropy_appbio_quantstudio_rt_pcr"
 
 
 def get_data() -> Data:

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_data.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_data.py
@@ -36,7 +36,7 @@ from allotropy.allotrope.models.shared.definitions.definitions import (
     TDatacubeData,
     TDatacubeStructure,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_structure import (
     AmplificationData,
     Data,
@@ -54,6 +54,8 @@ from allotropy.parsers.utils.calculated_data_documents.definition import (
     CalculatedDocument,
     DataSource,
 )
+
+ASM_CONVERTER_NAME = "allotropy_appbio_quantstudio_rt-pcr"
 
 
 def get_data() -> Data:
@@ -3350,7 +3352,7 @@ def get_broken_calc_doc_model() -> Model:
                 UNC_path="",
                 software_name="Thermo QuantStudio",
                 software_version="1.0",
-                ASM_converter_name="allotropy",
+                ASM_converter_name=ASM_CONVERTER_NAME,
                 ASM_converter_version=ASM_CONVERTER_VERSION,
             ),
             calculated_data_aggregate_document=TCalculatedDataAggregateDocument(

--- a/tests/parsers/beckman_vi_cell_blu/vi_cell_blu_data.py
+++ b/tests/parsers/beckman_vi_cell_blu/vi_cell_blu_data.py
@@ -22,7 +22,9 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValuePercent,
     TQuantityValueUnitless,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
+
+ASM_CONVERTER_NAME = "allotropy_beckman_vi-cell_blu"
 
 
 def get_filename() -> str:

--- a/tests/parsers/beckman_vi_cell_blu/vi_cell_blu_data.py
+++ b/tests/parsers/beckman_vi_cell_blu/vi_cell_blu_data.py
@@ -24,7 +24,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
 )
 from allotropy.constants import ASM_CONVERTER_VERSION
 
-ASM_CONVERTER_NAME = "allotropy_beckman_vi-cell_blu"
+ASM_CONVERTER_NAME = "allotropy_beckman_vi_cell_blu"
 
 
 def get_filename() -> str:

--- a/tests/parsers/methodical_mind/methodical_mind_parser_test.py
+++ b/tests/parsers/methodical_mind/methodical_mind_parser_test.py
@@ -17,4 +17,8 @@ def test_parse_biorad_bioplex_to_asm_contents(output_file: str) -> None:
     test_filepath = f"tests/parsers/methodical_mind/testdata/{output_file}"
     expected_filepath = test_filepath.replace(".txt", ".json")
     allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
-    validate_contents(allotrope_dict=allotrope_dict, expected_file=expected_filepath)
+    validate_contents(
+        allotrope_dict=allotrope_dict,
+        expected_file=expected_filepath,
+        vendor_type=VENDOR_TYPE,
+    )

--- a/tests/parsers/perkin_elmer_envision/perkin_elmer_envision_data.py
+++ b/tests/parsers/perkin_elmer_envision/perkin_elmer_envision_data.py
@@ -25,7 +25,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueRelativeFluorescenceUnit,
     TQuantityValueUnitless,
 )
-from allotropy.constants import ASM_CONVERTER_NAME, ASM_CONVERTER_VERSION
+from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.parsers.perkin_elmer_envision.perkin_elmer_envision_parser import (
     ReadType,
 )
@@ -197,7 +197,7 @@ def get_model() -> Model:
                 file_name="file.txt",
                 software_name="EnVision Workstation",
                 software_version="1.0",
-                ASM_converter_name=ASM_CONVERTER_NAME,
+                ASM_converter_name="allotropy_perkinelmer_envision",
                 ASM_converter_version=ASM_CONVERTER_VERSION,
             ),
             plate_reader_document=[

--- a/tests/to_allotrope_test.py
+++ b/tests/to_allotrope_test.py
@@ -38,5 +38,6 @@ class ParserTest:
         validate_contents(
             allotrope_dict,
             expected_filepath,
+            self.VENDOR,
             write_actual_to_expected_on_fail=overwrite,
         )


### PR DESCRIPTION
Update ASM converter name field to specify the parser name instead of just "allotropy", this is intended to give better granularity on the adapter that did the conversion and not just the library version