### PR TITLE
fix: Allow try_int to handle decimal in int value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Allow try_int to handle decimal point in int values (e.g. 1.0)
+
 ### Changed
 
 - Updated Softmax Pro adapter to use the REC/2024/06 plate reader schema

--- a/src/allotropy/parsers/utils/values.py
+++ b/src/allotropy/parsers/utils/values.py
@@ -27,7 +27,7 @@ def try_int(value: str | None, value_name: str) -> int:
         # If the value is expected to be an int, but represented as a float (e.g. 1.0) try casting with float
         # and return if it's a valid int.
         try:
-            float_value = float(str_value)
+            float_value = _try_float(str_value)
             if float_value == int(float_value):
                 return int(float_value)
         except ValueError:

--- a/src/allotropy/parsers/utils/values.py
+++ b/src/allotropy/parsers/utils/values.py
@@ -20,9 +20,18 @@ def str_to_bool(value: str) -> bool:
 
 
 def try_int(value: str | None, value_name: str) -> int:
+    str_value = assert_not_none(value, value_name)
     try:
-        return int(assert_not_none(value, value_name))
+        return int(str_value)
     except ValueError as e:
+        # If the value is expected to be an int, but represented as a float (e.g. 1.0) try casting with float
+        # and return if it's a valid int.
+        try:
+            float_value = float(str_value)
+            if float_value == int(float_value):
+                return int(float_value)
+        except ValueError:
+            pass
         msg = f"Invalid integer string: '{value}'."
         raise AllotropeConversionError(msg) from e
 

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example01.txt
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example01.txt
@@ -35,7 +35,7 @@
 
 [Sample Setup]
 Well	Well Position	Sample Name	Sample Color	Biogroup Name	Biogroup Color	Target Name	Target Color	Task	Reporter	Quencher	Quantity	Comments
-1	A1	1SAMPLE_1.1	"RGB(176,23,31)"			TARGET_1	"RGB(176,23,31)"	UNKNOWN	SYBR	None
+1.0	A1	1SAMPLE_1.1	"RGB(176,23,31)"			TARGET_1	"RGB(176,23,31)"	UNKNOWN	SYBR	None
 2	A2	2SAMPLE_1.2	"RGB(0,0,255)"			TARGET_1	"RGB(176,23,31)"	UNKNOWN	SYBR	None
 3	A3	3SAMPLE_1.3	"RGB(0,139,69)"			TARGET_1	"RGB(176,23,31)"	UNKNOWN	SYBR	None
 4	A4	4SAMPLE_2.1	"RGB(255,127,0)"			TARGET_1	"RGB(176,23,31)"	UNKNOWN	SYBR	None

--- a/tests/parsers/utils/values_test.py
+++ b/tests/parsers/utils/values_test.py
@@ -96,8 +96,15 @@ def _try_int(value: str | None) -> int:
     return try_int(value, "param")
 
 
-def test_try_int() -> None:
-    assert _try_int("1") == 1
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("1", 1),
+        ("1.0", 1),
+    ],
+)
+def test_try_int(value: str, expected: int) -> None:
+    assert _try_int(value) == expected
 
 
 @pytest.mark.parametrize(
@@ -105,6 +112,7 @@ def test_try_int() -> None:
     [
         (None, "Expected non-null value for param."),
         ("a", "Invalid integer string: 'a'."),
+        ("1.5", "Invalid integer string: '1.5'."),
     ],
 )
 def test_try_int_fails(value: str | None, expected_regex: str) -> None:


### PR DESCRIPTION
We saw an error in an input file that specified an int index with a decimal prefix (1.0 instead of 1).

Make try_int handle this case safely, so we can parse this messy data.