### PR TITLE
chore: Fix codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,8 @@
-src/allotropy/parsers	@slopez-b @alejandro-salgado
-tests			@slopez-b @alejandro-salgado
+# Give senior parser developers ownership over everything except allotrope schema code and CODEOWNERS
+*			@slopez-b @alejandro-salgado
+src/allotropy/allotrope
+CODEOWNERS
+# Give ASM experts ownership over docs
 docs			@james-leinas
+# Give Benchling Connect team ownership over all
 *   			@Benchling-Open-Source/benchling-connect


### PR DESCRIPTION
Current CODEOWNERS had an issue in that Alejandro and Sebastian could not approve PRs that changed CHANGELOG (or other root level files)

Instead, give them access to all, and then remove access to specific places (the empty ownership removes all owners, then at the end of the file Benchling Connect is given back access)