### PR TITLE
test: Add pytest flags for overwrite/filtering tests

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -225,6 +225,10 @@ tests against if by:
 1. Calling the parser specified by VENDOR on the file
 2. Comparing the output against expected output, contained in a file with the same name but a `json` extension.
 
+Note: the test runs against every file in the corresponding testdata/ folder by default, but you can use
+`--filter` to select specific cases to run, and `--exclude` to skip cases, and files with "error", "exclude" or "invalid"
+in their names will automatically be skipped.
+
 We can automatically generate the expected output by running `to_allotrope_test.py` without the corresponding
 expected output file:
 
@@ -240,9 +244,9 @@ Once created, the runs of the test in the future will compare the output of the 
 output file.
 
 If we make changes to our parser, we may need to update the results of the test file.
-We can do this by setting `OVERWRITE_ON_FAILURE = True` in the parser and running the test again.
+We can do this by passing `--overwrite` while running the test.
 The test will fail if the contents do not match, but it will then update the contents of the expected
-output file, and will pass on further runs (be sure to remove `OVERWRITE_ON_FAILURE` when done!)
+output file, and will pass on further runs.
 
 More complex parsers may require tests against helper methods, and will probably have many more input-output pairs to check.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,16 @@
 import inspect
 from pathlib import Path
 import re
+from typing import Any
 
 import pytest
+from pytest import FixtureRequest, Parser
 
 # ParserTest will ignore any files with "error",  "exclude", or "invalid" in their path.
 EXCLUDE_KEYWORDS = {"error", "exclude", "invalid"}
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser) -> None:
     parser.addoption(
         "--overwrite",
         action="store_true",
@@ -29,7 +31,7 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
-def overwrite(request) -> bool:
+def overwrite(request: FixtureRequest) -> Any:
     return request.config.getoption("--overwrite")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,23 @@ import pytest
 EXCLUDE_KEYWORDS = {"error", "exclude", "invalid"}
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--overwrite", action="store_true", help="If set, overwrite failing tests with new data."
+    )
+    parser.addoption(
+        "--exclude", action="store", default="", help="Comma separated list of patterns to exclude file paths from to_allotropy_test. If set, any test file matching one of the patterns will be excluded."
+    )
+    parser.addoption(
+        "--filter", action="store", default="", help="Comma separated list of patterns to filter file paths from to_allotropy_test. If set, only tests matching one of the patterns will be included."
+    )
+
+
+@pytest.fixture
+def overwrite(request) -> bool:
+    return request.config.getoption("--overwrite")
+
+
 def _is_valid_testcase(path: Path) -> bool:
     if not path.is_file():
         return False
@@ -27,20 +44,20 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     if "test_file_path" in metafunc.fixturenames and metafunc.cls.VENDOR:
         testdata_dir = Path(Path(inspect.getfile(metafunc.cls)).parent, "testdata")
         paths = get_test_cases(testdata_dir)
-        if metafunc.cls.INCLUDE_FILTER:
+        if metafunc.config.option.filter:
             paths = [
                 path
                 for path in paths
                 if any(
-                    re.search(regex, str(path)) for regex in metafunc.cls.INCLUDE_FILTER
+                    re.search(regex, str(path)) for regex in metafunc.config.option.filter.split(",")
                 )
             ]
-        if metafunc.cls.EXCLUDE_FILTER:
+        if metafunc.config.option.exclude:
             paths = [
                 path
                 for path in paths
                 if not any(
-                    re.search(regex, str(path)) for regex in metafunc.cls.EXCLUDE_FILTER
+                    re.search(regex, str(path)) for regex in metafunc.config.option.exclude.split(",")
                 )
             ]
         ids = [str(path.relative_to(testdata_dir)) for path in paths]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,13 +10,21 @@ EXCLUDE_KEYWORDS = {"error", "exclude", "invalid"}
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--overwrite", action="store_true", help="If set, overwrite failing tests with new data."
+        "--overwrite",
+        action="store_true",
+        help="If set, overwrite failing tests with new data.",
     )
     parser.addoption(
-        "--exclude", action="store", default="", help="Comma separated list of patterns to exclude file paths from to_allotropy_test. If set, any test file matching one of the patterns will be excluded."
+        "--exclude",
+        action="store",
+        default="",
+        help="Comma separated list of patterns to exclude file paths from to_allotropy_test. If set, any test file matching one of the patterns will be excluded.",
     )
     parser.addoption(
-        "--filter", action="store", default="", help="Comma separated list of patterns to filter file paths from to_allotropy_test. If set, only tests matching one of the patterns will be included."
+        "--filter",
+        action="store",
+        default="",
+        help="Comma separated list of patterns to filter file paths from to_allotropy_test. If set, only tests matching one of the patterns will be included.",
     )
 
 
@@ -49,7 +57,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                 path
                 for path in paths
                 if any(
-                    re.search(regex, str(path)) for regex in metafunc.config.option.filter.split(",")
+                    re.search(regex, str(path))
+                    for regex in metafunc.config.option.filter.split(",")
                 )
             ]
         if metafunc.config.option.exclude:
@@ -57,7 +66,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                 path
                 for path in paths
                 if not any(
-                    re.search(regex, str(path)) for regex in metafunc.config.option.exclude.split(",")
+                    re.search(regex, str(path))
+                    for regex in metafunc.config.option.exclude.split(",")
                 )
             ]
         ids = [str(path.relative_to(testdata_dir)) for path in paths]

--- a/tests/to_allotrope_test.py
+++ b/tests/to_allotrope_test.py
@@ -40,20 +40,15 @@ def test_allotrope_model_from_file_not_found() -> None:
 @pytest.mark.long
 class ParserTest:
     VENDOR: Vendor
-    OVERWRITE_ON_FAILURE: bool = False
-    # If set, only files matching regexes in this list will be run.
-    INCLUDE_FILTER: list[str] | None = None
-    # If set, files matching regexes in this list will be excluded.
-    EXCLUDE_FILTER: list[str] | None = None
 
     # test_file_path is automatically populated with all files in testdata folder next to the test file.
-    def test_positive_cases(self, test_file_path: Path) -> None:
+    def test_positive_cases(self, test_file_path: Path, *, overwrite: bool) -> None:
         expected_filepath = test_file_path.with_suffix(".json")
         allotrope_dict = from_file(
             str(test_file_path), self.VENDOR, encoding=CHARDET_ENCODING
         )
         # If expected output does not exist, assume this is a new file and write it.
-        overwrite = self.OVERWRITE_ON_FAILURE or not expected_filepath.exists()
+        overwrite = overwrite or not expected_filepath.exists()
         validate_contents(
             allotrope_dict,
             expected_filepath,


### PR DESCRIPTION
Replace test class variables (OVERWRITE_ON_FAILURE) with pytest flags, so users can now run:

`hatch run test --overwrite` to overwrite failing test cases
`hatch run test --filter <regex>` to filter to specific tests to run
`hatch run test --exclude <regex>` to skip specific tests

The makes it easier to test during development, and removes the change to accidentally commit the old class variables to a test.