### PR TITLE
fix: Update timezone parsing to use dateutil timezones instead of pytz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use dateutil timezone instead of pytz, because pytz is can create incorrect timezones when not localized.
+
 ### Deprecated
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
   "openpyxl >= 3.1.0",
   "pandas >= 2.2.0",
   "python-calamine >= 0.2.3",
-  "pytz",
   "xlrd >= 2.0.0",
   "rfc3339-validator >= 0.1.4",
 ]

--- a/scripts/generate_weyland_yutani.py
+++ b/scripts/generate_weyland_yutani.py
@@ -46,7 +46,7 @@ import random
 import sys
 from typing import Any
 
-import pytz
+from dateutil import tz
 
 CHECKSUM_RANGE = 2**16
 MODEL = "Weyland-Yutani 470"
@@ -165,7 +165,7 @@ def parse_args() -> argparse.Namespace:
         args.serial = SERIAL_NUMBER_RANGE + random.randint(1, SERIAL_NUMBER_RANGE - 1)
 
     if args.exptime is None:
-        args.exptime = datetime.now(tz=pytz.utc).strftime("%Y-%m-%d:%H:%M:%S")
+        args.exptime = datetime.now(tz=tz.UTC).strftime("%Y-%m-%d:%H:%M:%S")
 
     return args
 

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import subprocess
 
 import click
-from pytz import timezone
+from dateutil import timezone
 import semantic_version  # type: ignore
 
 from allotropy.__about__ import __version__

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import subprocess
 
 import click
-from dateutil import timezone
+from dateutil import tz
 import semantic_version  # type: ignore
 
 from allotropy.__about__ import __version__
@@ -45,7 +45,7 @@ def _update_changelog(version: str) -> str:
                         """## [Unreleased]\n\n### Added\n\n### Fixed\n\n### Changed\n\n### Deprecated\n\n### Removed\n\n### Security\n\n"""
                     )
                     f.write(
-                        f"## [{version}] - {datetime.now(timezone('EST')).strftime('%Y-%m-%d')}\n"
+                        f"## [{version}] - {datetime.now(tz.gettz('EST')).strftime('%Y-%m-%d')}\n"
                     )
                     editing = True
                     continue

--- a/src/allotropy/parsers/utils/timestamp_parser.py
+++ b/src/allotropy/parsers/utils/timestamp_parser.py
@@ -7,7 +7,10 @@ from dateutil.zoneinfo import getzoneinfofile_stream, ZoneInfoFile
 from allotropy.exceptions import AllotropeConversionError
 
 TIMEZONE_CODES_MAP = {
-    **{code: tz.gettz(code) for code in ZoneInfoFile(getzoneinfofile_stream()).zones.keys()},
+    **{
+        code: tz.gettz(code)
+        for code in ZoneInfoFile(getzoneinfofile_stream()).zones.keys()
+    },
     # Add daylight savings time codes for USA
     **{
         "EDT": timezone(timedelta(hours=-4), "EDT"),

--- a/src/allotropy/parsers/utils/timestamp_parser.py
+++ b/src/allotropy/parsers/utils/timestamp_parser.py
@@ -1,13 +1,13 @@
 from datetime import timedelta, timezone, tzinfo
 from zoneinfo import ZoneInfo
 
-from dateutil import parser
-import pytz
+from dateutil import parser, tz
+from dateutil.zoneinfo import getzoneinfofile_stream, ZoneInfoFile
 
 from allotropy.exceptions import AllotropeConversionError
 
 TIMEZONE_CODES_MAP = {
-    **{code: pytz.timezone(code) for code in pytz.all_timezones},
+    **{code: tz.gettz(code) for code in ZoneInfoFile(getzoneinfofile_stream()).zones.keys()},
     # Add daylight savings time codes for USA
     **{
         "EDT": timezone(timedelta(hours=-4), "EDT"),

--- a/src/allotropy/parsers/utils/timestamp_parser.py
+++ b/src/allotropy/parsers/utils/timestamp_parser.py
@@ -1,16 +1,12 @@
 from datetime import timedelta, timezone, tzinfo
 from zoneinfo import ZoneInfo
 
-from dateutil import parser, tz
-from dateutil.zoneinfo import getzoneinfofile_stream, ZoneInfoFile
+from dateutil import parser, tz, zoneinfo
 
 from allotropy.exceptions import AllotropeConversionError
 
 TIMEZONE_CODES_MAP = {
-    **{
-        code: tz.gettz(code)
-        for code in ZoneInfoFile(getzoneinfofile_stream()).zones.keys()
-    },
+    **{code: tz.gettz(code) for code in zoneinfo.get_zonefile_instance().zones.keys()},
     # Add daylight savings time codes for USA
     **{
         "EDT": timezone(timedelta(hours=-4), "EDT"),


### PR DESCRIPTION
pytz can create odd timezones if not used correctly (and it's easy to misuse) - use dateutil timezones instead.