### PR TITLE
refactor: Remove converting measurement calc docs to global calc docs

### DIFF
--- a/src/allotropy/allotrope/schema_mappers/adm/pcr/BENCHLING/_2023/_09/dpcr.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/pcr/BENCHLING/_2023/_09/dpcr.py
@@ -108,14 +108,6 @@ class Data:
     measurement_groups: list[MeasurementGroup]
     calculated_data: list[CalculatedDataItem] | None = None
 
-    def get_calculated_data_items(self) -> list[CalculatedDataItem]:
-        return (self.calculated_data or []) + [
-            calculated_data_item
-            for measurement_group in self.measurement_groups
-            for measurement in measurement_group.measurements
-            for calculated_data_item in (measurement.calculated_data or [])
-        ]
-
 
 class Mapper:
     MANIFEST = "http://purl.allotrope.org/manifests/pcr/BENCHLING/2023/09/dpcr.manifest"
@@ -145,7 +137,7 @@ class Mapper:
                     for measurement_group in data.measurement_groups
                 ],
                 calculated_data_aggregate_document=self._get_calculated_data_aggregate_document(
-                    data
+                    data.calculated_data
                 ),
             )
         )
@@ -221,9 +213,9 @@ class Mapper:
         )
 
     def _get_calculated_data_aggregate_document(
-        self, data: Data
+        self, calculated_data_items: list[CalculatedDataItem] | None
     ) -> TCalculatedDataAggregateDocument | None:
-        if not (calculated_data_document := data.get_calculated_data_items()):
+        if not calculated_data_items:
             return None
 
         return TCalculatedDataAggregateDocument(
@@ -245,6 +237,6 @@ class Mapper:
                         ]
                     ),
                 )
-                for calculated_data_item in calculated_data_document
+                for calculated_data_item in calculated_data_items
             ]
         )

--- a/src/allotropy/allotrope/schema_mappers/adm/plate_reader/benchling/_2023/_09/plate_reader.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/plate_reader/benchling/_2023/_09/plate_reader.py
@@ -116,7 +116,6 @@ class Measurement:
     luminescence: JsonFloat | None = None
 
     # Processed data
-    calculated_data: list[CalculatedDataItem] | None = None
     processed_data: ProcessedData | None = None
 
     # Settings
@@ -189,14 +188,6 @@ class Data:
     measurement_groups: list[MeasurementGroup]
     calculated_data: list[CalculatedDataItem] | None = None
 
-    def get_calculated_data_items(self) -> list[CalculatedDataItem]:
-        return (self.calculated_data or []) + [
-            calculated_data_item
-            for measurement_group in self.measurement_groups
-            for measurement in measurement_group.measurements
-            for calculated_data_item in (measurement.calculated_data or [])
-        ]
-
 
 class Mapper:
     MANIFEST = "http://purl.allotrope.org/manifests/plate-reader/BENCHLING/2023/09/plate-reader.manifest"
@@ -230,7 +221,7 @@ class Mapper:
                     for measurement_group in data.measurement_groups
                 ],
                 calculated_data_aggregate_document=self._get_calculated_data_aggregate_document(
-                    data
+                    data.calculated_data
                 ),
             ),
             field_asm_manifest=self.MANIFEST,
@@ -491,9 +482,9 @@ class Mapper:
         )
 
     def _get_calculated_data_aggregate_document(
-        self, data: Data
+        self, calculated_data_items: list[CalculatedDataItem] | None
     ) -> CalculatedDataAggregateDocument | None:
-        if not (calculated_data_document := data.get_calculated_data_items()):
+        if not calculated_data_items:
             return None
 
         return CalculatedDataAggregateDocument(
@@ -515,6 +506,6 @@ class Mapper:
                         ]
                     ),
                 )
-                for calculated_data_item in calculated_data_document
+                for calculated_data_item in calculated_data_items
             ]
         )

--- a/src/allotropy/allotrope/schema_mappers/adm/spectrophotometry/benchling/_2023/_12/spectrophotometry.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/spectrophotometry/benchling/_2023/_12/spectrophotometry.py
@@ -131,14 +131,6 @@ class Data:
     measurement_groups: list[MeasurementGroup]
     calculated_data: list[CalculatedDataItem] | None = None
 
-    def get_calculated_data_items(self) -> list[CalculatedDataItem]:
-        return (self.calculated_data or []) + [
-            calculated_data_item
-            for measurement_group in self.measurement_groups
-            for measurement in measurement_group.measurements
-            for calculated_data_item in (measurement.calculated_data or [])
-        ]
-
 
 class Mapper:
     MANIFEST = "http://purl.allotrope.org/manifests/spectrophotometry/BENCHLING/2023/12/spectrophotometry.manifest"
@@ -180,7 +172,7 @@ class Mapper:
                     for measurement_group in data.measurement_groups
                 ],
                 calculated_data_aggregate_document=self._get_calculated_data_aggregate_document(
-                    data
+                    data.calculated_data
                 ),
             ),
             field_asm_manifest=self.MANIFEST,
@@ -209,6 +201,9 @@ class Mapper:
             ),
             absorbance=TQuantityValueMilliAbsorbanceUnit(
                 value=assert_not_none(measurement.absorbance)  # type: ignore[arg-type]
+            ),
+            calculated_data_aggregate_document=self._get_calculated_data_aggregate_document(
+                measurement.calculated_data
             ),
         )
 
@@ -239,9 +234,9 @@ class Mapper:
         )
 
     def _get_calculated_data_aggregate_document(
-        self, data: Data
+        self, calculated_data_items: list[CalculatedDataItem] | None
     ) -> CalculatedDataAggregateDocument | None:
-        if not (calculated_data_document := data.get_calculated_data_items()):
+        if not calculated_data_items:
             return None
 
         return CalculatedDataAggregateDocument(
@@ -263,6 +258,6 @@ class Mapper:
                         ]
                     ),
                 )
-                for calculated_data_item in calculated_data_document
+                for calculated_data_item in calculated_data_items
             ]
         )


### PR DESCRIPTION
This removes a mistaken approach of pulling all calculated documents from all measurement documents into the global calculated data documents list. This is wrong because some ASM documents report calculated data documents inside of measurement documents.

The location of the calculated data documents within the data classes should signal where they should be placed within the ASM document.

This was done in the `plate reader` mapper because one parser (unchained labs) was taking this approach, of putting all calculated data documents in the global document, even if they correspond to measurement rows. I'm not sure why we are putting measurement-specific calculated data documents in the global calculated data document, and I'm not changing it here (left a TODO comment to investigate).

Instead, the offending parser is changed to move the calculated documents to the global level in the data class. 

Note that this is classified as a refactor only, because it does not change any output of any test cases.
