### PR TITLE
chore: Catch keyboard interrupt in backup_manager

### DIFF
--- a/src/allotropy/allotrope/schema_parser/backup_manager.py
+++ b/src/allotropy/allotrope/schema_parser/backup_manager.py
@@ -65,7 +65,7 @@ def backup_paths(
     backup_paths = [_backup_file(path) for path in paths]
     try:
         yield backup_paths
-    except Exception:
+    except (Exception, KeyboardInterrupt):
         for backup in backup_paths:
             backup.unlink(missing_ok=True)
         raise


### PR DESCRIPTION
Currently, if a user interrupts scripts or tests, a backup file may be left behind. 

Catch keyboard interrupts so this doesn't happen anymore.