### PR TITLE
fix: Fix measurement grouping in roche cedex bioht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Raise AllotropeConversionError on missing Results section in Agilent Gen5
 - Add error for multiple read modes in Agilent Gen5
 - Cast data to str before using in AppBio QuantStudio parser
+- Fix edge case where there are multiple measurements for a property in Roche Cedex Bioht
 
 ### Changed
 - Only return AllotropeConversionError when there is a problem with input data that we expect, add other errors for unexpected problems.

--- a/src/allotropy/parsers/roche_cedex_bioht/constants.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/constants.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from allotropy.allotrope.models.shared.definitions.custom import (
     TNullableQuantityValueCell,
     TNullableQuantityValueGramPerLiter,
@@ -13,6 +15,12 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TNullableQuantityValueUnitPerLiter,
 )
 
+# Measurements of a sample have different timestamps, typically spaced closely together (max diff observed - 9 min)
+# Some result files have multiple sets of measurements, over multiple days.
+# Measurements with a time difference greater than MAX_MEASUREMENT_TIME_GROUP_DIFFERENCE from the last
+# measurement recorded will be put into separate groups.
+MAX_MEASUREMENT_TIME_GROUP_DIFFERENCE = timedelta(hours=1)
+
 MOLAR_CONCENTRATION_CLASSES: list[
     (
         type[TNullableQuantityValueMillimolePerLiter]
@@ -27,7 +35,7 @@ MOLAR_CONCENTRATION_CLASSES: list[
 
 MOLAR_CONCENTRATION_CLS_BY_UNIT = {cls.unit: cls for cls in MOLAR_CONCENTRATION_CLASSES}
 
-NON_AGGREGABLE_PROPERTIES = {
+NON_ANALYTE_PROPERTIES = {
     "pco2": TNullableQuantityValueMillimeterOfMercury,
     "co2_saturation": TNullableQuantityValuePercent,
     "po2": TNullableQuantityValueMillimeterOfMercury,

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
@@ -7,7 +7,6 @@ from allotropy.allotrope.models.adm.cell_culture_analyzer.benchling._2023._09.ce
     Model,
     SampleDocument,
 )
-from allotropy.exceptions import get_key_or_error
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.release_state import ReleaseState
 from allotropy.parsers.roche_cedex_bioht.constants import (
@@ -19,7 +18,6 @@ from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_reader import (
 )
 from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_structure import Data, Sample
 from allotropy.parsers.utils.uuids import random_uuid_str
-from allotropy.parsers.utils.values import assert_not_none
 from allotropy.parsers.vendor_parser import VendorParser
 
 
@@ -83,7 +81,9 @@ class RocheCedexBiohtParser(VendorParser):
                         doc, name, analyte_cls(value=measurement.concentration_value)
                     )
                 else:
-                    molar_concentration_item_cls = MOLAR_CONCENTRATION_CLS_BY_UNIT.get(measurement.unit or "")
+                    molar_concentration_item_cls = MOLAR_CONCENTRATION_CLS_BY_UNIT.get(
+                        measurement.unit or ""
+                    )
                     if not molar_concentration_item_cls:
                         continue
                     analyte_documents.append(

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
@@ -9,6 +9,10 @@ from allotropy.allotrope.models.adm.cell_culture_analyzer.benchling._2023._09.ce
 )
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.release_state import ReleaseState
+from allotropy.parsers.roche_cedex_bioht.constants import (
+    MOLAR_CONCENTRATION_CLS_BY_UNIT,
+    NON_AGGREGABLE_PROPERTIES,
+)
 from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_reader import (
     RocheCedexBiohtReader,
 )
@@ -56,6 +60,33 @@ class RocheCedexBiohtParser(VendorParser):
     def _get_measurements_from_sample(
         self, sample: Sample
     ) -> list[MeasurementDocumentItem]:
+        docs: list[MeasurementDocumentItem] = []
+
+        for measurement_time, measurements in sample.analyte_list.measurements.items():
+            doc = MeasurementDocumentItem(
+                sample_document=SampleDocument(
+                    sample_identifier=sample.name,
+                    batch_identifier=sample.batch,
+                ),
+                measurement_time=self._get_date_time(measurement_time),
+                analyte_aggregate_document=AnalyteAggregateDocument(analyte_document=[]),
+            )
+            for name in sorted(measurements):
+                analyte = measurements[name]
+                if analyte_cls := NON_AGGREGABLE_PROPERTIES.get(name):
+                    setattr(doc, name, analyte_cls(value=analyte.concentration_value))
+                else:
+                    molar_concentration_item_cls = MOLAR_CONCENTRATION_CLS_BY_UNIT.get(analyte.unit)
+                    doc.analyte_aggregate_document.analyte_document.append(
+                        AnalyteDocumentItem(
+                            analyte_name=name,
+                            molar_concentration=molar_concentration_item_cls(value=analyte.concentration_value),
+                        )
+                    )
+            docs.append(doc)
+
+        return docs
+
         sample_measurements = [
             self._create_sample_measurement(sample)
             for _ in range(sample.analyte_list.num_measurement_docs)
@@ -82,13 +113,3 @@ class RocheCedexBiohtParser(VendorParser):
                 setattr(sample_measurement, analyte_name, value)
 
         return sample_measurements
-
-    def _create_sample_measurement(self, sample: Sample) -> MeasurementDocumentItem:
-        return MeasurementDocumentItem(
-            sample_document=SampleDocument(
-                sample_identifier=sample.name,
-                batch_identifier=sample.batch,
-            ),
-            measurement_time=self._get_date_time(sample.measurement_time),
-            analyte_aggregate_document=AnalyteAggregateDocument(analyte_document=[]),
-        )

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
@@ -94,7 +94,7 @@ class RocheCedexBiohtParser(VendorParser):
                             ),
                         )
                     )
-            doc.analyte_aggregate_document.analyte_document = analyte_documents or None
+            doc.analyte_aggregate_document.analyte_document = analyte_documents
             docs.append(doc)
 
         return docs

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
@@ -83,20 +83,13 @@ class RocheCedexBiohtParser(VendorParser):
                         doc, name, analyte_cls(value=measurement.concentration_value)
                     )
                 else:
-                    molar_concentration_item_cls = (
-                        get_key_or_error(
-                            "molar concentration unit",
-                            assert_not_none(
-                                measurement.unit,
-                                f"Expected unit to be specified for analyte {name}",
-                            ),
-                            MOLAR_CONCENTRATION_CLS_BY_UNIT,
-                        ),
-                    )
+                    molar_concentration_item_cls = MOLAR_CONCENTRATION_CLS_BY_UNIT.get(measurement.unit or "")
+                    if not molar_concentration_item_cls:
+                        continue
                     analyte_documents.append(
                         AnalyteDocumentItem(
                             analyte_name=name,
-                            molar_concentration=molar_concentration_item_cls(  # type: ignore[operator]
+                            molar_concentration=molar_concentration_item_cls(
                                 value=measurement.concentration_value
                             ),
                         )

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_structure.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_structure.py
@@ -66,13 +66,15 @@ class AnalyteList:
         measurements = defaultdict(dict)
 
         current_measurement_time = analytes[0].measurement_time
+        previous_measurement_time = current_measurement_time
         for analyte in analytes:
-            time_diff = parser.parse(analyte.measurement_time) - parser.parse(current_measurement_time)
+            time_diff = parser.parse(analyte.measurement_time) - parser.parse(previous_measurement_time)
             if time_diff > timedelta(hours=1):
                 current_measurement_time = analyte.measurement_time
             if analyte.concentration_value is None and analyte.name in measurements[current_measurement_time]:
                 continue
             measurements[current_measurement_time][analyte.name] = analyte
+            previous_measurement_time = analyte.measurement_time
 
         return AnalyteList(measurements)
 

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_structure.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_structure.py
@@ -4,19 +4,17 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import timedelta
 
 from dateutil import parser
 import pandas as pd
 
 from allotropy.parsers.roche_cedex_bioht.constants import (
-    MOLAR_CONCENTRATION_CLS_BY_UNIT,
-    NON_AGGREGABLE_PROPERTIES,
+    MAX_MEASUREMENT_TIME_GROUP_DIFFERENCE,
 )
 from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_reader import (
     RocheCedexBiohtReader,
 )
-from allotropy.parsers.utils.pandas import SeriesData
+from allotropy.parsers.utils.pandas import map_rows, SeriesData
 
 
 @dataclass(frozen=True)
@@ -37,132 +35,60 @@ class Title:
 
 
 @dataclass(frozen=True)
-class Analyte:
+class Measurement:
     name: str
     measurement_time: str
-    concentration_value: float | None
-    unit: str | None
+    concentration_value: float | None = None
+    unit: str | None = None
 
     @staticmethod
-    def create(data: pd.Series) -> Analyte:
-        analyte_name: str = data.get("analyte name")  # type: ignore[assignment]
-        measurement_time: str = data.get("measurement time")  # type: ignore[assignment]
-        concentration_value: float | None = data.get("concentration value")  # type: ignore[assignment]
-        unit: str | None = data.get("concentration unit")  # type: ignore[assignment]
-
-        return Analyte(analyte_name, measurement_time, concentration_value, unit)
-
-
-@dataclass(frozen=True)
-class AnalyteList:
-    measurements: dict[str, dict[str, Analyte]]
-
-    @staticmethod
-    def create(data: pd.DataFrame) -> AnalyteList:
-        analytes = [Analyte.create(analyte_data) for _, analyte_data in data.iterrows()]
-        analytes = sorted(analytes, key=lambda a: a.measurement_time)
-
-        # Dict from measurement time to data
-        measurements = defaultdict(dict)
-
-        current_measurement_time = analytes[0].measurement_time
-        previous_measurement_time = current_measurement_time
-        for analyte in analytes:
-            time_diff = parser.parse(analyte.measurement_time) - parser.parse(previous_measurement_time)
-            if time_diff > timedelta(minutes=5):
-                current_measurement_time = analyte.measurement_time
-            if analyte.concentration_value is None and analyte.name in measurements[current_measurement_time]:
-                continue
-            measurements[current_measurement_time][analyte.name] = analyte
-            previous_measurement_time = analyte.measurement_time
-
-        return AnalyteList(measurements)
-
-        molar_concentration_dict = defaultdict(list)
-        molar_concentration_nans = {}
-        non_aggregrable_dict = defaultdict(list)
-        non_aggregable_nans = {}
-        num_measurement_docs = 1
-
-        for analyte in analytes:
-            analyte_name = analyte.name
-            concentration_value = analyte.concentration_value
-
-            if analyte_cls := NON_AGGREGABLE_PROPERTIES.get(analyte_name):
-                if concentration_value is None:
-                    non_aggregable_nans[analyte_name] = analyte_cls(
-                        value=concentration_value
-                    )
-                else:
-                    non_aggregrable_dict[analyte_name].append(
-                        analyte_cls(value=concentration_value)
-                    )
-
-                num_measurement_docs = max(
-                    len(non_aggregrable_dict[analyte_name]), num_measurement_docs
-                )
-            else:
-                unit = analyte.unit
-                if unit is None:
-                    continue
-
-                molar_concentration_item_cls = MOLAR_CONCENTRATION_CLS_BY_UNIT.get(unit)
-                if molar_concentration_item_cls is None:
-                    continue
-
-                molar_concentration_item = molar_concentration_item_cls(
-                    value=concentration_value
-                )
-                if concentration_value is None:
-                    molar_concentration_nans[analyte_name] = molar_concentration_item
-                else:
-                    molar_concentration_dict[analyte_name].append(
-                        molar_concentration_item
-                    )
-                num_measurement_docs = max(
-                    len(molar_concentration_dict[analyte_name]), num_measurement_docs
-                )
-
-        # Only include None values if there is not a valid value for that analyte
-        for analyte_name in non_aggregable_nans:
-            if len(non_aggregrable_dict[analyte_name]) == 0:
-                non_aggregrable_dict[analyte_name].append(
-                    non_aggregable_nans[analyte_name]
-                )
-                num_measurement_docs = max(
-                    len(non_aggregrable_dict[analyte_name]), num_measurement_docs
-                )
-
-        for analyte_name in molar_concentration_nans:
-            if len(molar_concentration_dict[analyte_name]) == 0:
-                molar_concentration_dict[analyte_name].append(
-                    molar_concentration_nans[analyte_name]
-                )
-                num_measurement_docs = max(
-                    len(molar_concentration_dict[analyte_name]), num_measurement_docs
-                )
-
-        return AnalyteList(
-            analytes,
-            molar_concentration_dict,
-            molar_concentration_nans,
-            non_aggregrable_dict,
-            non_aggregable_nans,
-            num_measurement_docs,
+    def create(data: SeriesData) -> Measurement:
+        return Measurement(
+            data[str, "analyte name"],
+            data[str, "measurement time"],
+            data.get(float, "concentration value"),
+            data.get(str, "concentration unit"),
         )
+
+
+def create_measurements(data: pd.DataFrame) -> dict[str, dict[str, Measurement]]:
+    measurements = sorted(
+        map_rows(data, Measurement.create), key=lambda a: a.measurement_time
+    )
+
+    # Dict from measurement time to data
+    groups: defaultdict[str, dict[str, Measurement]] = defaultdict(dict)
+
+    current_measurement_time = measurements[0].measurement_time
+    previous_measurement_time = current_measurement_time
+    for analyte in measurements:
+        time_diff = parser.parse(analyte.measurement_time) - parser.parse(
+            previous_measurement_time
+        )
+        if time_diff > MAX_MEASUREMENT_TIME_GROUP_DIFFERENCE:
+            current_measurement_time = analyte.measurement_time
+        if (
+            analyte.concentration_value is None
+            and analyte.name in groups[current_measurement_time]
+        ):
+            continue
+        groups[current_measurement_time][analyte.name] = analyte
+        previous_measurement_time = analyte.measurement_time
+
+    return dict(groups)
 
 
 @dataclass(frozen=True)
 class Sample:
     name: str
-    analyte_list: AnalyteList
+    measurements: dict[str, dict[str, Measurement]]
     batch: str | None = None
 
     @staticmethod
     def create(name: str, batch: str | None, sample_data: pd.DataFrame) -> Sample:
         return Sample(
             name,
-            AnalyteList.create(sample_data),
+            create_measurements(sample_data),
             batch=batch or None,
         )
 
@@ -177,7 +103,7 @@ class Data:
         return Data(
             title=Title.create(reader.title_data),
             samples=[
-                Sample.create(name, batch, samples_data.sort_values(by="analyte name"))
+                Sample.create(name, batch, samples_data)
                 for (name, batch), samples_data in reader.samples_data.groupby(
                     # A sample group is defined by both the sample and the batch identifier
                     ["sample identifier", "batch identifier"]

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_structure.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_structure.py
@@ -69,7 +69,7 @@ class AnalyteList:
         previous_measurement_time = current_measurement_time
         for analyte in analytes:
             time_diff = parser.parse(analyte.measurement_time) - parser.parse(previous_measurement_time)
-            if time_diff > timedelta(hours=1):
+            if time_diff > timedelta(minutes=5):
                 current_measurement_time = analyte.measurement_time
             if analyte.concentration_value is None and analyte.name in measurements[current_measurement_time]:
                 continue

--- a/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_data.py
+++ b/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_data.py
@@ -20,9 +20,8 @@ from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_reader import (
     RocheCedexBiohtReader,
 )
 from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_structure import (
-    Analyte,
-    AnalyteList,
     Data,
+    Measurement,
     Sample,
     Title,
 )
@@ -163,29 +162,16 @@ def get_data() -> Data:
         samples=[
             Sample(
                 name="PPDTEST1",
-                measurement_time="2021-05-20 16:55:51",
-                analyte_list=AnalyteList(
-                    analytes=[
-                        Analyte("ammonia", 1.846, "mmol/L"),
-                        Analyte("glutamine", 2.45, "mmol/L"),
-                    ],
-                    molar_concentration_dict={
-                        "ammonia": [
-                            TNullableQuantityValueMillimolePerLiter(
-                                value=1.846,
-                            )
-                        ],
-                        "glutamine": [
-                            TNullableQuantityValueMillimolePerLiter(
-                                value=2.45,
-                            )
-                        ],
-                    },
-                    molar_concentration_nans={},
-                    non_aggregrable_dict={},
-                    non_aggregable_nans={},
-                    num_measurement_docs=1,
-                ),
+                measurements={
+                    "2021-05-20 16:55:51": {
+                        "ammonia": Measurement(
+                            "ammonia", "2021-05-20 16:55:51", 1.846, "mmol/L"
+                        ),
+                        "glutamine": Measurement(
+                            "glutamine", "2021-05-20 16:55:51", 2.45, "mmol/L"
+                        ),
+                    }
+                },
             )
         ],
     )

--- a/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_structure_test.py
+++ b/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_structure_test.py
@@ -1,14 +1,11 @@
 import pandas as pd
 import pytest
 
-from allotropy.allotrope.models.shared.definitions.custom import (
-    TNullableQuantityValueMilliOsmolesPerKilogram,
-)
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_structure import (
-    Analyte,
-    AnalyteList,
+    create_measurements,
     Data,
+    Measurement,
     Sample,
     Title,
 )
@@ -71,74 +68,100 @@ def test_create_title_with_no_serial_number() -> None:
 
 
 @pytest.mark.short
-def test_create_analyte() -> None:
-    data = pd.Series(
-        {
-            "analyte name": "glutamine",
-            "concentration value": 2.45,
-            "concentration unit": "mmol/L",
-        }
+def test_create_measurement() -> None:
+    data = SeriesData(
+        pd.Series(
+            {
+                "analyte name": "glutamine",
+                "measurement time": "2021-05-20T16:55:51+00:00",
+                "concentration value": 2.45,
+                "concentration unit": "mmol/L",
+            }
+        )
     )
-    analyte = Analyte.create(data)
-    assert analyte.name == "glutamine"
-    assert analyte.concentration_value == 2.45
-    assert analyte.unit == "mmol/L"
+    measurement = Measurement.create(data)
+    assert measurement.name == "glutamine"
+    assert measurement.measurement_time == "2021-05-20T16:55:51+00:00"
+    assert measurement.concentration_value == 2.45
+    assert measurement.unit == "mmol/L"
 
 
 @pytest.mark.short
-def test_create_analyte_with_no_unit() -> None:
-    data = pd.Series(
-        {
-            "analyte name": "aspartate",
-            "concentration value": 1.45,
-        }
+def test_create_measurement_with_no_unit() -> None:
+    data = SeriesData(
+        pd.Series(
+            {
+                "analyte name": "aspartate",
+                "measurement time": "2021-05-20T16:55:51+00:00",
+                "concentration value": 1.45,
+            }
+        )
     )
-    analyte = Analyte.create(data)
-    assert analyte.name == "aspartate"
-    assert analyte.concentration_value == 1.45
-    assert analyte.unit is None
+    measurement = Measurement.create(data)
+    assert measurement.name == "aspartate"
+    assert measurement.measurement_time == "2021-05-20T16:55:51+00:00"
+    assert measurement.concentration_value == 1.45
+    assert measurement.unit is None
 
 
 @pytest.mark.short
-def test_create_analyte_list() -> None:
+def test_create_measurements() -> None:
     data = pd.DataFrame(
         {
             "analyte name": ["lactate", "glutamine", "osmolality"],
+            "measurement time": [
+                "2021-05-20T16:55:51+00:00",
+                "2021-05-20T16:56:51+00:00",
+                "2021-05-20T16:57:51+00:00",
+            ],
             "concentration unit": ["g/L", "mmol/L", "mosm/kg"],
             "concentration value": [2.45, 4.35, 3.7448],
         }
     )
-    analyte_list = AnalyteList.create(data)
+    measurements = create_measurements(data)
 
-    assert analyte_list.analytes == [
-        Analyte("lactate", 2.45, "g/L"),
-        Analyte("glutamine", 4.35, "mmol/L"),
-        Analyte("osmolality", 3.7448, "mosm/kg"),
-    ]
-    assert analyte_list.non_aggregrable_dict == {
-        "osmolality": [TNullableQuantityValueMilliOsmolesPerKilogram(value=3.7448)]
+    assert measurements == {
+        "2021-05-20T16:55:51+00:00": {
+            "lactate": Measurement("lactate", "2021-05-20T16:55:51+00:00", 2.45, "g/L"),
+            "glutamine": Measurement(
+                "glutamine", "2021-05-20T16:56:51+00:00", 4.35, "mmol/L"
+            ),
+            "osmolality": Measurement(
+                "osmolality", "2021-05-20T16:57:51+00:00", 3.7448, "mosm/kg"
+            ),
+        }
     }
-    assert analyte_list.num_measurement_docs == 1
 
 
 @pytest.mark.short
-def test_create_analyte_list_more_than_one_mesurement_docs() -> None:
+def test_create_analyte_list_more_than_one_measurement_docs() -> None:
     data = pd.DataFrame(
         {
             "analyte name": ["lactate", "glutamine", "glutamine"],
+            "measurement time": [
+                "2021-05-20T16:55:51+00:00",
+                "2021-05-20T16:56:51+00:00",
+                "2021-05-21T16:57:51+00:00",
+            ],
             "concentration unit": ["g/L", "mmol/L", "mmol/L"],
             "concentration value": [2.45, 4.35, 3.45],
         },
     )
-    analyte_list = AnalyteList.create(data)
+    measurements = create_measurements(data)
 
-    assert analyte_list.analytes == [
-        Analyte("lactate", 2.45, "g/L"),
-        Analyte("glutamine", 4.35, "mmol/L"),
-        Analyte("glutamine", 3.45, "mmol/L"),
-    ]
-    assert analyte_list.num_measurement_docs == 2
-    assert analyte_list.non_aggregrable_dict == {}
+    assert measurements == {
+        "2021-05-20T16:55:51+00:00": {
+            "lactate": Measurement("lactate", "2021-05-20T16:55:51+00:00", 2.45, "g/L"),
+            "glutamine": Measurement(
+                "glutamine", "2021-05-20T16:56:51+00:00", 4.35, "mmol/L"
+            ),
+        },
+        "2021-05-21T16:57:51+00:00": {
+            "glutamine": Measurement(
+                "glutamine", "2021-05-21T16:57:51+00:00", 3.45, "mmol/L"
+            ),
+        },
+    }
 
 
 @pytest.mark.short
@@ -164,8 +187,14 @@ def test_create_sample() -> None:
     )
     assert sample.name == "PPDTEST1"
     assert sample.batch == "batch_id"
-    assert sample.measurement_time == "2021-05-20 16:56:51"
-    assert len(sample.analyte_list.analytes) == 2
+    assert sample.measurements == {
+        "2021-05-20 16:55:51": {
+            "lactate": Measurement("lactate", "2021-05-20 16:55:51", 2.45, "g/L"),
+            "glutamine": Measurement(
+                "glutamine", "2021-05-20 16:56:51", 4.35, "mmol/L"
+            ),
+        }
+    }
 
 
 @pytest.mark.short

--- a/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_structure_test.py
+++ b/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_structure_test.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from allotropy.exceptions import AllotropeConversionError
+from allotropy.exceptions import AllotropeConversionError, AllotropyParserError
 from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_structure import (
     create_measurements,
     Data,
@@ -134,7 +134,7 @@ def test_create_measurements() -> None:
 
 
 @pytest.mark.short
-def test_create_analyte_list_more_than_one_measurement_docs() -> None:
+def test_create_measurements_more_than_one_measurement_docs() -> None:
     data = pd.DataFrame(
         {
             "analyte name": ["lactate", "glutamine", "glutamine"],
@@ -162,6 +162,28 @@ def test_create_analyte_list_more_than_one_measurement_docs() -> None:
             ),
         },
     }
+
+
+@pytest.mark.short
+def test_create_measurements_duplicate_measurements() -> None:
+    data = pd.DataFrame(
+        {
+            "analyte name": ["lactate", "glutamine", "glutamine"],
+            "measurement time": [
+                "2021-05-20T16:55:51+00:00",
+                "2021-05-20T16:56:51+00:00",
+                "2021-05-20T16:57:51+00:00",
+            ],
+            "concentration unit": ["g/L", "mmol/L", "mmol/L"],
+            "concentration value": [2.45, 4.35, 3.45],
+        },
+    )
+
+    with pytest.raises(
+        AllotropyParserError,
+        match="Duplicate measurement for glutamine in the same measurement group.",
+    ):
+        create_measurements(data)
 
 
 @pytest.mark.short

--- a/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example01.json
+++ b/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example01.json
@@ -12,7 +12,7 @@
                 "sample document": {
                     "sample identifier": "SMPL1"
                 },
-                "measurement time": "2023-09-15T16:56:26+00:00",
+                "measurement time": "2023-09-15T16:55:51+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -64,7 +64,7 @@
                 "sample document": {
                     "sample identifier": "SMPL2"
                 },
-                "measurement time": "2023-09-15T16:57:30+00:00",
+                "measurement time": "2023-09-15T16:56:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -116,7 +116,7 @@
                 "sample document": {
                     "sample identifier": "SMPL3"
                 },
-                "measurement time": "2023-09-15T16:59:06+00:00",
+                "measurement time": "2023-09-15T16:58:34+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -168,7 +168,7 @@
                 "sample document": {
                     "sample identifier": "SMPL4"
                 },
-                "measurement time": "2023-09-16T10:13:37+00:00",
+                "measurement time": "2023-09-16T10:12:10+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {

--- a/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example02.json
+++ b/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example02.json
@@ -13,7 +13,7 @@
                     "sample identifier": "SMPLA0",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T15:15:09+00:00",
+                "measurement time": "2022-10-17T15:13:20+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -115,7 +115,7 @@
                     "sample identifier": "SMPLA1",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T15:44:43+00:00",
+                "measurement time": "2022-10-17T15:43:39+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -217,7 +217,7 @@
                     "sample identifier": "SMPLA2",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T16:16:44+00:00",
+                "measurement time": "2022-10-17T16:15:30+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -319,7 +319,7 @@
                     "sample identifier": "SMPLA3",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T16:49:29+00:00",
+                "measurement time": "2022-10-17T16:48:25+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -421,7 +421,7 @@
                     "sample identifier": "SMPLA4",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T17:29:17+00:00",
+                "measurement time": "2022-10-17T17:28:14+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -523,7 +523,7 @@
                     "sample identifier": "SMPLA5",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T17:54:56+00:00",
+                "measurement time": "2022-10-17T17:54:15+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -625,7 +625,7 @@
                     "sample identifier": "SMPLA6",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T18:20:58+00:00",
+                "measurement time": "2022-10-17T18:19:53+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -727,7 +727,7 @@
                     "sample identifier": "SMPLB0",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T15:18:53+00:00",
+                "measurement time": "2022-10-17T15:17:05+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -829,7 +829,7 @@
                     "sample identifier": "SMPLB1",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T15:50:53+00:00",
+                "measurement time": "2022-10-17T15:48:05+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -931,7 +931,7 @@
                     "sample identifier": "SMPLB2",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T16:22:55+00:00",
+                "measurement time": "2022-10-17T16:21:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1033,7 +1033,7 @@
                     "sample identifier": "SMPLB3",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T16:54:48+00:00",
+                "measurement time": "2022-10-17T16:53:11+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1135,7 +1135,7 @@
                     "sample identifier": "SMPLB4",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T17:33:32+00:00",
+                "measurement time": "2022-10-17T17:32:50+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1237,7 +1237,7 @@
                     "sample identifier": "SMPLB5",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T17:58:49+00:00",
+                "measurement time": "2022-10-17T17:58:08+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1339,7 +1339,7 @@
                     "sample identifier": "SMPLB6",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T18:25:23+00:00",
+                "measurement time": "2022-10-17T18:24:40+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1441,7 +1441,7 @@
                     "sample identifier": "SMPLC0",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T15:24:43+00:00",
+                "measurement time": "2022-10-17T15:23:18+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1543,7 +1543,7 @@
                     "sample identifier": "SMPLC1",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T15:55:39+00:00",
+                "measurement time": "2022-10-17T15:54:27+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1645,7 +1645,7 @@
                     "sample identifier": "SMPLC2",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T16:27:54+00:00",
+                "measurement time": "2022-10-17T16:26:59+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1747,7 +1747,7 @@
                     "sample identifier": "SMPLC3",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T17:00:27+00:00",
+                "measurement time": "2022-10-17T16:59:12+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1849,7 +1849,7 @@
                     "sample identifier": "SMPLC4",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T17:37:37+00:00",
+                "measurement time": "2022-10-17T17:36:55+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1951,7 +1951,7 @@
                     "sample identifier": "SMPLC5",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T18:03:04+00:00",
+                "measurement time": "2022-10-17T18:02:22+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2053,7 +2053,7 @@
                     "sample identifier": "SMPLC6",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T18:29:28+00:00",
+                "measurement time": "2022-10-17T18:28:35+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2155,7 +2155,7 @@
                     "sample identifier": "SMPLD0",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T15:30:21+00:00",
+                "measurement time": "2022-10-17T15:28:47+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2257,7 +2257,7 @@
                     "sample identifier": "SMPLD1",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T16:00:39+00:00",
+                "measurement time": "2022-10-17T15:59:34+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2359,7 +2359,7 @@
                     "sample identifier": "SMPLD2",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T16:33:32+00:00",
+                "measurement time": "2022-10-17T16:31:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2461,7 +2461,7 @@
                     "sample identifier": "SMPLD3",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T17:14:36+00:00",
+                "measurement time": "2022-10-17T17:13:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2563,7 +2563,7 @@
                     "sample identifier": "SMPLD4",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T17:41:20+00:00",
+                "measurement time": "2022-10-17T17:40:26+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2665,7 +2665,7 @@
                     "sample identifier": "SMPLD5",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T18:08:23+00:00",
+                "measurement time": "2022-10-17T18:07:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2767,7 +2767,7 @@
                     "sample identifier": "SMPLD6",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T18:34:57+00:00",
+                "measurement time": "2022-10-17T18:33:53+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2869,7 +2869,7 @@
                     "sample identifier": "SMPLE0",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T15:35:10+00:00",
+                "measurement time": "2022-10-17T15:34:05+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2971,7 +2971,7 @@
                     "sample identifier": "SMPLE1",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T16:06:06+00:00",
+                "measurement time": "2022-10-17T16:04:11+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3073,7 +3073,7 @@
                     "sample identifier": "SMPLE2",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T16:39:02+00:00",
+                "measurement time": "2022-10-17T16:38:09+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3175,7 +3175,7 @@
                     "sample identifier": "SMPLE3",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T17:18:20+00:00",
+                "measurement time": "2022-10-17T17:16:32+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3277,7 +3277,7 @@
                     "sample identifier": "SMPLE4",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T17:46:49+00:00",
+                "measurement time": "2022-10-17T17:45:33+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3379,7 +3379,7 @@
                     "sample identifier": "SMPLE5",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T18:11:55+00:00",
+                "measurement time": "2022-10-17T18:11:02+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3481,7 +3481,7 @@
                     "sample identifier": "SMPLE6",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T18:38:39+00:00",
+                "measurement time": "2022-10-17T18:37:35+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3583,7 +3583,7 @@
                     "sample identifier": "SMPLF0",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T15:40:38+00:00",
+                "measurement time": "2022-10-17T15:39:23+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3685,7 +3685,7 @@
                     "sample identifier": "SMPLF1",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T16:11:36+00:00",
+                "measurement time": "2022-10-17T16:10:34+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3787,7 +3787,7 @@
                     "sample identifier": "SMPLF2",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T16:44:21+00:00",
+                "measurement time": "2022-10-17T16:43:07+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3889,7 +3889,7 @@
                     "sample identifier": "SMPLF3",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T17:24:09+00:00",
+                "measurement time": "2022-10-17T17:22:45+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3991,7 +3991,7 @@
                     "sample identifier": "SMPLF4",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T17:50:53+00:00",
+                "measurement time": "2022-10-17T17:49:48+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4093,7 +4093,7 @@
                     "sample identifier": "SMPLF5",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T18:17:24+00:00",
+                "measurement time": "2022-10-17T18:15:59+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4195,7 +4195,7 @@
                     "sample identifier": "SMPLF6",
                     "batch identifier": "FBATCH_123"
                 },
-                "measurement time": "2022-10-17T18:43:36+00:00",
+                "measurement time": "2022-10-17T18:42:33+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4311,7 +4311,7 @@
                     "sample identifier": "Sample_1",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:45:25+00:00",
+                "measurement time": "2022-10-20T09:44:05+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4354,7 +4354,7 @@
                     "sample identifier": "Sample_10",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:50:11+00:00",
+                "measurement time": "2022-10-20T09:49:49+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4397,7 +4397,7 @@
                     "sample identifier": "Sample_11",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:50:43+00:00",
+                "measurement time": "2022-10-20T09:50:20+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4440,7 +4440,7 @@
                     "sample identifier": "Sample_12",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:51:56+00:00",
+                "measurement time": "2022-10-20T09:50:52+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4483,7 +4483,7 @@
                     "sample identifier": "Sample_13",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:53:32+00:00",
+                "measurement time": "2022-10-20T09:52:28+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4526,7 +4526,7 @@
                     "sample identifier": "Sample_14",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:54:26+00:00",
+                "measurement time": "2022-10-20T09:53:54+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4569,7 +4569,7 @@
                     "sample identifier": "Sample_15",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:55:07+00:00",
+                "measurement time": "2022-10-20T09:54:35+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4612,7 +4612,7 @@
                     "sample identifier": "Sample_16",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:56:01+00:00",
+                "measurement time": "2022-10-20T09:55:30+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4655,7 +4655,7 @@
                     "sample identifier": "Sample_17",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:56:42+00:00",
+                "measurement time": "2022-10-20T09:56:11+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4698,7 +4698,7 @@
                     "sample identifier": "Sample_18",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:57:15+00:00",
+                "measurement time": "2022-10-20T09:56:54+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4741,7 +4741,7 @@
                     "sample identifier": "Sample_19",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:57:47+00:00",
+                "measurement time": "2022-10-20T09:57:26+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4784,7 +4784,7 @@
                     "sample identifier": "Sample_2",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:45:55+00:00",
+                "measurement time": "2022-10-20T09:45:33+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4827,7 +4827,7 @@
                     "sample identifier": "Sample_20",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:58:19+00:00",
+                "measurement time": "2022-10-20T09:57:57+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4870,7 +4870,7 @@
                     "sample identifier": "Sample_21",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:58:50+00:00",
+                "measurement time": "2022-10-20T09:58:29+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4913,7 +4913,7 @@
                     "sample identifier": "Sample_22",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:59:22+00:00",
+                "measurement time": "2022-10-20T09:59:02+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4956,7 +4956,7 @@
                     "sample identifier": "Sample_23",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:00:27+00:00",
+                "measurement time": "2022-10-20T09:59:44+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4999,7 +4999,7 @@
                     "sample identifier": "Sample_24",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:01:20+00:00",
+                "measurement time": "2022-10-20T10:00:37+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5042,7 +5042,7 @@
                     "sample identifier": "Sample_25",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:02:13+00:00",
+                "measurement time": "2022-10-20T10:01:30+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5085,7 +5085,7 @@
                     "sample identifier": "Sample_26",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:02:55+00:00",
+                "measurement time": "2022-10-20T10:02:23+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5128,7 +5128,7 @@
                     "sample identifier": "Sample_27",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:03:38+00:00",
+                "measurement time": "2022-10-20T10:03:06+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5171,7 +5171,7 @@
                     "sample identifier": "Sample_28",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:04:20+00:00",
+                "measurement time": "2022-10-20T10:03:47+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5214,7 +5214,7 @@
                     "sample identifier": "Sample_29",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:04:51+00:00",
+                "measurement time": "2022-10-20T10:04:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5257,7 +5257,7 @@
                     "sample identifier": "Sample_3",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:46:27+00:00",
+                "measurement time": "2022-10-20T09:46:05+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5300,7 +5300,7 @@
                     "sample identifier": "Sample_30",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:05:34+00:00",
+                "measurement time": "2022-10-20T10:05:14+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5343,7 +5343,7 @@
                     "sample identifier": "Sample_31",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:06:16+00:00",
+                "measurement time": "2022-10-20T10:05:44+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5386,7 +5386,7 @@
                     "sample identifier": "Sample_32",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:06:49+00:00",
+                "measurement time": "2022-10-20T10:06:27+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5429,7 +5429,7 @@
                     "sample identifier": "Sample_33",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:07:32+00:00",
+                "measurement time": "2022-10-20T10:06:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5472,7 +5472,7 @@
                     "sample identifier": "Sample_34",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:08:13+00:00",
+                "measurement time": "2022-10-20T10:07:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5515,7 +5515,7 @@
                     "sample identifier": "Sample_35",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:09:07+00:00",
+                "measurement time": "2022-10-20T10:08:25+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5558,7 +5558,7 @@
                     "sample identifier": "Sample_36",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:10:00+00:00",
+                "measurement time": "2022-10-20T10:09:38+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5601,7 +5601,7 @@
                     "sample identifier": "Sample_37",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:10:52+00:00",
+                "measurement time": "2022-10-20T10:10:20+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5644,7 +5644,7 @@
                     "sample identifier": "Sample_38",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:11:34+00:00",
+                "measurement time": "2022-10-20T10:11:04+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5687,7 +5687,7 @@
                     "sample identifier": "Sample_39",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:12:18+00:00",
+                "measurement time": "2022-10-20T10:11:46+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5730,7 +5730,7 @@
                     "sample identifier": "Sample_4",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:46:58+00:00",
+                "measurement time": "2022-10-20T09:46:37+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5773,7 +5773,7 @@
                     "sample identifier": "Sample_40",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:13:21+00:00",
+                "measurement time": "2022-10-20T10:12:49+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5816,7 +5816,7 @@
                     "sample identifier": "Sample_41",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:14:04+00:00",
+                "measurement time": "2022-10-20T10:13:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5859,7 +5859,7 @@
                     "sample identifier": "Sample_42",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:14:36+00:00",
+                "measurement time": "2022-10-20T10:14:14+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5902,7 +5902,7 @@
                     "sample identifier": "Sample_43",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:15:07+00:00",
+                "measurement time": "2022-10-20T10:14:47+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5945,7 +5945,7 @@
                     "sample identifier": "Sample_44",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:15:50+00:00",
+                "measurement time": "2022-10-20T10:15:19+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5988,7 +5988,7 @@
                     "sample identifier": "Sample_45",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:16:22+00:00",
+                "measurement time": "2022-10-20T10:16:00+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6031,7 +6031,7 @@
                     "sample identifier": "Sample_46",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:17:05+00:00",
+                "measurement time": "2022-10-20T10:16:43+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6074,7 +6074,7 @@
                     "sample identifier": "Sample_47",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:18:07+00:00",
+                "measurement time": "2022-10-20T10:17:36+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6117,7 +6117,7 @@
                     "sample identifier": "Sample_48",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:18:39+00:00",
+                "measurement time": "2022-10-20T10:18:19+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6160,7 +6160,7 @@
                     "sample identifier": "Sample_49",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:19:34+00:00",
+                "measurement time": "2022-10-20T10:18:51+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6203,7 +6203,7 @@
                     "sample identifier": "Sample_5",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:47:30+00:00",
+                "measurement time": "2022-10-20T09:47:09+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6246,7 +6246,7 @@
                     "sample identifier": "Sample_50",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:20:36+00:00",
+                "measurement time": "2022-10-20T10:20:04+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6289,7 +6289,7 @@
                     "sample identifier": "Sample_51",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:21:20+00:00",
+                "measurement time": "2022-10-20T10:20:48+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6332,7 +6332,7 @@
                     "sample identifier": "Sample_52",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:22:12+00:00",
+                "measurement time": "2022-10-20T10:21:51+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6375,7 +6375,7 @@
                     "sample identifier": "Sample_53",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:22:55+00:00",
+                "measurement time": "2022-10-20T10:22:34+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6418,7 +6418,7 @@
                     "sample identifier": "Sample_54",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:23:26+00:00",
+                "measurement time": "2022-10-20T10:23:04+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6461,7 +6461,7 @@
                     "sample identifier": "Sample_55",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:24:08+00:00",
+                "measurement time": "2022-10-20T10:23:37+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6504,7 +6504,7 @@
                     "sample identifier": "Sample_56",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:24:40+00:00",
+                "measurement time": "2022-10-20T10:24:20+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6547,7 +6547,7 @@
                     "sample identifier": "Sample_57",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:25:12+00:00",
+                "measurement time": "2022-10-20T10:24:52+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6590,7 +6590,7 @@
                     "sample identifier": "Sample_58",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:25:55+00:00",
+                "measurement time": "2022-10-20T10:25:24+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6633,7 +6633,7 @@
                     "sample identifier": "Sample_59",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:26:48+00:00",
+                "measurement time": "2022-10-20T10:26:06+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6676,7 +6676,7 @@
                     "sample identifier": "Sample_6",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:48:02+00:00",
+                "measurement time": "2022-10-20T09:47:41+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6719,7 +6719,7 @@
                     "sample identifier": "Sample_60",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:27:41+00:00",
+                "measurement time": "2022-10-20T10:27:10+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6762,7 +6762,7 @@
                     "sample identifier": "Sample_61",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:28:34+00:00",
+                "measurement time": "2022-10-20T10:28:03+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6805,7 +6805,7 @@
                     "sample identifier": "Sample_62",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:29:17+00:00",
+                "measurement time": "2022-10-20T10:28:56+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6848,7 +6848,7 @@
                     "sample identifier": "Sample_63",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:29:49+00:00",
+                "measurement time": "2022-10-20T10:29:27+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6891,7 +6891,7 @@
                     "sample identifier": "Sample_64",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:30:42+00:00",
+                "measurement time": "2022-10-20T10:30:09+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6934,7 +6934,7 @@
                     "sample identifier": "Sample_65",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:31:24+00:00",
+                "measurement time": "2022-10-20T10:31:03+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6977,7 +6977,7 @@
                     "sample identifier": "Sample_66",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:32:07+00:00",
+                "measurement time": "2022-10-20T10:31:35+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7020,7 +7020,7 @@
                     "sample identifier": "Sample_67",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:32:49+00:00",
+                "measurement time": "2022-10-20T10:32:18+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7063,7 +7063,7 @@
                     "sample identifier": "Sample_68",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:33:22+00:00",
+                "measurement time": "2022-10-20T10:33:01+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7106,7 +7106,7 @@
                     "sample identifier": "Sample_69",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:33:54+00:00",
+                "measurement time": "2022-10-20T10:33:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7149,7 +7149,7 @@
                     "sample identifier": "Sample_7",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:48:35+00:00",
+                "measurement time": "2022-10-20T09:48:13+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7192,7 +7192,7 @@
                     "sample identifier": "Sample_70",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:34:36+00:00",
+                "measurement time": "2022-10-20T10:34:03+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7235,7 +7235,7 @@
                     "sample identifier": "Sample_71",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:35:39+00:00",
+                "measurement time": "2022-10-20T10:34:46+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7278,7 +7278,7 @@
                     "sample identifier": "Sample_72",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:36:32+00:00",
+                "measurement time": "2022-10-20T10:36:01+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7321,7 +7321,7 @@
                     "sample identifier": "Sample_73",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:37:25+00:00",
+                "measurement time": "2022-10-20T10:36:54+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7364,7 +7364,7 @@
                     "sample identifier": "Sample_74",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:37:57+00:00",
+                "measurement time": "2022-10-20T10:37:36+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7407,7 +7407,7 @@
                     "sample identifier": "Sample_75",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:38:40+00:00",
+                "measurement time": "2022-10-20T10:38:07+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7450,7 +7450,7 @@
                     "sample identifier": "Sample_76",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:39:21+00:00",
+                "measurement time": "2022-10-20T10:38:49+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7493,7 +7493,7 @@
                     "sample identifier": "Sample_77",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:40:05+00:00",
+                "measurement time": "2022-10-20T10:39:33+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7536,7 +7536,7 @@
                     "sample identifier": "Sample_78",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:40:58+00:00",
+                "measurement time": "2022-10-20T10:40:35+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7579,7 +7579,7 @@
                     "sample identifier": "Sample_79",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:41:29+00:00",
+                "measurement time": "2022-10-20T10:41:08+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7622,7 +7622,7 @@
                     "sample identifier": "Sample_8",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:49:07+00:00",
+                "measurement time": "2022-10-20T09:48:45+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7665,7 +7665,7 @@
                     "sample identifier": "Sample_80",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:42:22+00:00",
+                "measurement time": "2022-10-20T10:41:51+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7708,7 +7708,7 @@
                     "sample identifier": "Sample_81",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:42:54+00:00",
+                "measurement time": "2022-10-20T10:42:34+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7751,7 +7751,7 @@
                     "sample identifier": "Sample_82",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:43:26+00:00",
+                "measurement time": "2022-10-20T10:43:05+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7794,7 +7794,7 @@
                     "sample identifier": "Sample_83",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:44:29+00:00",
+                "measurement time": "2022-10-20T10:43:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7837,7 +7837,7 @@
                     "sample identifier": "Sample_84",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:45:02+00:00",
+                "measurement time": "2022-10-20T10:44:41+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7880,7 +7880,7 @@
                     "sample identifier": "Sample_85",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:45:54+00:00",
+                "measurement time": "2022-10-20T10:45:23+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7923,7 +7923,7 @@
                     "sample identifier": "Sample_86",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:46:38+00:00",
+                "measurement time": "2022-10-20T10:46:06+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7966,7 +7966,7 @@
                     "sample identifier": "Sample_87",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:47:20+00:00",
+                "measurement time": "2022-10-20T10:46:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8009,7 +8009,7 @@
                     "sample identifier": "Sample_88",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:48:02+00:00",
+                "measurement time": "2022-10-20T10:47:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8052,7 +8052,7 @@
                     "sample identifier": "Sample_89",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:48:56+00:00",
+                "measurement time": "2022-10-20T10:48:23+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8095,7 +8095,7 @@
                     "sample identifier": "Sample_9",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T09:49:39+00:00",
+                "measurement time": "2022-10-20T09:49:17+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8138,7 +8138,7 @@
                     "sample identifier": "Sample_90",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:49:27+00:00",
+                "measurement time": "2022-10-20T10:49:07+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8181,7 +8181,7 @@
                     "sample identifier": "Sample_91",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:49:59+00:00",
+                "measurement time": "2022-10-20T10:49:38+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8224,7 +8224,7 @@
                     "sample identifier": "Sample_92",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:50:53+00:00",
+                "measurement time": "2022-10-20T10:50:20+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8267,7 +8267,7 @@
                     "sample identifier": "Sample_93",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:51:23+00:00",
+                "measurement time": "2022-10-20T10:51:02+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8310,7 +8310,7 @@
                     "sample identifier": "Sample_94",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:52:07+00:00",
+                "measurement time": "2022-10-20T10:51:35+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8353,7 +8353,7 @@
                     "sample identifier": "Sample_95",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:52:59+00:00",
+                "measurement time": "2022-10-20T10:52:27+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8396,7 +8396,7 @@
                     "sample identifier": "Sample_96",
                     "batch identifier": "PBATCH_123"
                 },
-                "measurement time": "2022-10-20T10:53:53+00:00",
+                "measurement time": "2022-10-20T10:53:11+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {

--- a/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example03.json
+++ b/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example03.json
@@ -29,7 +29,7 @@
                 "sample document": {
                     "sample identifier": "1001"
                 },
-                "measurement time": "2023-03-16T13:27:29+00:00",
+                "measurement time": "2023-03-17T08:34:19+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -63,7 +63,7 @@
                 "sample document": {
                     "sample identifier": "1002"
                 },
-                "measurement time": "2023-03-16T13:28:05+00:00",
+                "measurement time": "2023-03-17T08:34:48+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -95,9 +95,43 @@
             },
             {
                 "sample document": {
+                    "sample identifier": "1003"
+                },
+                "measurement time": "2023-03-17T08:35:07+00:00",
+                "analyte aggregate document": {
+                    "analyte document": [
+                        {
+                            "analyte name": "glucose",
+                            "molar concentration": {
+                                "value": null,
+                                "unit": "mmol/L"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "sample document": {
                     "sample identifier": "1004"
                 },
                 "measurement time": "2023-03-16T13:30:13+00:00",
+                "analyte aggregate document": {
+                    "analyte document": [
+                        {
+                            "analyte name": "glucose",
+                            "molar concentration": {
+                                "value": null,
+                                "unit": "mmol/L"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "sample document": {
+                    "sample identifier": "1004"
+                },
+                "measurement time": "2023-03-17T08:35:28+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -129,6 +163,23 @@
             },
             {
                 "sample document": {
+                    "sample identifier": "1005"
+                },
+                "measurement time": "2023-03-17T08:35:49+00:00",
+                "analyte aggregate document": {
+                    "analyte document": [
+                        {
+                            "analyte name": "glucose",
+                            "molar concentration": {
+                                "value": null,
+                                "unit": "mmol/L"
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                "sample document": {
                     "sample identifier": "Plate1_1",
                     "batch identifier": "IDEA25"
                 },
@@ -146,7 +197,7 @@
                     "sample identifier": "Plate1_1",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:07:37+00:00",
+                "measurement time": "2023-03-16T11:07:09+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -175,7 +226,7 @@
                     "sample identifier": "Plate1_1",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:08:50+00:00",
+                "measurement time": "2023-03-16T08:07:30+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -218,7 +269,7 @@
                     "sample identifier": "Plate1_10",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:12:44+00:00",
+                "measurement time": "2023-03-16T11:12:00+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -247,7 +298,7 @@
                     "sample identifier": "Plate1_10",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:13:36+00:00",
+                "measurement time": "2023-03-16T08:13:14+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -290,7 +341,7 @@
                     "sample identifier": "Plate1_11",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:13:36+00:00",
+                "measurement time": "2023-03-16T11:12:55+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -319,7 +370,7 @@
                     "sample identifier": "Plate1_11",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:14:08+00:00",
+                "measurement time": "2023-03-16T08:13:45+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -362,7 +413,7 @@
                     "sample identifier": "Plate1_12",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:15:12+00:00",
+                "measurement time": "2023-03-16T11:14:08+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -391,7 +442,7 @@
                     "sample identifier": "Plate1_12",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:15:21+00:00",
+                "measurement time": "2023-03-16T08:14:17+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -434,7 +485,7 @@
                     "sample identifier": "Plate1_13",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:16:05+00:00",
+                "measurement time": "2023-03-16T11:15:23+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -463,7 +514,7 @@
                     "sample identifier": "Plate1_13",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:16:57+00:00",
+                "measurement time": "2023-03-16T08:15:53+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -506,7 +557,7 @@
                     "sample identifier": "Plate1_14",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:16:47+00:00",
+                "measurement time": "2023-03-16T11:16:15+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -535,7 +586,7 @@
                     "sample identifier": "Plate1_14",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:17:51+00:00",
+                "measurement time": "2023-03-16T08:17:19+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -578,7 +629,7 @@
                     "sample identifier": "Plate1_15",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:17:41+00:00",
+                "measurement time": "2023-03-16T11:17:10+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -607,7 +658,7 @@
                     "sample identifier": "Plate1_15",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:18:32+00:00",
+                "measurement time": "2023-03-16T08:18:00+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -650,7 +701,7 @@
                     "sample identifier": "Plate1_16",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:18:13+00:00",
+                "measurement time": "2023-03-16T11:17:51+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -679,7 +730,7 @@
                     "sample identifier": "Plate1_16",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:19:26+00:00",
+                "measurement time": "2023-03-16T08:18:55+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -722,7 +773,7 @@
                     "sample identifier": "Plate1_17",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:18:56+00:00",
+                "measurement time": "2023-03-16T11:18:22+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -751,7 +802,7 @@
                     "sample identifier": "Plate1_17",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:20:07+00:00",
+                "measurement time": "2023-03-16T08:19:36+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -794,7 +845,7 @@
                     "sample identifier": "Plate1_18",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:19:26+00:00",
+                "measurement time": "2023-03-16T11:19:06+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -823,7 +874,7 @@
                     "sample identifier": "Plate1_18",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:20:40+00:00",
+                "measurement time": "2023-03-16T08:20:19+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -866,7 +917,7 @@
                     "sample identifier": "Plate1_19",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:19:59+00:00",
+                "measurement time": "2023-03-16T11:19:37+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -895,7 +946,7 @@
                     "sample identifier": "Plate1_19",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:21:12+00:00",
+                "measurement time": "2023-03-16T08:20:51+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -938,7 +989,7 @@
                     "sample identifier": "Plate1_2",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:08:07+00:00",
+                "measurement time": "2023-03-16T11:07:45+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -967,7 +1018,7 @@
                     "sample identifier": "Plate1_2",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:09:20+00:00",
+                "measurement time": "2023-03-16T08:08:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1010,7 +1061,7 @@
                     "sample identifier": "Plate1_20",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:20:30+00:00",
+                "measurement time": "2023-03-16T11:20:09+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1039,7 +1090,7 @@
                     "sample identifier": "Plate1_20",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:21:44+00:00",
+                "measurement time": "2023-03-16T08:21:22+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1082,7 +1133,7 @@
                     "sample identifier": "Plate1_21",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:21:25+00:00",
+                "measurement time": "2023-03-16T11:20:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1111,7 +1162,7 @@
                     "sample identifier": "Plate1_21",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:22:15+00:00",
+                "measurement time": "2023-03-16T08:21:54+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1154,7 +1205,7 @@
                     "sample identifier": "Plate1_22",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:22:17+00:00",
+                "measurement time": "2023-03-16T11:21:35+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1183,7 +1234,7 @@
                     "sample identifier": "Plate1_22",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:22:47+00:00",
+                "measurement time": "2023-03-16T08:22:27+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1226,7 +1277,7 @@
                     "sample identifier": "Plate1_23",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:23:10+00:00",
+                "measurement time": "2023-03-16T11:22:39+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1255,7 +1306,7 @@
                     "sample identifier": "Plate1_23",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:23:52+00:00",
+                "measurement time": "2023-03-16T08:23:09+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1298,7 +1349,7 @@
                     "sample identifier": "Plate1_24",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:24:13+00:00",
+                "measurement time": "2023-03-16T11:23:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1327,7 +1378,7 @@
                     "sample identifier": "Plate1_24",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:24:45+00:00",
+                "measurement time": "2023-03-16T08:24:02+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1370,7 +1421,7 @@
                     "sample identifier": "Plate1_25",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:24:45+00:00",
+                "measurement time": "2023-03-16T11:24:25+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1399,7 +1450,7 @@
                     "sample identifier": "Plate1_25",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:25:38+00:00",
+                "measurement time": "2023-03-16T08:24:55+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1442,7 +1493,7 @@
                     "sample identifier": "Plate1_26",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:25:28+00:00",
+                "measurement time": "2023-03-16T11:24:56+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1471,7 +1522,7 @@
                     "sample identifier": "Plate1_26",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:26:20+00:00",
+                "measurement time": "2023-03-16T08:25:48+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1514,7 +1565,7 @@
                     "sample identifier": "Plate1_27",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:26:11+00:00",
+                "measurement time": "2023-03-16T11:25:39+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1543,7 +1594,7 @@
                     "sample identifier": "Plate1_27",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:27:03+00:00",
+                "measurement time": "2023-03-16T08:26:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1586,7 +1637,7 @@
                     "sample identifier": "Plate1_28",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:26:43+00:00",
+                "measurement time": "2023-03-16T11:26:22+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1615,7 +1666,7 @@
                     "sample identifier": "Plate1_28",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:27:45+00:00",
+                "measurement time": "2023-03-16T08:27:12+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1658,7 +1709,7 @@
                     "sample identifier": "Plate1_29",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:27:36+00:00",
+                "measurement time": "2023-03-16T11:26:53+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1687,7 +1738,7 @@
                     "sample identifier": "Plate1_29",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:28:16+00:00",
+                "measurement time": "2023-03-16T08:27:56+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1730,7 +1781,7 @@
                     "sample identifier": "Plate1_3",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:08:38+00:00",
+                "measurement time": "2023-03-16T11:08:17+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1759,7 +1810,7 @@
                     "sample identifier": "Plate1_3",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:09:52+00:00",
+                "measurement time": "2023-03-16T08:09:30+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1802,7 +1853,7 @@
                     "sample identifier": "Plate1_30",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:28:07+00:00",
+                "measurement time": "2023-03-16T11:27:46+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1831,7 +1882,7 @@
                     "sample identifier": "Plate1_30",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:28:59+00:00",
+                "measurement time": "2023-03-16T08:28:38+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1874,7 +1925,7 @@
                     "sample identifier": "Plate1_31",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:29:00+00:00",
+                "measurement time": "2023-03-16T11:28:29+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1903,7 +1954,7 @@
                     "sample identifier": "Plate1_31",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:29:41+00:00",
+                "measurement time": "2023-03-16T08:29:09+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1946,7 +1997,7 @@
                     "sample identifier": "Plate1_32",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:29:42+00:00",
+                "measurement time": "2023-03-16T11:29:10+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -1975,7 +2026,7 @@
                     "sample identifier": "Plate1_32",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:30:14+00:00",
+                "measurement time": "2023-03-16T08:29:52+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2018,7 +2069,7 @@
                     "sample identifier": "Plate1_33",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:30:14+00:00",
+                "measurement time": "2023-03-16T11:29:54+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2047,7 +2098,7 @@
                     "sample identifier": "Plate1_33",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:30:56+00:00",
+                "measurement time": "2023-03-16T08:30:23+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2090,7 +2141,7 @@
                     "sample identifier": "Plate1_34",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:31:08+00:00",
+                "measurement time": "2023-03-16T11:30:47+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2119,7 +2170,7 @@
                     "sample identifier": "Plate1_34",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:31:38+00:00",
+                "measurement time": "2023-03-16T08:31:07+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2162,7 +2213,7 @@
                     "sample identifier": "Plate1_35",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:32:11+00:00",
+                "measurement time": "2023-03-16T11:31:28+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2191,7 +2242,7 @@
                     "sample identifier": "Plate1_35",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:32:32+00:00",
+                "measurement time": "2023-03-16T08:31:50+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2234,7 +2285,7 @@
                     "sample identifier": "Plate1_36",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:33:05+00:00",
+                "measurement time": "2023-03-16T11:32:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2263,7 +2314,7 @@
                     "sample identifier": "Plate1_36",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:33:25+00:00",
+                "measurement time": "2023-03-16T08:33:03+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2306,7 +2357,7 @@
                     "sample identifier": "Plate1_37",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:33:36+00:00",
+                "measurement time": "2023-03-16T11:33:14+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2335,7 +2386,7 @@
                     "sample identifier": "Plate1_37",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:34:17+00:00",
+                "measurement time": "2023-03-16T08:33:45+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2378,7 +2429,7 @@
                     "sample identifier": "Plate1_38",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:34:20+00:00",
+                "measurement time": "2023-03-16T11:33:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2407,7 +2458,7 @@
                     "sample identifier": "Plate1_38",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:34:59+00:00",
+                "measurement time": "2023-03-16T08:34:28+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2450,7 +2501,7 @@
                     "sample identifier": "Plate1_39",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:34:50+00:00",
+                "measurement time": "2023-03-16T11:34:29+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2479,7 +2530,7 @@
                     "sample identifier": "Plate1_39",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:35:43+00:00",
+                "measurement time": "2023-03-16T08:35:11+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2522,7 +2573,7 @@
                     "sample identifier": "Plate1_4",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:09:10+00:00",
+                "measurement time": "2023-03-16T11:08:49+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2551,7 +2602,7 @@
                     "sample identifier": "Plate1_4",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:10:23+00:00",
+                "measurement time": "2023-03-16T08:10:02+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2594,7 +2645,7 @@
                     "sample identifier": "Plate1_40",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:35:23+00:00",
+                "measurement time": "2023-03-16T11:35:02+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2623,7 +2674,7 @@
                     "sample identifier": "Plate1_40",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:36:46+00:00",
+                "measurement time": "2023-03-16T08:36:13+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2666,7 +2717,7 @@
                     "sample identifier": "Plate1_41",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:36:16+00:00",
+                "measurement time": "2023-03-16T11:35:43+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2695,7 +2746,7 @@
                     "sample identifier": "Plate1_41",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:37:29+00:00",
+                "measurement time": "2023-03-16T08:36:56+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2738,7 +2789,7 @@
                     "sample identifier": "Plate1_42",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:37:20+00:00",
+                "measurement time": "2023-03-16T11:36:36+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2767,7 +2818,7 @@
                     "sample identifier": "Plate1_42",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:38:01+00:00",
+                "measurement time": "2023-03-16T08:37:39+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2810,7 +2861,7 @@
                     "sample identifier": "Plate1_43",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:38:02+00:00",
+                "measurement time": "2023-03-16T11:37:30+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2839,7 +2890,7 @@
                     "sample identifier": "Plate1_43",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:38:32+00:00",
+                "measurement time": "2023-03-16T08:38:12+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2882,7 +2933,7 @@
                     "sample identifier": "Plate1_44",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:38:34+00:00",
+                "measurement time": "2023-03-16T11:38:12+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2911,7 +2962,7 @@
                     "sample identifier": "Plate1_44",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:39:15+00:00",
+                "measurement time": "2023-03-16T08:38:44+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2954,7 +3005,7 @@
                     "sample identifier": "Plate1_45",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:39:17+00:00",
+                "measurement time": "2023-03-16T11:38:44+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -2983,7 +3034,7 @@
                     "sample identifier": "Plate1_45",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:39:47+00:00",
+                "measurement time": "2023-03-16T08:39:25+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3026,7 +3077,7 @@
                     "sample identifier": "Plate1_46",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:39:49+00:00",
+                "measurement time": "2023-03-16T11:39:28+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3055,7 +3106,7 @@
                     "sample identifier": "Plate1_46",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:40:30+00:00",
+                "measurement time": "2023-03-16T08:40:07+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3098,7 +3149,7 @@
                     "sample identifier": "Plate1_47",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:40:41+00:00",
+                "measurement time": "2023-03-16T11:39:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3127,7 +3178,7 @@
                     "sample identifier": "Plate1_47",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:41:32+00:00",
+                "measurement time": "2023-03-16T08:41:01+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3170,7 +3221,7 @@
                     "sample identifier": "Plate1_48",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:41:34+00:00",
+                "measurement time": "2023-03-16T11:40:51+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3199,7 +3250,7 @@
                     "sample identifier": "Plate1_48",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:42:04+00:00",
+                "measurement time": "2023-03-16T08:41:44+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3242,7 +3293,7 @@
                     "sample identifier": "Plate1_49",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:42:28+00:00",
+                "measurement time": "2023-03-16T11:41:45+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3271,7 +3322,7 @@
                     "sample identifier": "Plate1_49",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:42:59+00:00",
+                "measurement time": "2023-03-16T08:42:16+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3314,7 +3365,7 @@
                     "sample identifier": "Plate1_5",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:09:42+00:00",
+                "measurement time": "2023-03-16T11:09:21+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3343,7 +3394,7 @@
                     "sample identifier": "Plate1_5",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:10:55+00:00",
+                "measurement time": "2023-03-16T08:10:34+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3386,7 +3437,7 @@
                     "sample identifier": "Plate1_50",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:42:59+00:00",
+                "measurement time": "2023-03-16T11:42:37+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3415,7 +3466,7 @@
                     "sample identifier": "Plate1_50",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:44:01+00:00",
+                "measurement time": "2023-03-16T08:43:29+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3458,7 +3509,7 @@
                     "sample identifier": "Plate1_51",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:43:51+00:00",
+                "measurement time": "2023-03-16T11:43:20+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3487,7 +3538,7 @@
                     "sample identifier": "Plate1_51",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:44:45+00:00",
+                "measurement time": "2023-03-16T08:44:13+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3530,7 +3581,7 @@
                     "sample identifier": "Plate1_52",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:44:35+00:00",
+                "measurement time": "2023-03-16T11:44:02+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3559,7 +3610,7 @@
                     "sample identifier": "Plate1_52",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:45:37+00:00",
+                "measurement time": "2023-03-16T08:45:16+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3602,7 +3653,7 @@
                     "sample identifier": "Plate1_53",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:45:16+00:00",
+                "measurement time": "2023-03-16T11:44:46+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3631,7 +3682,7 @@
                     "sample identifier": "Plate1_53",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:46:20+00:00",
+                "measurement time": "2023-03-16T08:45:59+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3674,7 +3725,7 @@
                     "sample identifier": "Plate1_54",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:46:11+00:00",
+                "measurement time": "2023-03-16T11:45:48+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3703,7 +3754,7 @@
                     "sample identifier": "Plate1_54",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:46:51+00:00",
+                "measurement time": "2023-03-16T08:46:29+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3746,7 +3797,7 @@
                     "sample identifier": "Plate1_55",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:46:53+00:00",
+                "measurement time": "2023-03-16T11:46:30+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3775,7 +3826,7 @@
                     "sample identifier": "Plate1_55",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:47:33+00:00",
+                "measurement time": "2023-03-16T08:47:02+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3818,7 +3869,7 @@
                     "sample identifier": "Plate1_56",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:47:35+00:00",
+                "measurement time": "2023-03-16T11:47:04+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3847,7 +3898,7 @@
                     "sample identifier": "Plate1_56",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:48:05+00:00",
+                "measurement time": "2023-03-16T08:47:45+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3890,7 +3941,7 @@
                     "sample identifier": "Plate1_57",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:48:17+00:00",
+                "measurement time": "2023-03-16T11:47:46+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3919,7 +3970,7 @@
                     "sample identifier": "Plate1_57",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:48:37+00:00",
+                "measurement time": "2023-03-16T08:48:17+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3962,7 +4013,7 @@
                     "sample identifier": "Plate1_58",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:49:11+00:00",
+                "measurement time": "2023-03-16T11:48:29+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -3991,7 +4042,7 @@
                     "sample identifier": "Plate1_58",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:49:19+00:00",
+                "measurement time": "2023-03-16T08:48:49+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4034,7 +4085,7 @@
                     "sample identifier": "Plate1_59",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:50:04+00:00",
+                "measurement time": "2023-03-16T11:49:22+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4063,7 +4114,7 @@
                     "sample identifier": "Plate1_59",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:50:13+00:00",
+                "measurement time": "2023-03-16T08:49:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4106,7 +4157,7 @@
                     "sample identifier": "Plate1_6",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:10:14+00:00",
+                "measurement time": "2023-03-16T11:09:53+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4135,7 +4186,7 @@
                     "sample identifier": "Plate1_6",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:11:27+00:00",
+                "measurement time": "2023-03-16T08:11:06+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4178,7 +4229,7 @@
                     "sample identifier": "Plate1_60",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:50:47+00:00",
+                "measurement time": "2023-03-16T11:50:15+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4207,7 +4258,7 @@
                     "sample identifier": "Plate1_60",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:51:06+00:00",
+                "measurement time": "2023-03-16T08:50:35+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4250,7 +4301,7 @@
                     "sample identifier": "Plate1_61",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:51:18+00:00",
+                "measurement time": "2023-03-16T11:50:57+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4279,7 +4330,7 @@
                     "sample identifier": "Plate1_61",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:51:59+00:00",
+                "measurement time": "2023-03-16T08:51:28+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4322,7 +4373,7 @@
                     "sample identifier": "Plate1_62",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:51:49+00:00",
+                "measurement time": "2023-03-16T11:51:29+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4351,7 +4402,7 @@
                     "sample identifier": "Plate1_62",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:52:42+00:00",
+                "measurement time": "2023-03-16T08:52:21+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4394,7 +4445,7 @@
                     "sample identifier": "Plate1_63",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:52:32+00:00",
+                "measurement time": "2023-03-16T11:52:01+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4423,7 +4474,7 @@
                     "sample identifier": "Plate1_63",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:53:14+00:00",
+                "measurement time": "2023-03-16T08:52:52+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4466,7 +4517,7 @@
                     "sample identifier": "Plate1_64",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:53:16+00:00",
+                "measurement time": "2023-03-16T11:52:53+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4495,7 +4546,7 @@
                     "sample identifier": "Plate1_64",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:54:07+00:00",
+                "measurement time": "2023-03-16T08:53:34+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4538,7 +4589,7 @@
                     "sample identifier": "Plate1_65",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:54:18+00:00",
+                "measurement time": "2023-03-16T11:53:35+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4567,7 +4618,7 @@
                     "sample identifier": "Plate1_65",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:54:49+00:00",
+                "measurement time": "2023-03-16T08:54:28+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4610,7 +4661,7 @@
                     "sample identifier": "Plate1_66",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:55:01+00:00",
+                "measurement time": "2023-03-16T11:54:30+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4639,7 +4690,7 @@
                     "sample identifier": "Plate1_66",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:55:32+00:00",
+                "measurement time": "2023-03-16T08:55:00+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4682,7 +4733,7 @@
                     "sample identifier": "Plate1_67",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:55:33+00:00",
+                "measurement time": "2023-03-16T11:55:11+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4711,7 +4762,7 @@
                     "sample identifier": "Plate1_67",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:56:14+00:00",
+                "measurement time": "2023-03-16T08:55:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4754,7 +4805,7 @@
                     "sample identifier": "Plate1_68",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:56:46+00:00",
+                "measurement time": "2023-03-16T11:56:04+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4783,7 +4834,7 @@
                     "sample identifier": "Plate1_68",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:56:47+00:00",
+                "measurement time": "2023-03-16T08:56:26+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4826,7 +4877,7 @@
                     "sample identifier": "Plate1_69",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:57:40+00:00",
+                "measurement time": "2023-03-16T11:56:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4855,7 +4906,7 @@
                     "sample identifier": "Plate1_69",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:57:18+00:00",
+                "measurement time": "2023-03-16T08:56:56+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4898,7 +4949,7 @@
                     "sample identifier": "Plate1_7",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:10:47+00:00",
+                "measurement time": "2023-03-16T11:10:24+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4927,7 +4978,7 @@
                     "sample identifier": "Plate1_7",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:12:00+00:00",
+                "measurement time": "2023-03-16T08:11:38+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4970,7 +5021,7 @@
                     "sample identifier": "Plate1_70",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:58:22+00:00",
+                "measurement time": "2023-03-16T11:57:50+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -4999,7 +5050,7 @@
                     "sample identifier": "Plate1_70",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:58:01+00:00",
+                "measurement time": "2023-03-16T08:57:28+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5042,7 +5093,7 @@
                     "sample identifier": "Plate1_71",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:59:06+00:00",
+                "measurement time": "2023-03-16T11:58:33+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5071,7 +5122,7 @@
                     "sample identifier": "Plate1_71",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:59:04+00:00",
+                "measurement time": "2023-03-16T08:58:11+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5114,7 +5165,7 @@
                     "sample identifier": "Plate1_72",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:59:37+00:00",
+                "measurement time": "2023-03-16T11:59:15+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5143,7 +5194,7 @@
                     "sample identifier": "Plate1_72",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:59:57+00:00",
+                "measurement time": "2023-03-16T08:59:26+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5186,7 +5237,7 @@
                     "sample identifier": "Plate1_73",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:00:19+00:00",
+                "measurement time": "2023-03-16T11:59:48+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5215,7 +5266,7 @@
                     "sample identifier": "Plate1_73",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:00:50+00:00",
+                "measurement time": "2023-03-16T09:00:18+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5258,7 +5309,7 @@
                     "sample identifier": "Plate1_74",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:01:24+00:00",
+                "measurement time": "2023-03-16T12:00:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5287,7 +5338,7 @@
                     "sample identifier": "Plate1_74",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:01:22+00:00",
+                "measurement time": "2023-03-16T09:01:01+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5330,7 +5381,7 @@
                     "sample identifier": "Plate1_75",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:01:55+00:00",
+                "measurement time": "2023-03-16T12:01:33+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5359,7 +5410,7 @@
                     "sample identifier": "Plate1_75",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:02:05+00:00",
+                "measurement time": "2023-03-16T09:01:32+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5402,7 +5453,7 @@
                     "sample identifier": "Plate1_76",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:02:49+00:00",
+                "measurement time": "2023-03-16T12:02:06+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5431,7 +5482,7 @@
                     "sample identifier": "Plate1_76",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:02:46+00:00",
+                "measurement time": "2023-03-16T09:02:14+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5474,7 +5525,7 @@
                     "sample identifier": "Plate1_77",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:03:30+00:00",
+                "measurement time": "2023-03-16T12:02:59+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5503,7 +5554,7 @@
                     "sample identifier": "Plate1_77",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:03:30+00:00",
+                "measurement time": "2023-03-16T09:02:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5546,7 +5597,7 @@
                     "sample identifier": "Plate1_78",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:04:03+00:00",
+                "measurement time": "2023-03-16T12:03:41+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5575,7 +5626,7 @@
                     "sample identifier": "Plate1_78",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:04:23+00:00",
+                "measurement time": "2023-03-16T09:04:00+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5618,7 +5669,7 @@
                     "sample identifier": "Plate1_79",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:05:07+00:00",
+                "measurement time": "2023-03-16T12:04:24+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5647,7 +5698,7 @@
                     "sample identifier": "Plate1_79",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:04:54+00:00",
+                "measurement time": "2023-03-16T09:04:33+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5690,7 +5741,7 @@
                     "sample identifier": "Plate1_8",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:11:19+00:00",
+                "measurement time": "2023-03-16T11:10:57+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5719,7 +5770,7 @@
                     "sample identifier": "Plate1_8",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:12:32+00:00",
+                "measurement time": "2023-03-16T08:12:10+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5762,7 +5813,7 @@
                     "sample identifier": "Plate1_80",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:05:38+00:00",
+                "measurement time": "2023-03-16T12:05:17+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5791,7 +5842,7 @@
                     "sample identifier": "Plate1_80",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:05:46+00:00",
+                "measurement time": "2023-03-16T09:05:16+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5834,7 +5885,7 @@
                     "sample identifier": "Plate1_81",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:06:20+00:00",
+                "measurement time": "2023-03-16T12:05:49+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5863,7 +5914,7 @@
                     "sample identifier": "Plate1_81",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:06:19+00:00",
+                "measurement time": "2023-03-16T09:05:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5906,7 +5957,7 @@
                     "sample identifier": "Plate1_82",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:06:52+00:00",
+                "measurement time": "2023-03-16T12:06:32+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5935,7 +5986,7 @@
                     "sample identifier": "Plate1_82",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:06:51+00:00",
+                "measurement time": "2023-03-16T09:06:30+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -5978,7 +6029,7 @@
                     "sample identifier": "Plate1_83",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:07:35+00:00",
+                "measurement time": "2023-03-16T12:07:02+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6007,7 +6058,7 @@
                     "sample identifier": "Plate1_83",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:07:54+00:00",
+                "measurement time": "2023-03-16T09:07:22+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6050,7 +6101,7 @@
                     "sample identifier": "Plate1_84",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:08:07+00:00",
+                "measurement time": "2023-03-16T12:07:46+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6079,7 +6130,7 @@
                     "sample identifier": "Plate1_84",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:08:27+00:00",
+                "measurement time": "2023-03-16T09:08:06+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6122,7 +6173,7 @@
                     "sample identifier": "Plate1_85",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:09:00+00:00",
+                "measurement time": "2023-03-16T12:08:18+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6151,7 +6202,7 @@
                     "sample identifier": "Plate1_85",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:09:19+00:00",
+                "measurement time": "2023-03-16T09:08:48+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6194,7 +6245,7 @@
                     "sample identifier": "Plate1_86",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:10:04+00:00",
+                "measurement time": "2023-03-16T12:09:32+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6223,7 +6274,7 @@
                     "sample identifier": "Plate1_86",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:10:03+00:00",
+                "measurement time": "2023-03-16T09:09:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6266,7 +6317,7 @@
                     "sample identifier": "Plate1_87",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:10:36+00:00",
+                "measurement time": "2023-03-16T12:10:14+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6295,7 +6346,7 @@
                     "sample identifier": "Plate1_87",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:10:45+00:00",
+                "measurement time": "2023-03-16T09:10:23+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6338,7 +6389,7 @@
                     "sample identifier": "Plate1_88",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:11:29+00:00",
+                "measurement time": "2023-03-16T12:11:07+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6367,7 +6418,7 @@
                     "sample identifier": "Plate1_88",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:11:27+00:00",
+                "measurement time": "2023-03-16T09:11:07+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6410,7 +6461,7 @@
                     "sample identifier": "Plate1_89",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:12:01+00:00",
+                "measurement time": "2023-03-16T12:11:38+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6439,7 +6490,7 @@
                     "sample identifier": "Plate1_89",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:12:21+00:00",
+                "measurement time": "2023-03-16T09:11:48+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6482,7 +6533,7 @@
                     "sample identifier": "Plate1_9",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T11:11:51+00:00",
+                "measurement time": "2023-03-16T11:11:29+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6511,7 +6562,7 @@
                     "sample identifier": "Plate1_9",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T08:13:04+00:00",
+                "measurement time": "2023-03-16T08:12:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6554,7 +6605,7 @@
                     "sample identifier": "Plate1_90",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:12:33+00:00",
+                "measurement time": "2023-03-16T12:12:11+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6583,7 +6634,7 @@
                     "sample identifier": "Plate1_90",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:12:52+00:00",
+                "measurement time": "2023-03-16T09:12:32+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6626,7 +6677,7 @@
                     "sample identifier": "Plate1_91",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:13:35+00:00",
+                "measurement time": "2023-03-16T12:12:53+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6655,7 +6706,7 @@
                     "sample identifier": "Plate1_91",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:13:23+00:00",
+                "measurement time": "2023-03-16T09:13:03+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6698,7 +6749,7 @@
                     "sample identifier": "Plate1_92",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:14:19+00:00",
+                "measurement time": "2023-03-16T12:13:47+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6727,7 +6778,7 @@
                     "sample identifier": "Plate1_92",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:14:18+00:00",
+                "measurement time": "2023-03-16T09:13:45+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6770,7 +6821,7 @@
                     "sample identifier": "Plate1_93",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:15:00+00:00",
+                "measurement time": "2023-03-16T12:14:29+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6799,7 +6850,7 @@
                     "sample identifier": "Plate1_93",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:14:48+00:00",
+                "measurement time": "2023-03-16T09:14:27+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6842,7 +6893,7 @@
                     "sample identifier": "Plate1_94",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:16:04+00:00",
+                "measurement time": "2023-03-16T12:15:21+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6871,7 +6922,7 @@
                     "sample identifier": "Plate1_94",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:15:32+00:00",
+                "measurement time": "2023-03-16T09:15:00+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6914,7 +6965,7 @@
                     "sample identifier": "Plate1_95",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:16:35+00:00",
+                "measurement time": "2023-03-16T12:16:15+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6943,7 +6994,7 @@
                     "sample identifier": "Plate1_95",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:16:24+00:00",
+                "measurement time": "2023-03-16T09:15:52+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -6986,7 +7037,7 @@
                     "sample identifier": "Plate1_96",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:17:30+00:00",
+                "measurement time": "2023-03-16T12:16:47+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7015,7 +7066,7 @@
                     "sample identifier": "Plate1_96",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:17:18+00:00",
+                "measurement time": "2023-03-16T09:16:36+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7058,7 +7109,7 @@
                     "sample identifier": "Plate2_1",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:30:12+00:00",
+                "measurement time": "2023-03-16T12:29:57+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7087,7 +7138,7 @@
                     "sample identifier": "Plate2_1",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:37:51+00:00",
+                "measurement time": "2023-03-16T09:37:23+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7130,7 +7181,7 @@
                     "sample identifier": "Plate2_10",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:35:01+00:00",
+                "measurement time": "2023-03-16T12:34:39+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7159,7 +7210,7 @@
                     "sample identifier": "Plate2_10",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:42:36+00:00",
+                "measurement time": "2023-03-16T09:42:14+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7202,7 +7253,7 @@
                     "sample identifier": "Plate2_11",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:35:33+00:00",
+                "measurement time": "2023-03-16T12:35:10+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7231,7 +7282,7 @@
                     "sample identifier": "Plate2_11",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:43:08+00:00",
+                "measurement time": "2023-03-16T09:42:46+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7274,7 +7325,7 @@
                     "sample identifier": "Plate2_12",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:36:46+00:00",
+                "measurement time": "2023-03-16T12:35:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7303,7 +7354,7 @@
                     "sample identifier": "Plate2_12",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:44:21+00:00",
+                "measurement time": "2023-03-16T09:43:17+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7346,7 +7397,7 @@
                     "sample identifier": "Plate2_13",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:38:22+00:00",
+                "measurement time": "2023-03-16T12:37:18+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7375,7 +7426,7 @@
                     "sample identifier": "Plate2_13",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:45:57+00:00",
+                "measurement time": "2023-03-16T09:44:53+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7418,7 +7469,7 @@
                     "sample identifier": "Plate2_14",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:39:16+00:00",
+                "measurement time": "2023-03-16T12:38:44+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7447,7 +7498,7 @@
                     "sample identifier": "Plate2_14",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:46:51+00:00",
+                "measurement time": "2023-03-16T09:46:19+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7490,7 +7541,7 @@
                     "sample identifier": "Plate2_15",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:39:57+00:00",
+                "measurement time": "2023-03-16T12:39:25+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7519,7 +7570,7 @@
                     "sample identifier": "Plate2_15",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:47:32+00:00",
+                "measurement time": "2023-03-16T09:47:00+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7562,7 +7613,7 @@
                     "sample identifier": "Plate2_16",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:40:51+00:00",
+                "measurement time": "2023-03-16T12:40:20+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7591,7 +7642,7 @@
                     "sample identifier": "Plate2_16",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:48:26+00:00",
+                "measurement time": "2023-03-16T09:47:55+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7634,7 +7685,7 @@
                     "sample identifier": "Plate2_17",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:41:32+00:00",
+                "measurement time": "2023-03-16T12:41:01+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7663,7 +7714,7 @@
                     "sample identifier": "Plate2_17",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:49:07+00:00",
+                "measurement time": "2023-03-16T09:48:36+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7706,7 +7757,7 @@
                     "sample identifier": "Plate2_18",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:42:05+00:00",
+                "measurement time": "2023-03-16T12:41:44+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7735,7 +7786,7 @@
                     "sample identifier": "Plate2_18",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:49:40+00:00",
+                "measurement time": "2023-03-16T09:49:19+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7778,7 +7829,7 @@
                     "sample identifier": "Plate2_19",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:42:36+00:00",
+                "measurement time": "2023-03-16T12:42:16+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7807,7 +7858,7 @@
                     "sample identifier": "Plate2_19",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:50:12+00:00",
+                "measurement time": "2023-03-16T09:49:51+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7850,7 +7901,7 @@
                     "sample identifier": "Plate2_2",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:30:45+00:00",
+                "measurement time": "2023-03-16T12:30:23+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7879,7 +7930,7 @@
                     "sample identifier": "Plate2_2",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:38:20+00:00",
+                "measurement time": "2023-03-16T09:37:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7922,7 +7973,7 @@
                     "sample identifier": "Plate2_20",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:43:09+00:00",
+                "measurement time": "2023-03-16T12:42:47+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7951,7 +8002,7 @@
                     "sample identifier": "Plate2_20",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:50:44+00:00",
+                "measurement time": "2023-03-16T09:50:22+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -7994,7 +8045,7 @@
                     "sample identifier": "Plate2_21",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:43:40+00:00",
+                "measurement time": "2023-03-16T12:43:19+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8023,7 +8074,7 @@
                     "sample identifier": "Plate2_21",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:51:15+00:00",
+                "measurement time": "2023-03-16T09:50:54+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8066,7 +8117,7 @@
                     "sample identifier": "Plate2_22",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:44:12+00:00",
+                "measurement time": "2023-03-16T12:43:52+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8095,7 +8146,7 @@
                     "sample identifier": "Plate2_22",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:51:47+00:00",
+                "measurement time": "2023-03-16T09:51:27+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8138,7 +8189,7 @@
                     "sample identifier": "Plate2_23",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:45:17+00:00",
+                "measurement time": "2023-03-16T12:44:34+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8167,7 +8218,7 @@
                     "sample identifier": "Plate2_23",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:52:52+00:00",
+                "measurement time": "2023-03-16T09:52:10+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8210,7 +8261,7 @@
                     "sample identifier": "Plate2_24",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:46:10+00:00",
+                "measurement time": "2023-03-16T12:45:27+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8239,7 +8290,7 @@
                     "sample identifier": "Plate2_24",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:53:45+00:00",
+                "measurement time": "2023-03-16T09:53:02+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8282,7 +8333,7 @@
                     "sample identifier": "Plate2_25",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:47:03+00:00",
+                "measurement time": "2023-03-16T12:46:20+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8311,7 +8362,7 @@
                     "sample identifier": "Plate2_25",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:54:38+00:00",
+                "measurement time": "2023-03-16T09:53:56+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8354,7 +8405,7 @@
                     "sample identifier": "Plate2_26",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:47:45+00:00",
+                "measurement time": "2023-03-16T12:47:13+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8383,7 +8434,7 @@
                     "sample identifier": "Plate2_26",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:55:21+00:00",
+                "measurement time": "2023-03-16T09:54:48+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8426,7 +8477,7 @@
                     "sample identifier": "Plate2_27",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:48:28+00:00",
+                "measurement time": "2023-03-16T12:47:56+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8455,7 +8506,7 @@
                     "sample identifier": "Plate2_27",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:56:03+00:00",
+                "measurement time": "2023-03-16T09:55:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8498,7 +8549,7 @@
                     "sample identifier": "Plate2_28",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:49:10+00:00",
+                "measurement time": "2023-03-16T12:48:37+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8527,7 +8578,7 @@
                     "sample identifier": "Plate2_28",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:56:45+00:00",
+                "measurement time": "2023-03-16T09:56:13+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8570,7 +8621,7 @@
                     "sample identifier": "Plate2_29",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:49:41+00:00",
+                "measurement time": "2023-03-16T12:49:21+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8599,7 +8650,7 @@
                     "sample identifier": "Plate2_29",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:57:16+00:00",
+                "measurement time": "2023-03-16T09:56:56+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8642,7 +8693,7 @@
                     "sample identifier": "Plate2_3",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:31:16+00:00",
+                "measurement time": "2023-03-16T12:30:55+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8671,7 +8722,7 @@
                     "sample identifier": "Plate2_3",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:38:52+00:00",
+                "measurement time": "2023-03-16T09:38:30+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8714,7 +8765,7 @@
                     "sample identifier": "Plate2_30",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:50:24+00:00",
+                "measurement time": "2023-03-16T12:50:04+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8743,7 +8794,7 @@
                     "sample identifier": "Plate2_30",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:58:00+00:00",
+                "measurement time": "2023-03-16T09:57:39+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8786,7 +8837,7 @@
                     "sample identifier": "Plate2_31",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:51:06+00:00",
+                "measurement time": "2023-03-16T12:50:34+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8815,7 +8866,7 @@
                     "sample identifier": "Plate2_31",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:58:41+00:00",
+                "measurement time": "2023-03-16T09:58:09+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8858,7 +8909,7 @@
                     "sample identifier": "Plate2_32",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:51:39+00:00",
+                "measurement time": "2023-03-16T12:51:17+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8887,7 +8938,7 @@
                     "sample identifier": "Plate2_32",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:59:14+00:00",
+                "measurement time": "2023-03-16T09:58:52+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8930,7 +8981,7 @@
                     "sample identifier": "Plate2_33",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:52:21+00:00",
+                "measurement time": "2023-03-16T12:51:48+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -8959,7 +9010,7 @@
                     "sample identifier": "Plate2_33",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:59:57+00:00",
+                "measurement time": "2023-03-16T09:59:24+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9002,7 +9053,7 @@
                     "sample identifier": "Plate2_34",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:53:03+00:00",
+                "measurement time": "2023-03-16T12:52:32+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9031,7 +9082,7 @@
                     "sample identifier": "Plate2_34",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:00:38+00:00",
+                "measurement time": "2023-03-16T10:00:07+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9074,7 +9125,7 @@
                     "sample identifier": "Plate2_35",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:53:57+00:00",
+                "measurement time": "2023-03-16T12:53:15+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9103,7 +9154,7 @@
                     "sample identifier": "Plate2_35",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:01:32+00:00",
+                "measurement time": "2023-03-16T10:00:50+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9146,7 +9197,7 @@
                     "sample identifier": "Plate2_36",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:54:50+00:00",
+                "measurement time": "2023-03-16T12:54:28+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9175,7 +9226,7 @@
                     "sample identifier": "Plate2_36",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:02:26+00:00",
+                "measurement time": "2023-03-16T10:02:03+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9218,7 +9269,7 @@
                     "sample identifier": "Plate2_37",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:55:42+00:00",
+                "measurement time": "2023-03-16T12:55:10+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9247,7 +9298,7 @@
                     "sample identifier": "Plate2_37",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:03:17+00:00",
+                "measurement time": "2023-03-16T10:02:45+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9290,7 +9341,7 @@
                     "sample identifier": "Plate2_38",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:56:24+00:00",
+                "measurement time": "2023-03-16T12:55:53+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9319,7 +9370,7 @@
                     "sample identifier": "Plate2_38",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:04:00+00:00",
+                "measurement time": "2023-03-16T10:03:29+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9362,7 +9413,7 @@
                     "sample identifier": "Plate2_39",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:57:08+00:00",
+                "measurement time": "2023-03-16T12:56:36+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9391,7 +9442,7 @@
                     "sample identifier": "Plate2_39",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:04:43+00:00",
+                "measurement time": "2023-03-16T10:04:11+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9434,7 +9485,7 @@
                     "sample identifier": "Plate2_4",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:31:48+00:00",
+                "measurement time": "2023-03-16T12:31:27+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9463,7 +9514,7 @@
                     "sample identifier": "Plate2_4",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:39:24+00:00",
+                "measurement time": "2023-03-16T09:39:02+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9506,7 +9557,7 @@
                     "sample identifier": "Plate2_40",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:58:11+00:00",
+                "measurement time": "2023-03-16T12:57:39+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9535,7 +9586,7 @@
                     "sample identifier": "Plate2_40",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:05:46+00:00",
+                "measurement time": "2023-03-16T10:05:14+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9578,7 +9629,7 @@
                     "sample identifier": "Plate2_41",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:58:54+00:00",
+                "measurement time": "2023-03-16T12:58:21+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9607,7 +9658,7 @@
                     "sample identifier": "Plate2_41",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:06:29+00:00",
+                "measurement time": "2023-03-16T10:05:56+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9650,7 +9701,7 @@
                     "sample identifier": "Plate2_42",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:59:26+00:00",
+                "measurement time": "2023-03-16T12:59:04+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9679,7 +9730,7 @@
                     "sample identifier": "Plate2_42",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:07:01+00:00",
+                "measurement time": "2023-03-16T10:06:39+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9722,7 +9773,7 @@
                     "sample identifier": "Plate2_43",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:59:57+00:00",
+                "measurement time": "2023-03-16T12:59:37+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9751,7 +9802,7 @@
                     "sample identifier": "Plate2_43",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:07:32+00:00",
+                "measurement time": "2023-03-16T10:07:12+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9794,7 +9845,7 @@
                     "sample identifier": "Plate2_44",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:00:40+00:00",
+                "measurement time": "2023-03-16T13:00:09+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9823,7 +9874,7 @@
                     "sample identifier": "Plate2_44",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:08:16+00:00",
+                "measurement time": "2023-03-16T10:07:44+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9866,7 +9917,7 @@
                     "sample identifier": "Plate2_45",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:01:12+00:00",
+                "measurement time": "2023-03-16T13:00:50+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9895,7 +9946,7 @@
                     "sample identifier": "Plate2_45",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:08:47+00:00",
+                "measurement time": "2023-03-16T10:08:25+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9938,7 +9989,7 @@
                     "sample identifier": "Plate2_46",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:01:55+00:00",
+                "measurement time": "2023-03-16T13:01:32+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -9967,7 +10018,7 @@
                     "sample identifier": "Plate2_46",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:09:30+00:00",
+                "measurement time": "2023-03-16T10:09:08+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10010,7 +10061,7 @@
                     "sample identifier": "Plate2_47",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:02:57+00:00",
+                "measurement time": "2023-03-16T13:02:25+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10039,7 +10090,7 @@
                     "sample identifier": "Plate2_47",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:10:32+00:00",
+                "measurement time": "2023-03-16T10:10:01+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10082,7 +10133,7 @@
                     "sample identifier": "Plate2_48",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:03:29+00:00",
+                "measurement time": "2023-03-16T13:03:09+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10111,7 +10162,7 @@
                     "sample identifier": "Plate2_48",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:11:04+00:00",
+                "measurement time": "2023-03-16T10:10:44+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10154,7 +10205,7 @@
                     "sample identifier": "Plate2_49",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:04:24+00:00",
+                "measurement time": "2023-03-16T13:03:41+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10183,7 +10234,7 @@
                     "sample identifier": "Plate2_49",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:11:59+00:00",
+                "measurement time": "2023-03-16T10:11:16+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10226,7 +10277,7 @@
                     "sample identifier": "Plate2_5",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:32:20+00:00",
+                "measurement time": "2023-03-16T12:31:59+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10255,7 +10306,7 @@
                     "sample identifier": "Plate2_5",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:39:55+00:00",
+                "measurement time": "2023-03-16T09:39:34+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10298,7 +10349,7 @@
                     "sample identifier": "Plate2_50",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:05:26+00:00",
+                "measurement time": "2023-03-16T13:04:54+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10327,7 +10378,7 @@
                     "sample identifier": "Plate2_50",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:13:01+00:00",
+                "measurement time": "2023-03-16T10:12:29+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10370,7 +10421,7 @@
                     "sample identifier": "Plate2_51",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:06:10+00:00",
+                "measurement time": "2023-03-16T13:05:38+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10399,7 +10450,7 @@
                     "sample identifier": "Plate2_51",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:13:45+00:00",
+                "measurement time": "2023-03-16T10:13:13+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10442,7 +10493,7 @@
                     "sample identifier": "Plate2_52",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:07:02+00:00",
+                "measurement time": "2023-03-16T13:06:41+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10471,7 +10522,7 @@
                     "sample identifier": "Plate2_52",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:14:37+00:00",
+                "measurement time": "2023-03-16T10:14:16+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10514,7 +10565,7 @@
                     "sample identifier": "Plate2_53",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:07:45+00:00",
+                "measurement time": "2023-03-16T13:07:24+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10543,7 +10594,7 @@
                     "sample identifier": "Plate2_53",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:15:20+00:00",
+                "measurement time": "2023-03-16T10:14:59+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10586,7 +10637,7 @@
                     "sample identifier": "Plate2_54",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:08:16+00:00",
+                "measurement time": "2023-03-16T13:07:54+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10615,7 +10666,7 @@
                     "sample identifier": "Plate2_54",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:15:51+00:00",
+                "measurement time": "2023-03-16T10:15:29+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10658,7 +10709,7 @@
                     "sample identifier": "Plate2_55",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:08:58+00:00",
+                "measurement time": "2023-03-16T13:08:27+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10687,7 +10738,7 @@
                     "sample identifier": "Plate2_55",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:16:33+00:00",
+                "measurement time": "2023-03-16T10:16:03+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10730,7 +10781,7 @@
                     "sample identifier": "Plate2_56",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:09:30+00:00",
+                "measurement time": "2023-03-16T13:09:10+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10759,7 +10810,7 @@
                     "sample identifier": "Plate2_56",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:17:05+00:00",
+                "measurement time": "2023-03-16T10:16:45+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10802,7 +10853,7 @@
                     "sample identifier": "Plate2_57",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:10:02+00:00",
+                "measurement time": "2023-03-16T13:09:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10831,7 +10882,7 @@
                     "sample identifier": "Plate2_57",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:17:37+00:00",
+                "measurement time": "2023-03-16T10:17:17+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10874,7 +10925,7 @@
                     "sample identifier": "Plate2_58",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:10:44+00:00",
+                "measurement time": "2023-03-16T13:10:14+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10903,7 +10954,7 @@
                     "sample identifier": "Plate2_58",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:18:20+00:00",
+                "measurement time": "2023-03-16T10:17:49+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10946,7 +10997,7 @@
                     "sample identifier": "Plate2_59",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:11:38+00:00",
+                "measurement time": "2023-03-16T13:10:56+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -10975,7 +11026,7 @@
                     "sample identifier": "Plate2_59",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:19:14+00:00",
+                "measurement time": "2023-03-16T10:18:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11018,7 +11069,7 @@
                     "sample identifier": "Plate2_6",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:32:52+00:00",
+                "measurement time": "2023-03-16T12:32:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11047,7 +11098,7 @@
                     "sample identifier": "Plate2_6",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:40:27+00:00",
+                "measurement time": "2023-03-16T09:40:06+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11090,7 +11141,7 @@
                     "sample identifier": "Plate2_60",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:12:31+00:00",
+                "measurement time": "2023-03-16T13:12:00+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11119,7 +11170,7 @@
                     "sample identifier": "Plate2_60",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:20:06+00:00",
+                "measurement time": "2023-03-16T10:19:35+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11162,7 +11213,7 @@
                     "sample identifier": "Plate2_61",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:13:24+00:00",
+                "measurement time": "2023-03-16T13:12:53+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11191,7 +11242,7 @@
                     "sample identifier": "Plate2_61",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:20:59+00:00",
+                "measurement time": "2023-03-16T10:20:28+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11234,7 +11285,7 @@
                     "sample identifier": "Plate2_62",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:14:07+00:00",
+                "measurement time": "2023-03-16T13:13:46+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11263,7 +11314,7 @@
                     "sample identifier": "Plate2_62",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:21:42+00:00",
+                "measurement time": "2023-03-16T10:21:21+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11306,7 +11357,7 @@
                     "sample identifier": "Plate2_63",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:14:39+00:00",
+                "measurement time": "2023-03-16T13:14:17+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11335,7 +11386,7 @@
                     "sample identifier": "Plate2_63",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:22:14+00:00",
+                "measurement time": "2023-03-16T10:21:52+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11378,7 +11429,7 @@
                     "sample identifier": "Plate2_64",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:15:32+00:00",
+                "measurement time": "2023-03-16T13:14:59+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11407,7 +11458,7 @@
                     "sample identifier": "Plate2_64",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:23:07+00:00",
+                "measurement time": "2023-03-16T10:22:35+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11450,7 +11501,7 @@
                     "sample identifier": "Plate2_65",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:16:14+00:00",
+                "measurement time": "2023-03-16T13:15:53+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11479,7 +11530,7 @@
                     "sample identifier": "Plate2_65",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:23:50+00:00",
+                "measurement time": "2023-03-16T10:23:28+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11522,7 +11573,7 @@
                     "sample identifier": "Plate2_66",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:16:57+00:00",
+                "measurement time": "2023-03-16T13:16:25+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11551,7 +11602,7 @@
                     "sample identifier": "Plate2_66",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:24:32+00:00",
+                "measurement time": "2023-03-16T10:24:00+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11594,7 +11645,7 @@
                     "sample identifier": "Plate2_67",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:17:38+00:00",
+                "measurement time": "2023-03-16T13:17:07+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11623,7 +11674,7 @@
                     "sample identifier": "Plate2_67",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:25:14+00:00",
+                "measurement time": "2023-03-16T10:24:43+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11666,7 +11717,7 @@
                     "sample identifier": "Plate2_68",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:18:12+00:00",
+                "measurement time": "2023-03-16T13:17:50+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11695,7 +11746,7 @@
                     "sample identifier": "Plate2_68",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:25:47+00:00",
+                "measurement time": "2023-03-16T10:25:26+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11738,7 +11789,7 @@
                     "sample identifier": "Plate2_69",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:18:43+00:00",
+                "measurement time": "2023-03-16T13:18:21+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11767,7 +11818,7 @@
                     "sample identifier": "Plate2_69",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:26:19+00:00",
+                "measurement time": "2023-03-16T10:25:56+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11810,7 +11861,7 @@
                     "sample identifier": "Plate2_7",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:33:25+00:00",
+                "measurement time": "2023-03-16T12:33:03+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11839,7 +11890,7 @@
                     "sample identifier": "Plate2_7",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:41:00+00:00",
+                "measurement time": "2023-03-16T09:40:38+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11882,7 +11933,7 @@
                     "sample identifier": "Plate2_70",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:19:26+00:00",
+                "measurement time": "2023-03-16T13:18:53+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11911,7 +11962,7 @@
                     "sample identifier": "Plate2_70",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:27:01+00:00",
+                "measurement time": "2023-03-16T10:26:28+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11954,7 +12005,7 @@
                     "sample identifier": "Plate2_71",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:20:36+00:00",
+                "measurement time": "2023-03-16T13:19:36+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -11983,7 +12034,7 @@
                     "sample identifier": "Plate2_71",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:28:04+00:00",
+                "measurement time": "2023-03-16T10:27:11+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12026,7 +12077,7 @@
                     "sample identifier": "Plate2_72",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:21:22+00:00",
+                "measurement time": "2023-03-16T13:20:51+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12055,7 +12106,7 @@
                     "sample identifier": "Plate2_72",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:28:58+00:00",
+                "measurement time": "2023-03-16T10:28:26+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12098,7 +12149,7 @@
                     "sample identifier": "Plate2_73",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:22:15+00:00",
+                "measurement time": "2023-03-16T13:21:43+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12127,7 +12178,7 @@
                     "sample identifier": "Plate2_73",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:29:50+00:00",
+                "measurement time": "2023-03-16T10:29:19+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12170,7 +12221,7 @@
                     "sample identifier": "Plate2_74",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:22:54+00:00",
+                "measurement time": "2023-03-16T13:22:26+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12199,7 +12250,7 @@
                     "sample identifier": "Plate2_74",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:30:22+00:00",
+                "measurement time": "2023-03-16T10:30:02+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12242,7 +12293,7 @@
                     "sample identifier": "Plate2_75",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:23:30+00:00",
+                "measurement time": "2023-03-16T13:22:57+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12271,7 +12322,7 @@
                     "sample identifier": "Plate2_75",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:31:05+00:00",
+                "measurement time": "2023-03-16T10:30:32+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12314,7 +12365,7 @@
                     "sample identifier": "Plate2_76",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:24:18+00:00",
+                "measurement time": "2023-03-16T13:23:39+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12343,7 +12394,7 @@
                     "sample identifier": "Plate2_76",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:31:46+00:00",
+                "measurement time": "2023-03-16T10:31:14+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12386,7 +12437,7 @@
                     "sample identifier": "Plate2_77",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:24:57+00:00",
+                "measurement time": "2023-03-16T13:24:23+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12415,7 +12466,7 @@
                     "sample identifier": "Plate2_77",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:32:30+00:00",
+                "measurement time": "2023-03-16T10:31:59+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12458,7 +12509,7 @@
                     "sample identifier": "Plate2_78",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:25:48+00:00",
+                "measurement time": "2023-03-16T13:25:25+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12487,7 +12538,7 @@
                     "sample identifier": "Plate2_78",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:33:23+00:00",
+                "measurement time": "2023-03-16T10:33:01+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12530,7 +12581,7 @@
                     "sample identifier": "Plate2_79",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:26:19+00:00",
+                "measurement time": "2023-03-16T13:25:58+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12559,7 +12610,7 @@
                     "sample identifier": "Plate2_79",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:33:54+00:00",
+                "measurement time": "2023-03-16T10:33:34+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12602,7 +12653,7 @@
                     "sample identifier": "Plate2_8",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:33:57+00:00",
+                "measurement time": "2023-03-16T12:33:35+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12631,7 +12682,7 @@
                     "sample identifier": "Plate2_8",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:41:32+00:00",
+                "measurement time": "2023-03-16T09:41:10+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12674,7 +12725,7 @@
                     "sample identifier": "Plate2_80",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:27:11+00:00",
+                "measurement time": "2023-03-16T13:26:41+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12703,7 +12754,7 @@
                     "sample identifier": "Plate2_80",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:34:47+00:00",
+                "measurement time": "2023-03-16T10:34:16+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12746,7 +12797,7 @@
                     "sample identifier": "Plate2_81",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:31:39+00:00",
+                "measurement time": "2023-03-16T13:31:16+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12775,7 +12826,7 @@
                     "sample identifier": "Plate2_81",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:35:19+00:00",
+                "measurement time": "2023-03-16T10:34:59+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12818,7 +12869,7 @@
                     "sample identifier": "Plate2_82",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:32:10+00:00",
+                "measurement time": "2023-03-16T13:31:48+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12847,7 +12898,7 @@
                     "sample identifier": "Plate2_82",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:35:51+00:00",
+                "measurement time": "2023-03-16T10:35:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12890,7 +12941,7 @@
                     "sample identifier": "Plate2_83",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:33:13+00:00",
+                "measurement time": "2023-03-16T13:32:32+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12919,7 +12970,7 @@
                     "sample identifier": "Plate2_83",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:36:54+00:00",
+                "measurement time": "2023-03-16T10:36:23+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12962,7 +13013,7 @@
                     "sample identifier": "Plate2_84",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:33:45+00:00",
+                "measurement time": "2023-03-16T13:33:24+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -12991,7 +13042,7 @@
                     "sample identifier": "Plate2_84",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:37:27+00:00",
+                "measurement time": "2023-03-16T10:37:06+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13034,7 +13085,7 @@
                     "sample identifier": "Plate2_85",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:34:18+00:00",
+                "measurement time": "2023-03-16T13:33:55+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13063,7 +13114,7 @@
                     "sample identifier": "Plate2_85",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:38:19+00:00",
+                "measurement time": "2023-03-16T10:37:49+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13106,7 +13157,7 @@
                     "sample identifier": "Plate2_86",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:34:49+00:00",
+                "measurement time": "2023-03-16T13:34:27+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13135,7 +13186,7 @@
                     "sample identifier": "Plate2_86",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:39:03+00:00",
+                "measurement time": "2023-03-16T10:38:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13178,7 +13229,7 @@
                     "sample identifier": "Plate2_87",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:35:21+00:00",
+                "measurement time": "2023-03-16T13:34:59+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13207,7 +13258,7 @@
                     "sample identifier": "Plate2_87",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:39:45+00:00",
+                "measurement time": "2023-03-16T10:39:23+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13250,7 +13301,7 @@
                     "sample identifier": "Plate2_88",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:35:52+00:00",
+                "measurement time": "2023-03-16T13:35:31+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13279,7 +13330,7 @@
                     "sample identifier": "Plate2_88",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:40:28+00:00",
+                "measurement time": "2023-03-16T10:40:07+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13322,7 +13373,7 @@
                     "sample identifier": "Plate2_89",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:36:35+00:00",
+                "measurement time": "2023-03-16T13:36:04+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13351,7 +13402,7 @@
                     "sample identifier": "Plate2_89",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:41:21+00:00",
+                "measurement time": "2023-03-16T10:40:48+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13394,7 +13445,7 @@
                     "sample identifier": "Plate2_9",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T12:34:29+00:00",
+                "measurement time": "2023-03-16T12:34:07+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13423,7 +13474,7 @@
                     "sample identifier": "Plate2_9",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T09:42:04+00:00",
+                "measurement time": "2023-03-16T09:41:42+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13466,7 +13517,7 @@
                     "sample identifier": "Plate2_90",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:37:38+00:00",
+                "measurement time": "2023-03-16T13:36:46+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13495,7 +13546,7 @@
                     "sample identifier": "Plate2_90",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:41:52+00:00",
+                "measurement time": "2023-03-16T10:41:32+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13538,7 +13589,7 @@
                     "sample identifier": "Plate2_91",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:38:32+00:00",
+                "measurement time": "2023-03-16T13:38:01+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13567,7 +13618,7 @@
                     "sample identifier": "Plate2_91",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:42:24+00:00",
+                "measurement time": "2023-03-16T10:42:03+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13610,7 +13661,7 @@
                     "sample identifier": "Plate2_92",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:39:14+00:00",
+                "measurement time": "2023-03-16T13:38:43+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13639,7 +13690,7 @@
                     "sample identifier": "Plate2_92",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:43:18+00:00",
+                "measurement time": "2023-03-16T10:42:45+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13682,7 +13733,7 @@
                     "sample identifier": "Plate2_93",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:40:17+00:00",
+                "measurement time": "2023-03-16T13:39:47+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13711,7 +13762,7 @@
                     "sample identifier": "Plate2_93",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:43:49+00:00",
+                "measurement time": "2023-03-16T10:43:27+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13754,7 +13805,7 @@
                     "sample identifier": "Plate2_94",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:41:01+00:00",
+                "measurement time": "2023-03-16T13:40:40+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13783,7 +13834,7 @@
                     "sample identifier": "Plate2_94",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:44:32+00:00",
+                "measurement time": "2023-03-16T10:44:00+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13826,7 +13877,7 @@
                     "sample identifier": "Plate2_95",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:41:53+00:00",
+                "measurement time": "2023-03-16T13:41:21+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13855,7 +13906,7 @@
                     "sample identifier": "Plate2_95",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:45:24+00:00",
+                "measurement time": "2023-03-16T10:44:52+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13898,7 +13949,7 @@
                     "sample identifier": "Plate2_96",
                     "batch identifier": "PATCH_23"
                 },
-                "measurement time": "2023-03-16T13:42:26+00:00",
+                "measurement time": "2023-03-16T13:42:04+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -13927,7 +13978,7 @@
                     "sample identifier": "Plate2_96",
                     "batch identifier": "PATCH_29"
                 },
-                "measurement time": "2023-03-16T10:46:19+00:00",
+                "measurement time": "2023-03-16T10:45:36+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {

--- a/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example04.json
+++ b/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example04.json
@@ -13,7 +13,7 @@
                     "sample identifier": "Plate1_1",
                     "batch identifier": "P_391"
                 },
-                "measurement time": "2022-10-20T09:45:25+00:00",
+                "measurement time": "2022-10-20T09:44:05+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -42,7 +42,7 @@
                     "sample identifier": "Plate1_1",
                     "batch identifier": "P_492"
                 },
-                "measurement time": "2022-10-20T09:45:25+00:00",
+                "measurement time": "2022-10-20T09:44:05+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -64,7 +64,7 @@
                     "sample identifier": "Plate1_2",
                     "batch identifier": "P_391"
                 },
-                "measurement time": "2022-10-20T09:45:55+00:00",
+                "measurement time": "2022-10-20T09:45:33+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {
@@ -92,7 +92,7 @@
                 "sample document": {
                     "sample identifier": "Plate1_3"
                 },
-                "measurement time": "2022-10-20T09:46:27+00:00",
+                "measurement time": "2022-10-20T09:46:05+00:00",
                 "analyte aggregate document": {
                     "analyte document": [
                         {

--- a/tests/parsers/roche_cedex_bioht/to_allotrope_test.py
+++ b/tests/parsers/roche_cedex_bioht/to_allotrope_test.py
@@ -4,4 +4,3 @@ from tests.to_allotrope_test import ParserTest
 
 class TestParser(ParserTest):
     VENDOR = Vendor.ROCHE_CEDEX_BIOHT
-    OVERWRITE_ON_FAILURE = True

--- a/tests/parsers/roche_cedex_bioht/to_allotrope_test.py
+++ b/tests/parsers/roche_cedex_bioht/to_allotrope_test.py
@@ -4,3 +4,4 @@ from tests.to_allotrope_test import ParserTest
 
 class TestParser(ParserTest):
     VENDOR = Vendor.ROCHE_CEDEX_BIOHT
+    OVERWRITE_ON_FAILURE = True


### PR DESCRIPTION
This fixes a rare(ish?) edge case in bioht where two measurements for the same sample and property are taken over several days.

In the result files for this parser, all measurements are taken at separate times, but we want to group measurements for a given sample. To do this, all measurements for a sample were group, and then duplicate measurements were aggregated in a list and split out in to separate measurement documents in the order the were encountered.

However, this misses the context of what these duplicate measurements actually are. In reality, a duplicate measurement for a sample happens when multiple measurements are taken over a period of time (in the example file we have, over 3 days). 

To really capture this context, we instead group measurements close in time (using a heuristic of 1 hour max time difference)

Note that this also fixes another minor bug for the recorded measurement time, which the requirements specify should be the earliest measurement time (previous it was just the first measurement time encountered).