### PR TITLE
refactor: Remove pandas from parsers simple cases

### DIFF
--- a/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_contents.py
+++ b/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_contents.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import re
+import warnings
+
 import numpy as np
 import pandas as pd
 
 from allotropy.exceptions import AllotropeConversionError
+from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.utils.values import (
     assert_not_empty_df,
     assert_not_none,
@@ -11,6 +15,20 @@ from allotropy.parsers.utils.values import (
 
 
 class DesignQuantstudioContents:
+    @staticmethod
+    def create(named_file_contents: NamedFileContents) -> DesignQuantstudioContents:
+        # We can get a warning that the workbook does not have a default style. We are OK with this, so suppress.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=UserWarning,
+                module=re.escape("openpyxl.styles.stylesheet"),
+            )
+            raw_contents = pd.read_excel(
+                named_file_contents.contents, header=None, sheet_name=None
+            )
+        return DesignQuantstudioContents(raw_contents)
+
     def __init__(self, raw_contents: dict[str, pd.DataFrame]) -> None:
         contents = {
             str(name): df.replace(np.nan, None) for name, df in raw_contents.items()

--- a/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_parser.py
@@ -1,8 +1,3 @@
-import re
-import warnings
-
-import pandas as pd
-
 from allotropy.allotrope.models.adm.pcr.benchling._2023._09.qpcr import (
     BaselineCorrectedReporterDataCube,
     CalculatedDataDocumentItem,
@@ -69,17 +64,7 @@ class AppBioQuantStudioDesignandanalysisParser(VendorParser):
         return ReleaseState.RECOMMENDED
 
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Model:
-        # We can get a warning that the workbook does not have a default style. We are OK with this, so suppress.
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                category=UserWarning,
-                module=re.escape("openpyxl.styles.stylesheet"),
-            )
-            raw_contents = pd.read_excel(
-                named_file_contents.contents, header=None, sheet_name=None
-            )
-        contents = DesignQuantstudioContents(raw_contents)
+        contents = DesignQuantstudioContents.create(named_file_contents)
         data = create_data(contents)
         return self._get_model(data, named_file_contents.original_file_name)
 

--- a/src/allotropy/parsers/beckman_pharmspec/beckman_pharmspec_parser.py
+++ b/src/allotropy/parsers/beckman_pharmspec/beckman_pharmspec_parser.py
@@ -1,8 +1,6 @@
 import re
 from typing import Any
 
-import pandas as pd
-
 from allotropy.allotrope.models.adm.light_obscuration.benchling._2023._12.light_obscuration import (
     CalculatedDataDocumentItem,
     DataProcessingDocument,
@@ -32,6 +30,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueMilliliter,
     TQuantityValueUnitless,
 )
+from allotropy.allotrope.pandas_util import read_excel
 from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.beckman_pharmspec.beckman_pharmspec_structure import (
@@ -69,7 +68,7 @@ class PharmSpecParser(VendorParser):
         return ReleaseState.RECOMMENDED
 
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Model:
-        df = pd.read_excel(named_file_contents.contents, header=None, engine="openpyxl")
+        df = read_excel(named_file_contents.contents, header=None, engine="openpyxl")
         data = PharmSpecData.create(df)
         return self._setup_model(data, named_file_contents.original_file_name)
 

--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_contents.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_contents.py
@@ -8,7 +8,6 @@ from allotropy.parsers.utils.values import assert_not_none
 
 
 class MabtechApexContents:
-
     @staticmethod
     def create(named_file_contents: NamedFileContents) -> MabtechApexContents:
         raw_contents = pd.read_excel(named_file_contents.contents, sheet_name=None)

--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_contents.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_contents.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
+from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.utils.values import assert_not_none
 
 
 class MabtechApexContents:
+
+    @staticmethod
+    def create(named_file_contents: NamedFileContents) -> MabtechApexContents:
+        raw_contents = pd.read_excel(named_file_contents.contents, sheet_name=None)
+        return MabtechApexContents(raw_contents)
+
     def __init__(self, raw_contents: dict[str, pd.DataFrame]) -> None:
         contents = {
             str(name): df.replace(np.nan, None) for name, df in raw_contents.items()

--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_parser.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_parser.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from allotropy.allotrope.models.adm.plate_reader.benchling._2023._09.plate_reader import (
     ContainerType,
     DataSystemDocument,

--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_parser.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_parser.py
@@ -20,7 +20,6 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueNumber,
     TQuantityValueUnitless,
 )
-from allotropy.allotrope.pandas_util import read_excel
 from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.constants import NOT_APPLICABLE
@@ -46,8 +45,7 @@ class MabtechApexParser(VendorParser):
         return ReleaseState.CANDIDATE_RELEASE
 
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Model:
-        raw_contents = read_excel(named_file_contents.contents, sheet_name=None)
-        contents = MabtechApexContents(raw_contents)
+        contents = MabtechApexContents.create(named_file_contents)
         data = PlateInformation.create(contents)
         wells = WellList.create(contents)
         return self._get_model(data, wells, named_file_contents.original_file_name)

--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_parser.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_parser.py
@@ -22,6 +22,7 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValueNumber,
     TQuantityValueUnitless,
 )
+from allotropy.allotrope.pandas_util import read_excel
 from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.constants import NOT_APPLICABLE
@@ -47,7 +48,7 @@ class MabtechApexParser(VendorParser):
         return ReleaseState.CANDIDATE_RELEASE
 
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Model:
-        raw_contents = pd.read_excel(named_file_contents.contents, sheet_name=None)
+        raw_contents = read_excel(named_file_contents.contents, sheet_name=None)
         contents = MabtechApexContents(raw_contents)
         data = PlateInformation.create(contents)
         wells = WellList.create(contents)


### PR DESCRIPTION
The goal here is to ban pandas from parser classes, to encourage authors to structure data when reading it.

These are not cases of that, but just other minor uses of pandas that muddy up the results.