### PR TITLE
chore: Pin jsonschema below 4.18.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,11 @@ classifiers = [
 dependencies = [
   "cattrs == 23.1.2",
   "chardet >= 5.2.0",
-  "jsonschema >= 4.3.3",
+  # NOTE: jsonschema 4.18.0 introduces a serious performance regression, seemingly due to use of new
+  # referencing library.
+  # TODO(nstender): investigate removing all refs from schema before use to work around perf issues
+  # while unblocking package upgrades.
+  "jsonschema >= 4.3.3, < 4.18.0",
   "numpy >= 1.25.0",
   "openpyxl >= 3.1.0",
   "pandas >= 2.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "chardet >= 5.2.0",
   # NOTE: jsonschema 4.18.0 introduces a serious performance regression, seemingly due to use of new
   # referencing library.
+  # Filed issue: https://github.com/python-jsonschema/referencing/issues/178
   # TODO(nstender): investigate removing all refs from schema before use to work around perf issues
   # while unblocking package upgrades.
   "jsonschema >= 4.3.3, < 4.18.0",


### PR DESCRIPTION
jsonschema 4.18.0 introduces a serious performance regression, seemingly due to use of new referencing library: https://github.com/python-jsonschema/jsonschema/blob/main/CHANGELOG.rst#v4180

While we wait for resolution, pin package below this change.

Current test timing drops from ~3m (with 12 cores parallelized tests) to ~35 sec

For Softmax pro tests (particularly large schema) single threaded tests drop from ~3m to ~6s