### PR TITLE
refactor: Move detection_type to Measurement

### DIFF
--- a/src/allotropy/allotrope/schema_mappers/adm/plate_reader/benchling/_2023/_09/plate_reader.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/plate_reader/benchling/_2023/_09/plate_reader.py
@@ -52,7 +52,6 @@ from allotropy.allotrope.models.shared.definitions.definitions import (
 from allotropy.allotrope.schema_mappers.schema_mapper import SchemaMapper
 from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.exceptions import AllotropyParserError
-from allotropy.parsers.agilent_gen5.constants import ReadMode
 from allotropy.parsers.utils.values import assert_not_none, quantity_or_none
 
 
@@ -109,6 +108,7 @@ class Measurement:
     analyst: str | None = None
     measurement_time: str | None = None
     well_plate_identifier: str | None = None
+    detection_type: str | None = None
 
     # Measurements
     absorbance: JsonFloat | None = None
@@ -169,7 +169,6 @@ class Metadata:
     device_type: str
     model_number: str
     software_name: str | None = None
-    detection_type: str | None = None
     unc_path: str | None = None
     software_version: str | None = None
     equipment_serial_number: str | None = None
@@ -277,7 +276,7 @@ class Mapper(SchemaMapper[Data, Model]):
                 device_control_document=[
                     OpticalImagingDeviceControlDocumentItem(
                         device_type=metadata.device_type,
-                        detection_type=metadata.detection_type,
+                        detection_type=measurement.detection_type,
                         detector_wavelength_setting=quantity_or_none(
                             TQuantityValueNanometer,
                             measurement.detector_wavelength_setting,
@@ -323,7 +322,7 @@ class Mapper(SchemaMapper[Data, Model]):
                 device_control_document=[
                     UltravioletAbsorbancePointDetectionDeviceControlDocumentItem(
                         device_type=metadata.device_type,
-                        detection_type=ReadMode.ABSORBANCE.value,
+                        detection_type=measurement.detection_type,
                         detector_wavelength_setting=TQuantityValueNanometer(
                             value=assert_not_none(  # type: ignore[arg-type]
                                 measurement.detector_wavelength_setting,
@@ -358,7 +357,7 @@ class Mapper(SchemaMapper[Data, Model]):
                 device_control_document=[
                     LuminescencePointDetectionDeviceControlDocumentItem(
                         device_type=metadata.device_type,
-                        detection_type=ReadMode.LUMINESCENCE.value,
+                        detection_type=measurement.detection_type,
                         detector_wavelength_setting=quantity_or_none(
                             TQuantityValueNanometer,
                             measurement.detector_wavelength_setting,
@@ -394,7 +393,7 @@ class Mapper(SchemaMapper[Data, Model]):
                 device_control_document=[
                     FluorescencePointDetectionDeviceControlDocumentItem(
                         device_type=metadata.device_type,
-                        detection_type=ReadMode.FLUORESCENCE.value,
+                        detection_type=measurement.detection_type,
                         detector_wavelength_setting=quantity_or_none(
                             TQuantityValueNanometer,
                             measurement.detector_wavelength_setting,

--- a/src/allotropy/parsers/agilent_gen5/agilent_gen5_structure.py
+++ b/src/allotropy/parsers/agilent_gen5/agilent_gen5_structure.py
@@ -601,6 +601,7 @@ def _create_measurement(
         or f"{header_data.well_plate_identifier} {well_position}",
         location_identifier=well_position,
         well_plate_identifier=header_data.well_plate_identifier,
+        detection_type=read_data.read_mode.value,
         detector_wavelength_setting=detector_wavelength_setting,
         detector_bandwidth_setting=filter_data.detector_bandwidth_setting
         if filter_data

--- a/src/allotropy/parsers/agilent_gen5_image/agilent_gen5_image_structure.py
+++ b/src/allotropy/parsers/agilent_gen5_image/agilent_gen5_image_structure.py
@@ -316,7 +316,6 @@ def create_results(
 def create_metadata(header_data: HeaderData) -> Metadata:
     return Metadata(
         device_type=DEVICE_TYPE,
-        detection_type=DETECTION_TYPE,
         device_identifier=NOT_APPLICABLE,
         model_number=header_data.model_number or NOT_APPLICABLE,
         equipment_serial_number=header_data.equipment_serial_number,
@@ -342,6 +341,7 @@ def _create_measurement(
         or f"{header_data.well_plate_identifier} {well_position}",
         location_identifier=well_position,
         well_plate_identifier=header_data.well_plate_identifier,
+        detection_type=DETECTION_TYPE,
         detector_wavelength_setting=instrument_settings.detector_wavelength,
         excitation_wavelength_setting=instrument_settings.excitation_wavelength,
         # TODO: this setting won't get reported at the moment since Gen5 only reports it

--- a/src/allotropy/parsers/ctl_immunospot/constants.py
+++ b/src/allotropy/parsers/ctl_immunospot/constants.py
@@ -1,0 +1,4 @@
+DETECTION_TYPE = "optical-imaging"
+SOFTWARE_NAME = "ImmunoSpot"
+PRODUCT_MANUFACTURER = "CTL"
+DEVICE_TYPE = "imager"

--- a/src/allotropy/parsers/ctl_immunospot/ctl_immunospot_structure.py
+++ b/src/allotropy/parsers/ctl_immunospot/ctl_immunospot_structure.py
@@ -15,6 +15,7 @@ from allotropy.allotrope.schema_mappers.adm.plate_reader.benchling._2023._09.pla
 )
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.parsers.constants import NOT_APPLICABLE
+from allotropy.parsers.ctl_immunospot import constants
 from allotropy.parsers.lines_reader import LinesReader
 from allotropy.parsers.utils.uuids import random_uuid_str
 from allotropy.parsers.utils.values import (
@@ -115,7 +116,7 @@ def create_measurement_groups(
                     well_plate_identifier=well_plate_identifier,
                     location_identifier=well_position,
                     sample_identifier=f"{well_plate_identifier}_{well_position}",
-                    detection_type="optical-imaging",
+                    detection_type=constants.DETECTION_TYPE,
                     processed_data=ProcessedData(
                         random_uuid_str(),
                         features=[
@@ -166,7 +167,7 @@ def create_metadata(reader: LinesReader) -> Metadata:
     )
     return Metadata(
         device_identifier=NOT_APPLICABLE,
-        device_type="imager",
+        device_type=constants.DEVICE_TYPE,
         model_number=assert_not_none(
             re.match(r"^(\w+)-(\w+)", analyzer_serial_number),
             msg="Unable to parse analyzer serial number.",
@@ -178,8 +179,8 @@ def create_metadata(reader: LinesReader) -> Metadata:
         ),
         file_name=path.name,
         unc_path=raw_path,
-        product_manufacturer="CTL",
-        software_name="ImmunoSpot",
+        product_manufacturer=constants.PRODUCT_MANUFACTURER,
+        software_name=constants.SOFTWARE_NAME,
         software_version=assert_not_none(
             re.match(r"^ImmunoSpot ([\d\.]+)$", software_info),
             msg="Unable to parse software version",

--- a/src/allotropy/parsers/ctl_immunospot/ctl_immunospot_structure.py
+++ b/src/allotropy/parsers/ctl_immunospot/ctl_immunospot_structure.py
@@ -115,6 +115,7 @@ def create_measurement_groups(
                     well_plate_identifier=well_plate_identifier,
                     location_identifier=well_position,
                     sample_identifier=f"{well_plate_identifier}_{well_position}",
+                    detection_type="optical-imaging",
                     processed_data=ProcessedData(
                         random_uuid_str(),
                         features=[
@@ -166,7 +167,6 @@ def create_metadata(reader: LinesReader) -> Metadata:
     return Metadata(
         device_identifier=NOT_APPLICABLE,
         device_type="imager",
-        detection_type="optical-imaging",
         model_number=assert_not_none(
             re.match(r"^(\w+)-(\w+)", analyzer_serial_number),
             msg="Unable to parse analyzer serial number.",

--- a/src/allotropy/parsers/example_weyland_yutani/constants.py
+++ b/src/allotropy/parsers/example_weyland_yutani/constants.py
@@ -1,4 +1,5 @@
 DEVICE_TYPE = "fluorescence detector"
+DETECTION_TYPE = "Fluorescence"
 PROTOCOL_ID = "Weyland Yutani Example"
 ASSAY_ID = "Example Assay"
 EMPTY_CSV_LINE = r"^,*$"

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_structure.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_structure.py
@@ -108,6 +108,7 @@ def create_measurement_group(
             Measurement(
                 type_=MeasurementType.FLUORESCENCE,
                 identifier=random_uuid_str(),
+                detection_type=constants.DETECTION_TYPE,
                 sample_identifier=f"Plate {plate.number}",
                 location_identifier=f"{result.col}{result.row}",
                 fluorescence=result.value,

--- a/src/allotropy/parsers/mabtech_apex/constants.py
+++ b/src/allotropy/parsers/mabtech_apex/constants.py
@@ -1,6 +1,5 @@
 DETECTION_TYPE = "optical-imaging"
 SOFTWARE_NAME = "Apex"
-PRODUCT_MANUFACTURER = "CTL"
 DEVICE_TYPE = "imager"
 
 IMAGE_FEATURES = [

--- a/src/allotropy/parsers/mabtech_apex/constants.py
+++ b/src/allotropy/parsers/mabtech_apex/constants.py
@@ -1,0 +1,10 @@
+DETECTION_TYPE = "optical-imaging"
+SOFTWARE_NAME = "Apex"
+PRODUCT_MANUFACTURER = "CTL"
+DEVICE_TYPE = "imager"
+
+IMAGE_FEATURES = [
+    "Spot Forming Units (SFU)",
+    "Average Relative Spot Volume (RSV)",
+    "Sum of Spot Volume (RSV)",
+]

--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_structure.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_structure.py
@@ -12,16 +12,11 @@ from allotropy.allotrope.schema_mappers.adm.plate_reader.benchling._2023._09.pla
     ProcessedData,
 )
 from allotropy.parsers.constants import NOT_APPLICABLE
+from allotropy.parsers.mabtech_apex import constants
 from allotropy.parsers.mabtech_apex.mabtech_apex_reader import MabtechApexReader
 from allotropy.parsers.utils.pandas import SeriesData
 from allotropy.parsers.utils.uuids import random_uuid_str
 from allotropy.parsers.utils.values import assert_not_none
-
-IMAGE_FEATURES = [
-    "Spot Forming Units (SFU)",
-    "Average Relative Spot Volume (RSV)",
-    "Sum of Spot Volume (RSV)",
-]
 
 
 def create_metadata(reader: MabtechApexReader, file_name: str) -> Metadata:
@@ -35,8 +30,8 @@ def create_metadata(reader: MabtechApexReader, file_name: str) -> Metadata:
 
     return Metadata(
         device_identifier=NOT_APPLICABLE,
-        device_type="imager",
-        software_name="Apex",
+        device_type=constants.DEVICE_TYPE,
+        software_name=constants.SOFTWARE_NAME,
         unc_path=reader.plate_info.get(str, "Path:"),
         software_version=reader.plate_info.get(str, "Software Version:"),
         model_number=machine_id.group(1),
@@ -57,7 +52,7 @@ def _create_measurement(plate_data: SeriesData) -> Measurement:
         location_identifier=location_id,
         well_plate_identifier=well_plate,
         sample_identifier=f"{well_plate}_{location_id}",
-        detection_type="optical-imaging",
+        detection_type=constants.DETECTION_TYPE,
         exposure_duration_setting=plate_data.get(float, "Exposure"),
         illumination_setting=plate_data.get(float, "Preset Intensity"),
         processed_data=ProcessedData(
@@ -68,7 +63,7 @@ def _create_measurement(plate_data: SeriesData) -> Measurement:
                     feature=feature,
                     result=plate_data.get(float, feature, NaN),
                 )
-                for feature in IMAGE_FEATURES
+                for feature in constants.IMAGE_FEATURES
             ],
         ),
     )

--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_structure.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_structure.py
@@ -36,7 +36,6 @@ def create_metadata(reader: MabtechApexReader, file_name: str) -> Metadata:
     return Metadata(
         device_identifier=NOT_APPLICABLE,
         device_type="imager",
-        detection_type="optical-imaging",
         software_name="Apex",
         unc_path=reader.plate_info.get(str, "Path:"),
         software_version=reader.plate_info.get(str, "Software Version:"),
@@ -58,6 +57,7 @@ def _create_measurement(plate_data: SeriesData) -> Measurement:
         location_identifier=location_id,
         well_plate_identifier=well_plate,
         sample_identifier=f"{well_plate}_{location_id}",
+        detection_type="optical-imaging",
         exposure_duration_setting=plate_data.get(float, "Exposure"),
         illumination_setting=plate_data.get(float, "Preset Intensity"),
         processed_data=ProcessedData(

--- a/src/allotropy/parsers/unchained_labs_lunatic/constants.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/constants.py
@@ -2,6 +2,7 @@ import re
 
 from allotropy.allotrope.models.shared.definitions.units import UNITLESS
 
+DETECTION_TYPE = "Absorbance"
 WAVELENGTH_COLUMNS_RE = re.compile(r"^A\d{3}$")
 NO_WAVELENGTH_COLUMN_ERROR_MSG = (
     "The file is required to include an absorbance measurement column (e.g. A280)"

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
@@ -14,6 +14,7 @@ from allotropy.allotrope.schema_mappers.adm.plate_reader.benchling._2023._09.pla
 from allotropy.exceptions import AllotropeConversionError
 from allotropy.parsers.unchained_labs_lunatic.constants import (
     CALCULATED_DATA_LOOKUP,
+    DETECTION_TYPE,
     INCORRECT_WAVELENGTH_COLUMN_FORMAT_ERROR_MSG,
     NO_DATE_OR_TIME_ERROR_MSG,
     NO_DEVICE_IDENTIFIER_ERROR_MSG,
@@ -47,6 +48,7 @@ def _create_measurement(
     )
     return Measurement(
         type_=MeasurementType.ULTRAVIOLET_ABSORBANCE,
+        detection_type=DETECTION_TYPE,
         identifier=measurement_identifier,
         detector_wavelength_setting=float(wavelength_column[1:]),
         absorbance=well_plate_data.get(float, wavelength_column, NaN),


### PR DESCRIPTION
Because `detection_type` can be different for different measurements in a document, move detection_type to Measurement