### PR TITLE
test: Remove non-ready parsers test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,8 +82,6 @@ it must be included in the README. This can be done automatically via:
 hatch run scripts:update-readme
 ```
 
-If the parser is not in the `RECOMMENDED` state, it must be added to `NON_READY_PARSERS` in `tests/parser_factory_test.py`
-
 # Error messaging
 
 We ask that all error messages thrown in exceptions are written to be clear and useful to developers and end users. As such, please follow these guidelines. `AllotropeConversionError` and helper functions can be found in [`exceptions.py`](src/allotropy/exceptions.py) (and as always, we welcome any additions you may have).

--- a/tests/parser_factory_test.py
+++ b/tests/parser_factory_test.py
@@ -3,25 +3,6 @@ from pathlib import Path
 from allotropy.parser_factory import Vendor
 from allotropy.parsers.release_state import ReleaseState
 
-NON_READY_PARSERS = {
-    # NOTE: example parser will never be marked as ready to use, as it shouldn't be used.
-    Vendor.EXAMPLE_WEYLAND_YUTANI,
-    # We want to collect more test cases for this parser before marking as ready.
-    Vendor.QIACUITY_DPCR,
-    # We want to collect more test cases for this parser before marking as ready.
-    Vendor.MABTECH_APEX,
-    # We want to collect more test cases for this parser before marking as ready.
-    Vendor.THERMO_FISHER_QUBIT4,
-    # parser is under working draft
-    Vendor.THERMO_FISHER_QUBIT_FLEX,
-    # We want to collect more test cases for this parser before marking as ready.
-    Vendor.ROCHE_CEDEX_HIRES,
-    # Parser is under working draft
-    Vendor.BMG_MARS,
-    # Parser is under working draft
-    Vendor.THERMO_FISHER_GENESYS30,
-}
-
 
 def test_vendor_display_name() -> None:
     # All vendors implement display_name
@@ -30,14 +11,6 @@ def test_vendor_display_name() -> None:
 
     # All display names unique
     assert len(Vendor) == len({vendor.display_name for vendor in Vendor})
-
-
-def test_vendor_release_state() -> None:
-    for vendor in Vendor:
-        assert (
-            vendor.release_state == ReleaseState.RECOMMENDED
-            or vendor in NON_READY_PARSERS
-        )
 
 
 def test_get_parser() -> None:


### PR DESCRIPTION
This test doesn't add much value and adds another touchpoint for a new parser.

The idea was to prevent someone from adding a parser and then forgetting to mark it as ready to use.

However, at this time, deciding a parser is ready is largely done by repo owners, who know the drill