### PR TITLE
refactor: Allow timestamp parser to be None

### DIFF
--- a/src/allotropy/parsers/utils/timestamp_parser.py
+++ b/src/allotropy/parsers/utils/timestamp_parser.py
@@ -5,7 +5,6 @@ from dateutil import parser
 import pytz
 
 from allotropy.exceptions import AllotropeConversionError
-from allotropy.parsers.utils.values import assert_not_none
 
 TIMEZONE_CODES_MAP = {
     **{code: pytz.timezone(code) for code in pytz.all_timezones},
@@ -24,9 +23,6 @@ class TimestampParser:
     default_timezone: tzinfo
 
     def __init__(self, default_timezone: tzinfo | None = None):
-        if default_timezone and not isinstance(default_timezone, tzinfo):
-            msg = f"Invalid default timezone '{default_timezone}'."
-            raise AllotropeConversionError(msg)
         self.default_timezone = default_timezone or ZoneInfo("UTC")
 
     def parse(self, time: str) -> str:
@@ -37,8 +33,6 @@ class TimestampParser:
         :param time: the string to parse
         :raises AllotropeConversionError if time cannot be parsed
         """
-        assert_not_none(time, "time")
-
         try:
             timestamp = parser.parse(time, tzinfos=TIMEZONE_CODES_MAP, fuzzy=True)
         except ValueError as e:

--- a/src/allotropy/parsers/vendor_parser.py
+++ b/src/allotropy/parsers/vendor_parser.py
@@ -2,15 +2,12 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Any, Generic, TypeVar
 
-from pandas import Timestamp
-
 from allotropy.allotrope.models.shared.definitions.definitions import TDateTimeValue
 from allotropy.allotrope.schema_mappers.schema_mapper import SchemaMapper
 from allotropy.constants import ASM_CONVERTER_NAME
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.release_state import ReleaseState
 from allotropy.parsers.utils.timestamp_parser import TimestampParser
-from allotropy.parsers.utils.values import assert_not_none
 
 Data = TypeVar("Data")
 Model = TypeVar("Model")
@@ -18,16 +15,16 @@ Mapper = TypeVar("Mapper")
 
 
 class VendorParser(ABC):
+    """Base class for all vendor parsers."""
+
     # The display name of the parser. Displayed in the README.
     DISPLAY_NAME: str
     # Signifies if the parser is ready to be used. Can be set to ReleaseState.WORKING_DRAFT while being developed.
     RELEASE_STATE: ReleaseState
     timestamp_parser: TimestampParser
 
-    """Base class for all vendor parsers."""
-
-    def __init__(self, timestamp_parser: TimestampParser):
-        self.timestamp_parser = assert_not_none(timestamp_parser, "timestamp_parser")
+    def __init__(self, timestamp_parser: TimestampParser | None = None):
+        self.timestamp_parser = timestamp_parser or TimestampParser()
 
     @abstractmethod
     def to_allotrope(self, named_file_contents: NamedFileContents) -> Any:
@@ -38,16 +35,7 @@ class VendorParser(ABC):
         return f'{ASM_CONVERTER_NAME}_{self.DISPLAY_NAME.replace(" ", "_").replace("-", "_")}'.lower()
 
     def _get_date_time(self, time: str) -> TDateTimeValue:
-        assert_not_none(time, "time")
-
         return self.timestamp_parser.parse(time)
-
-    # TODO(brian): Calling str() to pass to _get_date_time() potentially loses information.
-    def _get_date_time_from_timestamp(self, timestamp: Timestamp) -> TDateTimeValue:
-        # TODO(brian): fail if timestamp is not a Timestamp?
-        assert_not_none(timestamp, "timestamp")
-        time = str(timestamp)
-        return self._get_date_time(time)
 
 
 class MapperVendorParser(VendorParser, Generic[Data, Model]):

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_parser_test.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_parser_test.py
@@ -8,7 +8,6 @@ from allotropy.parser_factory import Vendor
 from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_parser import (
     AppBioQuantStudioParser,
 )
-from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from tests.parsers.appbio_quantstudio.appbio_quantstudio_data import (
     get_broken_calc_doc_data,
     get_broken_calc_doc_model,
@@ -46,6 +45,5 @@ VENDOR_TYPE = Vendor.APPBIO_QUANTSTUDIO
     ],
 )
 def test_get_model(data: Data, model: Model) -> None:
-    parser = AppBioQuantStudioParser(TimestampParser())
-    generated = parser._get_mapper().map_model(data)
+    generated = AppBioQuantStudioParser()._get_mapper().map_model(data)
     assert generated == model

--- a/tests/parsers/appbio_quantstudio/appbio_quantstudio_structure_test.py
+++ b/tests/parsers/appbio_quantstudio/appbio_quantstudio_structure_test.py
@@ -21,7 +21,6 @@ from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_structure import (
     Result,
 )
 from allotropy.parsers.lines_reader import LinesReader, read_to_lines
-from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from allotropy.types import IOType
 from tests.parsers.appbio_quantstudio.appbio_quantstudio_data import (
     get_broken_calc_doc_data,
@@ -218,7 +217,7 @@ def test_data_builder(
 ) -> None:
     with open(test_filepath, "rb") as raw_contents:
         assert rm_uuid(
-            AppBioQuantStudioParser(TimestampParser()).create_data(
+            AppBioQuantStudioParser().create_data(
                 NamedFileContents(raw_contents, test_filepath)
             )
         ) == rm_uuid(create_expected_data_func(test_filepath))

--- a/tests/parsers/beckman_pharmspec/beckman_pharmspec_parser_test.py
+++ b/tests/parsers/beckman_pharmspec/beckman_pharmspec_parser_test.py
@@ -14,16 +14,13 @@ from allotropy.allotrope.models.adm.light_obscuration.benchling._2023._12.light_
 from allotropy.named_file_contents import NamedFileContents
 from allotropy.parsers.beckman_pharmspec.beckman_pharmspec_parser import PharmSpecParser
 from allotropy.parsers.beckman_pharmspec.beckman_pharmspec_structure import Header
-from allotropy.parsers.utils.timestamp_parser import TimestampParser
 
 TESTDATA = f"{Path(__file__).parent}/testdata"
 
 
 @pytest.mark.short
 def test_get_model() -> None:
-    parser = PharmSpecParser(TimestampParser())
-
-    model = parser.to_allotrope(
+    model = PharmSpecParser().to_allotrope(
         NamedFileContents(open(Path(TESTDATA, "hiac_example_1.xlsx"), "rb"), "")
     )
     assert isinstance(

--- a/tests/parsers/beckman_vi_cell_blu/vi_cell_blu_parser_test.py
+++ b/tests/parsers/beckman_vi_cell_blu/vi_cell_blu_parser_test.py
@@ -12,7 +12,6 @@ from allotropy.parsers.beckman_vi_cell_blu.vi_cell_blu_structure import (
     create_metadata,
 )
 from allotropy.parsers.utils.pandas import map_rows
-from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from tests.parsers.beckman_vi_cell_blu.vi_cell_blu_data import (
     get_data,
     get_filename,
@@ -34,10 +33,9 @@ def _clear_measurement_identifier(model: Model) -> None:
 
 
 def test_get_model() -> None:
-    parser = ViCellBluParser(TimestampParser())
     data = Data(
         create_metadata(get_filename()), map_rows(get_data(), create_measurement_group)
     )
-    result = parser._get_mapper().map_model(data)
+    result = ViCellBluParser()._get_mapper().map_model(data)
     _clear_measurement_identifier(result)
     assert result == get_model()

--- a/tests/parsers/novabio_flex2/novabio_flex2_structure_test.py
+++ b/tests/parsers/novabio_flex2/novabio_flex2_structure_test.py
@@ -15,7 +15,6 @@ from allotropy.parsers.novabio_flex2.novabio_flex2_structure import (
     SampleList,
     Title,
 )
-from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from tests.parsers.novabio_flex2.novabio_flex2_data import (
     get_data,
     get_input_stream,
@@ -141,7 +140,4 @@ def test_create_data() -> None:
         "allotropy.parsers.novabio_flex2.novabio_flex2_structure.random_uuid_str",
         return_value="dummy_id",
     ):
-        assert (
-            NovaBioFlexParser(TimestampParser()).create_data(named_file_contents)
-            == get_data()
-        )
+        assert NovaBioFlexParser().create_data(named_file_contents) == get_data()

--- a/tests/parsers/perkin_elmer_envision/perkin_elmer_envision_parser_test.py
+++ b/tests/parsers/perkin_elmer_envision/perkin_elmer_envision_parser_test.py
@@ -4,7 +4,6 @@ from allotropy.parser_factory import Vendor
 from allotropy.parsers.perkin_elmer_envision.perkin_elmer_envision_parser import (
     PerkinElmerEnvisionParser,
 )
-from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from tests.parsers.perkin_elmer_envision.perkin_elmer_envision_data import (
     get_data,
     get_model,
@@ -15,8 +14,7 @@ VENDOR_TYPE = Vendor.PERKIN_ELMER_ENVISION
 
 @pytest.mark.short
 def test_get_model() -> None:
-    parser = PerkinElmerEnvisionParser(TimestampParser())
-    model = parser._get_model(get_data(), "file.txt")
+    model = PerkinElmerEnvisionParser()._get_model(get_data(), "file.txt")
 
     # remove all random UUIDs
     if agg_doc := model.plate_reader_aggregate_document:

--- a/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_parser_test.py
+++ b/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_parser_test.py
@@ -3,12 +3,10 @@ import pytest
 from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_parser import (
     RocheCedexBiohtParser,
 )
-from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from tests.parsers.roche_cedex_bioht.roche_cedex_bioht_data import get_data, get_model
 
 
 @pytest.mark.short
 def test_get_model() -> None:
-    parser = RocheCedexBiohtParser(TimestampParser())
-    model = parser._get_mapper().map_model(get_data())
+    model = RocheCedexBiohtParser()._get_mapper().map_model(get_data())
     assert model == get_model()

--- a/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_structure_test.py
+++ b/tests/parsers/roche_cedex_bioht/roche_cedex_bioht_structure_test.py
@@ -15,7 +15,6 @@ from allotropy.parsers.roche_cedex_bioht.roche_cedex_bioht_structure import (
     Title,
 )
 from allotropy.parsers.utils.pandas import SeriesData
-from allotropy.parsers.utils.timestamp_parser import TimestampParser
 from tests.parsers.roche_cedex_bioht.roche_cedex_bioht_data import (
     get_data,
     get_data_stream,
@@ -227,7 +226,7 @@ def test_create_data() -> None:
         return_value="dummy_id",
     ):
         assert (
-            RocheCedexBiohtParser(TimestampParser()).create_data(
+            RocheCedexBiohtParser().create_data(
                 NamedFileContents(get_data_stream(), "dummy.txt")
             )
             == get_data()

--- a/tests/parsers/utils/timestamp_parser_test.py
+++ b/tests/parsers/utils/timestamp_parser_test.py
@@ -8,14 +8,6 @@ from allotropy.parsers.utils.timestamp_parser import TimestampParser
 
 
 @pytest.mark.short
-def test_timestamp_parser_init_fails_invalid_default_timezone() -> None:
-    with pytest.raises(
-        AllotropeConversionError, match="Invalid default timezone 'timezone'."
-    ):
-        TimestampParser("timezone")  # type: ignore[arg-type]
-
-
-@pytest.mark.short
 @pytest.mark.parametrize(
     "time_str,expected",
     [


### PR DESCRIPTION
Also removes asserts that are impossible due to typing and removes _get_date_time_from_timestamp which is unused.