### PR TITLE
refactor: Move pandas read_excel to mabtech contents

### DIFF
--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_contents.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_contents.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
+from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.utils.values import assert_not_none
 
 
 class MabtechApexContents:
-    def __init__(self, raw_contents: dict[str, pd.DataFrame]) -> None:
+    def __init__(self, named_file_contents: NamedFileContents) -> None:
+        raw_contents = pd.read_excel(named_file_contents.contents, sheet_name=None)
         contents = {
             str(name): df.replace(np.nan, None) for name, df in raw_contents.items()
         }

--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_parser.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_parser.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from allotropy.allotrope.models.adm.plate_reader.benchling._2023._09.plate_reader import (
     ContainerType,
     DataSystemDocument,
@@ -47,8 +45,7 @@ class MabtechApexParser(VendorParser):
         return ReleaseState.CANDIDATE_RELEASE
 
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Model:
-        raw_contents = pd.read_excel(named_file_contents.contents, sheet_name=None)
-        contents = MabtechApexContents(raw_contents)
+        contents = MabtechApexContents(named_file_contents)
         data = PlateInformation.create(contents)
         wells = WellList.create(contents)
         return self._get_model(data, wells, named_file_contents.original_file_name)


### PR DESCRIPTION
Tiny refactor - the reasoning here is to enforce a pattern that raw data handling (and as a proxy - pandas imports) do not happen in the parser class.