### PR TITLE
fix: Fix call to read_excel in 3 parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug where name of contents instead of contents was being passed to reader in Roche Cedex Bioht, Thermo Qubit 4 and flex parsers.
+
 ### Changed
 
 - Use dateutil timezone instead of pytz, because pytz is can create incorrect timezones when not localized.

--- a/src/allotropy/parsers/roche_cedex_hires/roche_cedex_hires_reader.py
+++ b/src/allotropy/parsers/roche_cedex_hires/roche_cedex_hires_reader.py
@@ -23,7 +23,7 @@ class RocheCedexHiResReader:
                 encoding=DEFAULT_ENCODING,
             )
         else:
-            df = read_excel(named_file_contents.contents.name)
+            df = read_excel(named_file_contents.contents)
 
         # Fix typo found in some source files.
         df.columns = df.columns.str.replace("identifer", "identifier", regex=True)

--- a/src/allotropy/parsers/thermo_fisher_qubit4/thermo_fisher_qubit4_reader.py
+++ b/src/allotropy/parsers/thermo_fisher_qubit4/thermo_fisher_qubit4_reader.py
@@ -35,7 +35,7 @@ class ThermoFisherQubit4Reader:
         AllotropeConversionError: If the file format is not supported.
         """
         if named_file_contents.extension == "xlsx":
-            dataframe = read_excel(named_file_contents.contents.name)
+            dataframe = read_excel(named_file_contents.contents)
         else:
             dataframe = read_csv(
                 named_file_contents.contents,

--- a/src/allotropy/parsers/thermo_fisher_qubit_flex/thermo_fisher_qubit_flex_reader.py
+++ b/src/allotropy/parsers/thermo_fisher_qubit_flex/thermo_fisher_qubit_flex_reader.py
@@ -32,4 +32,4 @@ class ThermoFisherQubitFlexReader:
                 encoding=DEFAULT_ENCODING,
             )
         else:
-            return read_excel(named_file_contents.contents.name)
+            return read_excel(named_file_contents.contents)


### PR DESCRIPTION
This bug slipped in because unit tests pass BufferedReader, but this only breaks when we pass a BytesIO

TODO is to fix testing coverage, but this fixes the issue.