### PR TITLE
test: Add data source identifier validation to all parsers

### DIFF
--- a/tests/parsers/moldev_softmax_pro/to_allotrope_test.py
+++ b/tests/parsers/moldev_softmax_pro/to_allotrope_test.py
@@ -3,11 +3,9 @@ import re
 
 import pytest
 
-from allotropy.constants import CHARDET_ENCODING
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.parser_factory import Vendor
 from allotropy.testing.utils import from_file
-from tests.conftest import get_test_cases
 from tests.to_allotrope_test import ParserTest
 
 VENDOR_TYPE = Vendor.MOLDEV_SOFTMAX_PRO
@@ -54,38 +52,3 @@ def test_unrecognized_read_type(test_file: str) -> None:
         match="Only Endpoint measurements can be processed at this time.",
     ):
         from_file(test_file, VENDOR_TYPE)
-
-
-@pytest.mark.parametrize("test_filepath", get_test_cases(TESTDATA))
-def test_data_source_id_references(
-    test_filepath: Path,
-) -> None:
-    allotrope_dict = from_file(test_filepath, VENDOR_TYPE, CHARDET_ENCODING)
-    data_source_ids = []
-    if (
-        "calculated data aggregate document"
-        in allotrope_dict["plate reader aggregate document"]
-    ):
-        data_source_ids = [
-            dsd["data source identifier"]
-            for calc_doc in allotrope_dict["plate reader aggregate document"][
-                "calculated data aggregate document"
-            ]["calculated data document"]
-            for dsd in calc_doc["data source aggregate document"][
-                "data source document"
-            ]
-        ]
-    measurement_ids = [
-        meas_doc["measurement identifier"]
-        for spec_doc in allotrope_dict["plate reader aggregate document"][
-            "plate reader document"
-        ]
-        for meas_doc in spec_doc["measurement aggregate document"][
-            "measurement document"
-        ]
-    ]
-
-    for data_source_id in data_source_ids:
-        assert (
-            data_source_id in measurement_ids
-        ), f"data source identifier {data_source_id} is referenced but is not found in any measurement document"

--- a/tests/parsers/thermo_fisher_nanodrop_eight/to_allotrope_test.py
+++ b/tests/parsers/thermo_fisher_nanodrop_eight/to_allotrope_test.py
@@ -1,10 +1,6 @@
 from pathlib import Path
 
-import pytest
-
 from allotropy.parser_factory import Vendor
-from allotropy.testing.utils import from_file
-from tests.conftest import get_test_cases
 from tests.to_allotrope_test import ParserTest
 
 VENDOR_TYPE = Vendor.THERMO_FISHER_NANODROP_EIGHT
@@ -13,31 +9,3 @@ TESTDATA = Path(Path(__file__).parent, "testdata")
 
 class TestParser(ParserTest):
     VENDOR = Vendor.THERMO_FISHER_NANODROP_EIGHT
-
-
-@pytest.mark.parametrize("test_filepath", get_test_cases(TESTDATA))
-def test_parse_thermo_fisher_nanodrop_eight_data_source_ids(
-    test_filepath: Path,
-) -> None:
-    allotrope_dict = from_file(test_filepath, VENDOR_TYPE)
-    data_source_ids = [
-        dsd["data source identifier"]
-        for calc_doc in allotrope_dict["spectrophotometry aggregate document"][
-            "calculated data aggregate document"
-        ]["calculated data document"]
-        for dsd in calc_doc["data source aggregate document"]["data source document"]
-    ]
-    measurement_ids = [
-        meas_doc["measurement identifier"]
-        for spec_doc in allotrope_dict["spectrophotometry aggregate document"][
-            "spectrophotometry document"
-        ]
-        for meas_doc in spec_doc["measurement aggregate document"][
-            "measurement document"
-        ]
-    ]
-
-    for data_source_id in data_source_ids:
-        assert (
-            data_source_id in measurement_ids
-        ), f"data source identifier {data_source_id} is referenced but is not found in any measurement document"


### PR DESCRIPTION
Add verification that all "data source identifier"s in a document have a valid identifier reference to the general validation that is run on every positive test case

Remove tests that do this for two specific parsers.