### PR TITLE
fix: Simplify Vi-cell XR text reader

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,6 +1,7 @@
 {
   "allowCompoundWords": true,
   "words": [
+    "astype",
     "chardet",
     "flourescence",
     "genotyping",
@@ -12,7 +13,8 @@
     "pydantic",
     "pyproject",
     "pytest",
-    "sdist"
+    "sdist",
+    "unstructure"
   ],
   "flagWords": [
     "hte",

--- a/.vscode/cspell_companies.txt
+++ b/.vscode/cspell_companies.txt
@@ -4,7 +4,6 @@ MOLDEV
 Nucleoview
 Qiacuity
 Revvity
-unstructure
 WEYLAND
 Xponent
 YUTANI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Raise AllotropeConversionError on missing Results section in Agilent Gen5
 - Add error for multiple read modes in Agilent Gen5
 - Cast data to str before using in AppBio QuantStudio parser
+- Simplify VI-Cell XR text file reader, removing bug in pivot operation
 
 ### Changed
 - Only return AllotropeConversionError when there is a problem with input data that we expect, add other errors for unexpected problems.

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_reader.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_reader.py
@@ -7,7 +7,8 @@ from typing import Any
 
 import pandas as pd
 
-from allotropy.allotrope.pandas_util import read_excel
+from allotropy.allotrope.pandas_util import read_csv, read_excel
+from allotropy.exceptions import AllotropyParserError
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.beckman_vi_cell_xr.constants import (
     DATE_HEADER,
@@ -17,13 +18,13 @@ from allotropy.parsers.beckman_vi_cell_xr.constants import (
     XrVersion,
 )
 from allotropy.parsers.lines_reader import read_to_lines
-from allotropy.parsers.utils.pandas import SeriesData
+from allotropy.parsers.utils.pandas import df_to_series, SeriesData
 from allotropy.parsers.utils.values import assert_value_from_df
 
 
 @dataclass
 class ViCellData:
-    data: pd.DataFrame
+    data: list[SeriesData]
     file_info: SeriesData
 
 
@@ -37,7 +38,7 @@ def create_reader_data(named_file_contents: NamedFileContents) -> ViCellData:
 
 
 class ViCellXRReader:
-    data: pd.DataFrame
+    data: list[SeriesData]
     series: SeriesData
 
     def __init__(self, named_file_contents: NamedFileContents) -> None:
@@ -55,7 +56,7 @@ class ViCellXRReader:
     def _read_excel(self, **kwargs: Any) -> pd.DataFrame:
         return read_excel(self.contents, engine=self.engine, **kwargs)
 
-    def _read_data(self) -> pd.DataFrame:
+    def _read_data(self) -> list[SeriesData]:
         header_row = 4
         if self.file_version == XrVersion._2_04:
             header_row = 3
@@ -78,19 +79,22 @@ class ViCellXRReader:
             errors="coerce",
         )
         file_data = file_data.dropna(subset=DATE_HEADER)
-
-        return file_data
+        return [SeriesData(x) for _, x in file_data.iterrows()]
 
     def _get_file_header(self, header_row: int) -> list[str]:
         """Combine the two rows that forms the header."""
-        header = self._read_excel(
-            nrows=2,
-            skiprows=header_row,
-            header=None,
-        ).fillna("")
+        header = (
+            self._read_excel(
+                nrows=2,
+                skiprows=header_row,
+                header=None,
+            )
+            .fillna("")
+            .astype(str)
+        )
 
         header_list: list[str] = header.agg(
-            lambda x: " ".join([str(v) for v in x]).replace(" /ml", "/ml").strip()
+            lambda x: " ".join(x).replace(" /ml", "/ml").strip()
         ).to_list()
         return header_list
 
@@ -102,9 +106,15 @@ class ViCellXRReader:
         return SeriesData(info)
 
     def _get_file_version(self) -> XrVersion:
-        match = re.match(MODEL_RE, self.file_info[str, "model"], flags=re.IGNORECASE)
+        raw_model = self.file_info.get(str, "model")
+        if not raw_model:
+            msg = f"Unable to retrive model from file info: {self.file_info}"
+            raise AllotropyParserError(msg)
+        match = re.match(MODEL_RE, raw_model, flags=re.IGNORECASE)
+        if not match:
+            return DEFAULT_VERSION
         try:
-            version = match.groupdict()["version"]  # type: ignore[union-attr]
+            version = match.groupdict()["version"]
         except AttributeError:
             return DEFAULT_VERSION
         # TODO: raise exception for unsupported versions
@@ -113,7 +123,7 @@ class ViCellXRReader:
 
 
 class ViCellXRTXTReader:
-    data: pd.DataFrame
+    data: list[SeriesData]
     series: SeriesData
 
     def __init__(self, contents: NamedFileContents) -> None:
@@ -121,42 +131,26 @@ class ViCellXRTXTReader:
         self.file_info = self._get_file_info()
         self.data = self._read_data()
 
-    def _read_data(self) -> pd.DataFrame:
-        # generate long, single column dataframe
-        file_data = pd.DataFrame(data=StringIO("\n".join(self.lines)))
-
-        # strip whitespace
-        file_data[0] = file_data[0].str.strip()
-
-        # drop empty cells
-        file_data = file_data.replace("", None).dropna(axis=0, how="all")
-
-        # split on colon surrounded by any amount of space, limited to one split to avoid destroying datetimes
-        file_data = file_data[file_data.columns[0]].str.split(
-            r"\s*:\s*", n=1, expand=True
+    def _read_data(self) -> list[SeriesData]:
+        data_frame = read_csv(
+            StringIO("\n".join(self.lines)), sep=" :", index_col=0, engine="python"
         )
-
-        # pivot the long data of a single sample to a df that is 1 wide row
-        file_data["Pivot Index"] = 1
-        file_data = file_data.pivot(index="Pivot Index", columns=0)
-
-        # rename the columns to match the existing parser that was based on xls(x) files
-        file_data.columns = pd.Index(
-            [
-                HEADINGS_TO_PARSER_HEADINGS.get(name, name)
-                for name in [x[1] for x in file_data.columns]
-            ]
+        file_data = df_to_series(
+            data_frame.astype(str).T, "Failed to parse input file."
         )
-
+        file_data = file_data.str.strip().replace("", None)
+        file_data.index = pd.Index(
+            [HEADINGS_TO_PARSER_HEADINGS.get(name, name) for name in file_data.index]
+        )
         # Do the datetime conversion and remove all rows that fail to pass as datetime
         # This fixes an issue where some files have a hidden invalid first row
         file_data[DATE_HEADER] = pd.to_datetime(
-            file_data[DATE_HEADER].astype(str),
+            file_data[DATE_HEADER],
             format="%d %b %Y  %I:%M:%S %p",
             errors="coerce",
         )
 
-        return file_data
+        return [SeriesData(file_data)]
 
     def _get_file_info(self) -> SeriesData:
         data = self.lines

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_structure.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_structure.py
@@ -21,7 +21,7 @@ from allotropy.parsers.beckman_vi_cell_xr.constants import (
     XrVersion,
 )
 from allotropy.parsers.beckman_vi_cell_xr.vi_cell_xr_reader import ViCellData
-from allotropy.parsers.utils.pandas import map_rows, SeriesData
+from allotropy.parsers.utils.pandas import SeriesData
 from allotropy.parsers.utils.uuids import random_uuid_str
 from allotropy.parsers.utils.values import assert_not_none
 
@@ -91,4 +91,4 @@ def create_data(reader_data: ViCellData, file_name: str) -> Data:
         file_name=file_name,
     )
 
-    return Data(metadata, map_rows(reader_data.data, _create_measurement_group))
+    return Data(metadata, [_create_measurement_group(row) for row in reader_data.data])


### PR DESCRIPTION
The `pivot` operation in XR text file reader can have a failure if there is duplicated data, which was seen a couple times in real life usage. 

Simplify the parsing of the text file into pandas dataframe, removing the need for the pivot entirely.