### PR TITLE
fix: Fixes to add the multiple read modes to release and removed the multi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `supported_extensions` to Vendor, allowing parsers to specify supported file extensions.
+- Added `supported_extensions` to Vendor, allowing parsers to specify supported file extensions. 
+- Added support for `multiple read modes` in `Agilent Gen5` Adapter
 
 ### Fixed
 
@@ -30,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added requirement doc for ThermoFisher Genesys 30 adapter
 - Added support for xlsx exports in Unchained Lunatic parser
 - Add column special character normalization to pandas util (and so most parsers)
-- Added support for multiple read modes in Agilent Gen5 Adapter
 
 ### Fixed
 

--- a/src/allotropy/parsers/agilent_gen5/constants.py
+++ b/src/allotropy/parsers/agilent_gen5/constants.py
@@ -1,7 +1,6 @@
 from enum import Enum
 
 MULTIPLATE_FILE_ERROR = "Only a single plate per file can be processed at this time. Please refer to Gen5 documentation for how to generate single plate exports from multi-plate experiments"
-MULTIPLE_READ_MODE_ERROR = "Only a single endpoint read per file can be processed at this time. Please refer to the Gen5 documentation for supported exports"
 NO_PLATE_DATA_ERROR = "No plate data found in file."
 DEFAULT_EXPORT_FORMAT_ERROR = "Could not find 'Results' section. This export format cannot be processed at this time - ensure the 'Regroup data in one matrix/table' option is enabled within Gen5"
 UNSUPPORTED_READ_TYPE_ERROR = (


### PR DESCRIPTION
This feature of multiple read modes was not released in the previous version of `Allotropy`. So, moved the feature to unreleased and removed an error message from the constants file from the `Agilent Gen5` Adapter