### PR TITLE
fix: Remove leading '0' from well identifiers in Perkin Elmer Envision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add cache decorator to amp score calculated data construction in AppBio Quantstuido
+
+- AppBio Quantstuido - add cache decorator to amp score calculated data construction.
 
 ### Fixed
 
 - Mark "PCR Detection Chemistry" as optional in PCR schema.
+- Perkin Elmer Envision - remove leading '0' from well identifier numbers.
 
 ### Changed
 
@@ -35,8 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Simplify sheets needed to infer presence/absence experiment type inference in Appbio Quantstudio Design and Analysis
-- Allow software name and version to be None in Appbio Quantstudio Design and Analysis 
+- Appbio Quantstudio Design and Analysis - simplify sheets needed to infer presence/absence experiment type inference.
+- Appbio Quantstudio Design and Analysis - allow software name and version to be None.
 
 ## [0.1.53] - 2024-09-17
 

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
@@ -224,8 +224,8 @@ def create_calculated_results(reader: CsvReader) -> list[CalculatedResult]:
         else data_frame
     )
     rows, cols = series.shape
-    series.index = [num_to_chars(i) for i in range(rows)]  # type: ignore[assignment]
-    series.columns = [str(i) for i in range(1, cols + 1)]  # type: ignore[assignment]
+    series.index = pd.Index([num_to_chars(i) for i in range(rows)])
+    series.columns = pd.Index([str(i) for i in range(1, cols + 1)])
 
     return [
         CalculatedResult(
@@ -464,8 +464,8 @@ class PlateMap:
             else data_frame
         )
         rows, cols = series.shape
-        series.index = [num_to_chars(i) for i in range(rows)]  # type: ignore[assignment]
-        series.columns = [str(i) for i in range(1, cols + 1)]  # type: ignore[assignment]
+        series.index = pd.Index([num_to_chars(i) for i in range(rows)])
+        series.columns = pd.Index([str(i) for i in range(1, cols + 1)])
 
         sample_role_type_mapping: dict[str, dict[str, SampleRoleType]] = {}
         for row, row_data in series.replace([np.nan, "''"], None).to_dict().items():

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
@@ -261,7 +261,7 @@ def create_results(reader: CsvReader) -> list[Result]:
     )
     rows, cols = series.shape
     series.index = pd.Index([num_to_chars(i) for i in range(rows)])
-    series.columns = [str(i) for i in range(1, cols + 1)]
+    series.columns = pd.Index([str(i) for i in range(1, cols + 1)])
 
     return [
         Result(

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
@@ -769,7 +769,10 @@ def create_measurement_groups(data: Data) -> list[MeasurementGroup]:
             experimental_data_identifier=data.basic_assay_info.assay_id,
             measurements=well_loc_measurements[well_location],
         )
-        for well_location in sorted(well_loc_measurements.keys(), key=lambda key: (key[0], key[1][0], int(key[1][1:])))
+        for well_location in sorted(
+            well_loc_measurements.keys(),
+            key=lambda key: (key[0], key[1][0], int(key[1][1:])),
+        )
     ]
 
 

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
@@ -23,6 +23,7 @@ from enum import Enum
 from re import search
 
 import numpy as np
+import pandas as pd
 
 from allotropy.allotrope.models.adm.plate_reader.benchling._2023._09.plate_reader import (
     ScanPositionSettingPlateReader,
@@ -224,7 +225,7 @@ def create_calculated_results(reader: CsvReader) -> list[CalculatedResult]:
     )
     rows, cols = series.shape
     series.index = [num_to_chars(i) for i in range(rows)]  # type: ignore[assignment]
-    series.columns = [str(i).zfill(2) for i in range(1, cols + 1)]  # type: ignore[assignment]
+    series.columns = [str(i) for i in range(1, cols + 1)]  # type: ignore[assignment]
 
     return [
         CalculatedResult(
@@ -259,8 +260,8 @@ def create_results(reader: CsvReader) -> list[Result]:
         else data_frame
     )
     rows, cols = series.shape
-    series.index = [num_to_chars(i) for i in range(rows)]  # type: ignore[assignment]
-    series.columns = [str(i).zfill(2) for i in range(1, cols + 1)]  # type: ignore[assignment]
+    series.index = pd.Index([num_to_chars(i) for i in range(rows)])
+    series.columns = [str(i) for i in range(1, cols + 1)]
 
     return [
         Result(
@@ -464,7 +465,7 @@ class PlateMap:
         )
         rows, cols = series.shape
         series.index = [num_to_chars(i) for i in range(rows)]  # type: ignore[assignment]
-        series.columns = [str(i).zfill(2) for i in range(1, cols + 1)]  # type: ignore[assignment]
+        series.columns = [str(i) for i in range(1, cols + 1)]  # type: ignore[assignment]
 
         sample_role_type_mapping: dict[str, dict[str, SampleRoleType]] = {}
         for row, row_data in series.replace([np.nan, "''"], None).to_dict().items():
@@ -768,7 +769,7 @@ def create_measurement_groups(data: Data) -> list[MeasurementGroup]:
             experimental_data_identifier=data.basic_assay_info.assay_id,
             measurements=well_loc_measurements[well_location],
         )
-        for well_location in sorted(well_loc_measurements.keys())
+        for well_location in sorted(well_loc_measurements.keys(), key=lambda key: (key[0], key[1][0], int(key[1][1:])))
     ]
 
 

--- a/tests/parsers/perkin_elmer_envision/perkin_elmer_envision_structure_test.py
+++ b/tests/parsers/perkin_elmer_envision/perkin_elmer_envision_structure_test.py
@@ -98,25 +98,25 @@ def test_create_result() -> None:
         Result(
             uuid="TEST_ID_0",
             col="A",
-            row="01",
+            row="1",
             value=1,
         ),
         Result(
             uuid="TEST_ID_1",
             col="A",
-            row="02",
+            row="2",
             value=2,
         ),
         Result(
             uuid="TEST_ID_2",
             col="B",
-            row="01",
+            row="1",
             value=3,
         ),
         Result(
             uuid="TEST_ID_3",
             col="B",
-            row="02",
+            row="2",
             value=4,
         ),
     ]
@@ -174,19 +174,19 @@ def test_create_plates() -> None:
                     Result(
                         uuid="TEST_ID_0",
                         col="A",
-                        row="01",
+                        row="1",
                         value=6,
                     ),
                     Result(
                         uuid="TEST_ID_1",
                         col="A",
-                        row="03",
+                        row="3",
                         value=7,
                     ),
                     Result(
                         uuid="TEST_ID_2",
                         col="C",
-                        row="02",
+                        row="2",
                         value=8,
                     ),
                 ],
@@ -246,19 +246,19 @@ def test_create_plates_with_calculated_data() -> None:
                     CalculatedResult(
                         uuid="TEST_ID_0",
                         col="A",
-                        row="01",
+                        row="1",
                         value=3,
                     ),
                     CalculatedResult(
                         uuid="TEST_ID_1",
                         col="A",
-                        row="03",
+                        row="3",
                         value=3.5,
                     ),
                     CalculatedResult(
                         uuid="TEST_ID_2",
                         col="C",
-                        row="02",
+                        row="2",
                         value=4,
                     ),
                 ],
@@ -411,19 +411,19 @@ def test_create_plate_maps() -> None:
             plate_n="1",
             group_n="1",
             sample_role_type_mapping={
-                "01": {
+                "1": {
                     "A": SampleRoleType.unknown_sample_role,
                     "C": SampleRoleType.standard_sample_role,
                 },
-                "02": {"B": SampleRoleType.control_sample_role},
-                "03": {"C": SampleRoleType.sample_role},
+                "2": {"B": SampleRoleType.control_sample_role},
+                "3": {"C": SampleRoleType.sample_role},
             },
         ),
         "2": PlateMap(
             plate_n="2",
             group_n="3",
             sample_role_type_mapping={
-                "04": {"A": SampleRoleType.blank_role},
+                "4": {"A": SampleRoleType.blank_role},
             },
         ),
     }

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_absorbance_example01.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_absorbance_example01.json
@@ -29,8 +29,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM A01",
-                                "location identifier": "A01",
+                                "sample identifier": "8/22/2023 10:50:28 AM A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -76,8 +76,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM A02",
-                                "location identifier": "A02",
+                                "sample identifier": "8/22/2023 10:50:28 AM A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -123,8 +123,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM A03",
-                                "location identifier": "A03",
+                                "sample identifier": "8/22/2023 10:50:28 AM A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -170,8 +170,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM A04",
-                                "location identifier": "A04",
+                                "sample identifier": "8/22/2023 10:50:28 AM A4",
+                                "location identifier": "A4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -217,8 +217,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM A05",
-                                "location identifier": "A05",
+                                "sample identifier": "8/22/2023 10:50:28 AM A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -264,8 +264,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM A06",
-                                "location identifier": "A06",
+                                "sample identifier": "8/22/2023 10:50:28 AM A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -311,8 +311,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM A07",
-                                "location identifier": "A07",
+                                "sample identifier": "8/22/2023 10:50:28 AM A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -358,8 +358,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM A08",
-                                "location identifier": "A08",
+                                "sample identifier": "8/22/2023 10:50:28 AM A8",
+                                "location identifier": "A8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -405,8 +405,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM A09",
-                                "location identifier": "A09",
+                                "sample identifier": "8/22/2023 10:50:28 AM A9",
+                                "location identifier": "A9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -1157,8 +1157,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM B01",
-                                "location identifier": "B01",
+                                "sample identifier": "8/22/2023 10:50:28 AM B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -1204,8 +1204,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM B02",
-                                "location identifier": "B02",
+                                "sample identifier": "8/22/2023 10:50:28 AM B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -1251,8 +1251,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM B03",
-                                "location identifier": "B03",
+                                "sample identifier": "8/22/2023 10:50:28 AM B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -1298,8 +1298,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM B04",
-                                "location identifier": "B04",
+                                "sample identifier": "8/22/2023 10:50:28 AM B4",
+                                "location identifier": "B4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -1345,8 +1345,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM B05",
-                                "location identifier": "B05",
+                                "sample identifier": "8/22/2023 10:50:28 AM B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -1392,8 +1392,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM B06",
-                                "location identifier": "B06",
+                                "sample identifier": "8/22/2023 10:50:28 AM B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -1439,8 +1439,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM B07",
-                                "location identifier": "B07",
+                                "sample identifier": "8/22/2023 10:50:28 AM B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -1486,8 +1486,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM B08",
-                                "location identifier": "B08",
+                                "sample identifier": "8/22/2023 10:50:28 AM B8",
+                                "location identifier": "B8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -1533,8 +1533,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM B09",
-                                "location identifier": "B09",
+                                "sample identifier": "8/22/2023 10:50:28 AM B9",
+                                "location identifier": "B9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -2285,8 +2285,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM C01",
-                                "location identifier": "C01",
+                                "sample identifier": "8/22/2023 10:50:28 AM C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -2332,8 +2332,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM C02",
-                                "location identifier": "C02",
+                                "sample identifier": "8/22/2023 10:50:28 AM C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -2379,8 +2379,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM C03",
-                                "location identifier": "C03",
+                                "sample identifier": "8/22/2023 10:50:28 AM C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -2426,8 +2426,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM C04",
-                                "location identifier": "C04",
+                                "sample identifier": "8/22/2023 10:50:28 AM C4",
+                                "location identifier": "C4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -2473,8 +2473,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM C05",
-                                "location identifier": "C05",
+                                "sample identifier": "8/22/2023 10:50:28 AM C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -2520,8 +2520,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM C06",
-                                "location identifier": "C06",
+                                "sample identifier": "8/22/2023 10:50:28 AM C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -2567,8 +2567,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM C07",
-                                "location identifier": "C07",
+                                "sample identifier": "8/22/2023 10:50:28 AM C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -2614,8 +2614,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM C08",
-                                "location identifier": "C08",
+                                "sample identifier": "8/22/2023 10:50:28 AM C8",
+                                "location identifier": "C8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -2661,8 +2661,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM C09",
-                                "location identifier": "C09",
+                                "sample identifier": "8/22/2023 10:50:28 AM C9",
+                                "location identifier": "C9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -3413,8 +3413,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM D01",
-                                "location identifier": "D01",
+                                "sample identifier": "8/22/2023 10:50:28 AM D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -3460,8 +3460,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM D02",
-                                "location identifier": "D02",
+                                "sample identifier": "8/22/2023 10:50:28 AM D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -3507,8 +3507,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM D03",
-                                "location identifier": "D03",
+                                "sample identifier": "8/22/2023 10:50:28 AM D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -3554,8 +3554,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM D04",
-                                "location identifier": "D04",
+                                "sample identifier": "8/22/2023 10:50:28 AM D4",
+                                "location identifier": "D4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -3601,8 +3601,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM D05",
-                                "location identifier": "D05",
+                                "sample identifier": "8/22/2023 10:50:28 AM D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -3648,8 +3648,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM D06",
-                                "location identifier": "D06",
+                                "sample identifier": "8/22/2023 10:50:28 AM D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -3695,8 +3695,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM D07",
-                                "location identifier": "D07",
+                                "sample identifier": "8/22/2023 10:50:28 AM D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -3742,8 +3742,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM D08",
-                                "location identifier": "D08",
+                                "sample identifier": "8/22/2023 10:50:28 AM D8",
+                                "location identifier": "D8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -3789,8 +3789,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM D09",
-                                "location identifier": "D09",
+                                "sample identifier": "8/22/2023 10:50:28 AM D9",
+                                "location identifier": "D9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -4541,8 +4541,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM E01",
-                                "location identifier": "E01",
+                                "sample identifier": "8/22/2023 10:50:28 AM E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -4588,8 +4588,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM E02",
-                                "location identifier": "E02",
+                                "sample identifier": "8/22/2023 10:50:28 AM E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -4635,8 +4635,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM E03",
-                                "location identifier": "E03",
+                                "sample identifier": "8/22/2023 10:50:28 AM E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -4682,8 +4682,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM E04",
-                                "location identifier": "E04",
+                                "sample identifier": "8/22/2023 10:50:28 AM E4",
+                                "location identifier": "E4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -4729,8 +4729,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM E05",
-                                "location identifier": "E05",
+                                "sample identifier": "8/22/2023 10:50:28 AM E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -4776,8 +4776,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM E06",
-                                "location identifier": "E06",
+                                "sample identifier": "8/22/2023 10:50:28 AM E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -4823,8 +4823,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM E07",
-                                "location identifier": "E07",
+                                "sample identifier": "8/22/2023 10:50:28 AM E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -4870,8 +4870,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM E08",
-                                "location identifier": "E08",
+                                "sample identifier": "8/22/2023 10:50:28 AM E8",
+                                "location identifier": "E8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -4917,8 +4917,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM E09",
-                                "location identifier": "E09",
+                                "sample identifier": "8/22/2023 10:50:28 AM E9",
+                                "location identifier": "E9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -5669,8 +5669,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM F01",
-                                "location identifier": "F01",
+                                "sample identifier": "8/22/2023 10:50:28 AM F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -5716,8 +5716,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM F02",
-                                "location identifier": "F02",
+                                "sample identifier": "8/22/2023 10:50:28 AM F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -5763,8 +5763,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM F03",
-                                "location identifier": "F03",
+                                "sample identifier": "8/22/2023 10:50:28 AM F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -5810,8 +5810,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM F04",
-                                "location identifier": "F04",
+                                "sample identifier": "8/22/2023 10:50:28 AM F4",
+                                "location identifier": "F4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -5857,8 +5857,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM F05",
-                                "location identifier": "F05",
+                                "sample identifier": "8/22/2023 10:50:28 AM F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -5904,8 +5904,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM F06",
-                                "location identifier": "F06",
+                                "sample identifier": "8/22/2023 10:50:28 AM F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -5951,8 +5951,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM F07",
-                                "location identifier": "F07",
+                                "sample identifier": "8/22/2023 10:50:28 AM F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -5998,8 +5998,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM F08",
-                                "location identifier": "F08",
+                                "sample identifier": "8/22/2023 10:50:28 AM F8",
+                                "location identifier": "F8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -6045,8 +6045,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM F09",
-                                "location identifier": "F09",
+                                "sample identifier": "8/22/2023 10:50:28 AM F9",
+                                "location identifier": "F9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -6797,8 +6797,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM G01",
-                                "location identifier": "G01",
+                                "sample identifier": "8/22/2023 10:50:28 AM G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -6844,8 +6844,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM G02",
-                                "location identifier": "G02",
+                                "sample identifier": "8/22/2023 10:50:28 AM G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -6891,8 +6891,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM G03",
-                                "location identifier": "G03",
+                                "sample identifier": "8/22/2023 10:50:28 AM G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -6938,8 +6938,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM G04",
-                                "location identifier": "G04",
+                                "sample identifier": "8/22/2023 10:50:28 AM G4",
+                                "location identifier": "G4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -6985,8 +6985,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM G05",
-                                "location identifier": "G05",
+                                "sample identifier": "8/22/2023 10:50:28 AM G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -7032,8 +7032,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM G06",
-                                "location identifier": "G06",
+                                "sample identifier": "8/22/2023 10:50:28 AM G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -7079,8 +7079,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM G07",
-                                "location identifier": "G07",
+                                "sample identifier": "8/22/2023 10:50:28 AM G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -7126,8 +7126,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM G08",
-                                "location identifier": "G08",
+                                "sample identifier": "8/22/2023 10:50:28 AM G8",
+                                "location identifier": "G8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -7173,8 +7173,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM G09",
-                                "location identifier": "G09",
+                                "sample identifier": "8/22/2023 10:50:28 AM G9",
+                                "location identifier": "G9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -7925,8 +7925,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM H01",
-                                "location identifier": "H01",
+                                "sample identifier": "8/22/2023 10:50:28 AM H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -7972,8 +7972,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM H02",
-                                "location identifier": "H02",
+                                "sample identifier": "8/22/2023 10:50:28 AM H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -8019,8 +8019,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM H03",
-                                "location identifier": "H03",
+                                "sample identifier": "8/22/2023 10:50:28 AM H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -8066,8 +8066,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM H04",
-                                "location identifier": "H04",
+                                "sample identifier": "8/22/2023 10:50:28 AM H4",
+                                "location identifier": "H4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -8113,8 +8113,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM H05",
-                                "location identifier": "H05",
+                                "sample identifier": "8/22/2023 10:50:28 AM H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -8160,8 +8160,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM H06",
-                                "location identifier": "H06",
+                                "sample identifier": "8/22/2023 10:50:28 AM H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -8207,8 +8207,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM H07",
-                                "location identifier": "H07",
+                                "sample identifier": "8/22/2023 10:50:28 AM H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -8254,8 +8254,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM H08",
-                                "location identifier": "H08",
+                                "sample identifier": "8/22/2023 10:50:28 AM H8",
+                                "location identifier": "H8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -8301,8 +8301,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM H09",
-                                "location identifier": "H09",
+                                "sample identifier": "8/22/2023 10:50:28 AM H9",
+                                "location identifier": "H9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -9053,8 +9053,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM I01",
-                                "location identifier": "I01",
+                                "sample identifier": "8/22/2023 10:50:28 AM I1",
+                                "location identifier": "I1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -9100,8 +9100,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM I02",
-                                "location identifier": "I02",
+                                "sample identifier": "8/22/2023 10:50:28 AM I2",
+                                "location identifier": "I2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -9147,8 +9147,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM I03",
-                                "location identifier": "I03",
+                                "sample identifier": "8/22/2023 10:50:28 AM I3",
+                                "location identifier": "I3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -9194,8 +9194,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM I04",
-                                "location identifier": "I04",
+                                "sample identifier": "8/22/2023 10:50:28 AM I4",
+                                "location identifier": "I4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -9241,8 +9241,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM I05",
-                                "location identifier": "I05",
+                                "sample identifier": "8/22/2023 10:50:28 AM I5",
+                                "location identifier": "I5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -9288,8 +9288,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM I06",
-                                "location identifier": "I06",
+                                "sample identifier": "8/22/2023 10:50:28 AM I6",
+                                "location identifier": "I6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -9335,8 +9335,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM I07",
-                                "location identifier": "I07",
+                                "sample identifier": "8/22/2023 10:50:28 AM I7",
+                                "location identifier": "I7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -9382,8 +9382,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM I08",
-                                "location identifier": "I08",
+                                "sample identifier": "8/22/2023 10:50:28 AM I8",
+                                "location identifier": "I8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -9429,8 +9429,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM I09",
-                                "location identifier": "I09",
+                                "sample identifier": "8/22/2023 10:50:28 AM I9",
+                                "location identifier": "I9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -10181,8 +10181,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM J01",
-                                "location identifier": "J01",
+                                "sample identifier": "8/22/2023 10:50:28 AM J1",
+                                "location identifier": "J1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -10228,8 +10228,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM J02",
-                                "location identifier": "J02",
+                                "sample identifier": "8/22/2023 10:50:28 AM J2",
+                                "location identifier": "J2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -10275,8 +10275,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM J03",
-                                "location identifier": "J03",
+                                "sample identifier": "8/22/2023 10:50:28 AM J3",
+                                "location identifier": "J3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -10322,8 +10322,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM J04",
-                                "location identifier": "J04",
+                                "sample identifier": "8/22/2023 10:50:28 AM J4",
+                                "location identifier": "J4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -10369,8 +10369,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM J05",
-                                "location identifier": "J05",
+                                "sample identifier": "8/22/2023 10:50:28 AM J5",
+                                "location identifier": "J5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -10416,8 +10416,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM J06",
-                                "location identifier": "J06",
+                                "sample identifier": "8/22/2023 10:50:28 AM J6",
+                                "location identifier": "J6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -10463,8 +10463,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM J07",
-                                "location identifier": "J07",
+                                "sample identifier": "8/22/2023 10:50:28 AM J7",
+                                "location identifier": "J7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -10510,8 +10510,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM J08",
-                                "location identifier": "J08",
+                                "sample identifier": "8/22/2023 10:50:28 AM J8",
+                                "location identifier": "J8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -10557,8 +10557,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM J09",
-                                "location identifier": "J09",
+                                "sample identifier": "8/22/2023 10:50:28 AM J9",
+                                "location identifier": "J9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -11309,8 +11309,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM K01",
-                                "location identifier": "K01",
+                                "sample identifier": "8/22/2023 10:50:28 AM K1",
+                                "location identifier": "K1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -11356,8 +11356,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM K02",
-                                "location identifier": "K02",
+                                "sample identifier": "8/22/2023 10:50:28 AM K2",
+                                "location identifier": "K2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -11403,8 +11403,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM K03",
-                                "location identifier": "K03",
+                                "sample identifier": "8/22/2023 10:50:28 AM K3",
+                                "location identifier": "K3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -11450,8 +11450,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM K04",
-                                "location identifier": "K04",
+                                "sample identifier": "8/22/2023 10:50:28 AM K4",
+                                "location identifier": "K4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -11497,8 +11497,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM K05",
-                                "location identifier": "K05",
+                                "sample identifier": "8/22/2023 10:50:28 AM K5",
+                                "location identifier": "K5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -11544,8 +11544,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM K06",
-                                "location identifier": "K06",
+                                "sample identifier": "8/22/2023 10:50:28 AM K6",
+                                "location identifier": "K6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -11591,8 +11591,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM K07",
-                                "location identifier": "K07",
+                                "sample identifier": "8/22/2023 10:50:28 AM K7",
+                                "location identifier": "K7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -11638,8 +11638,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM K08",
-                                "location identifier": "K08",
+                                "sample identifier": "8/22/2023 10:50:28 AM K8",
+                                "location identifier": "K8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -11685,8 +11685,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM K09",
-                                "location identifier": "K09",
+                                "sample identifier": "8/22/2023 10:50:28 AM K9",
+                                "location identifier": "K9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -12437,8 +12437,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM L01",
-                                "location identifier": "L01",
+                                "sample identifier": "8/22/2023 10:50:28 AM L1",
+                                "location identifier": "L1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -12484,8 +12484,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM L02",
-                                "location identifier": "L02",
+                                "sample identifier": "8/22/2023 10:50:28 AM L2",
+                                "location identifier": "L2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -12531,8 +12531,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM L03",
-                                "location identifier": "L03",
+                                "sample identifier": "8/22/2023 10:50:28 AM L3",
+                                "location identifier": "L3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -12578,8 +12578,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM L04",
-                                "location identifier": "L04",
+                                "sample identifier": "8/22/2023 10:50:28 AM L4",
+                                "location identifier": "L4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -12625,8 +12625,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM L05",
-                                "location identifier": "L05",
+                                "sample identifier": "8/22/2023 10:50:28 AM L5",
+                                "location identifier": "L5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -12672,8 +12672,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM L06",
-                                "location identifier": "L06",
+                                "sample identifier": "8/22/2023 10:50:28 AM L6",
+                                "location identifier": "L6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -12719,8 +12719,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM L07",
-                                "location identifier": "L07",
+                                "sample identifier": "8/22/2023 10:50:28 AM L7",
+                                "location identifier": "L7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -12766,8 +12766,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM L08",
-                                "location identifier": "L08",
+                                "sample identifier": "8/22/2023 10:50:28 AM L8",
+                                "location identifier": "L8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -12813,8 +12813,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM L09",
-                                "location identifier": "L09",
+                                "sample identifier": "8/22/2023 10:50:28 AM L9",
+                                "location identifier": "L9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -13565,8 +13565,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM M01",
-                                "location identifier": "M01",
+                                "sample identifier": "8/22/2023 10:50:28 AM M1",
+                                "location identifier": "M1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -13612,8 +13612,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM M02",
-                                "location identifier": "M02",
+                                "sample identifier": "8/22/2023 10:50:28 AM M2",
+                                "location identifier": "M2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -13659,8 +13659,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM M03",
-                                "location identifier": "M03",
+                                "sample identifier": "8/22/2023 10:50:28 AM M3",
+                                "location identifier": "M3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -13706,8 +13706,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM M04",
-                                "location identifier": "M04",
+                                "sample identifier": "8/22/2023 10:50:28 AM M4",
+                                "location identifier": "M4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -13753,8 +13753,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM M05",
-                                "location identifier": "M05",
+                                "sample identifier": "8/22/2023 10:50:28 AM M5",
+                                "location identifier": "M5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -13800,8 +13800,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM M06",
-                                "location identifier": "M06",
+                                "sample identifier": "8/22/2023 10:50:28 AM M6",
+                                "location identifier": "M6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -13847,8 +13847,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM M07",
-                                "location identifier": "M07",
+                                "sample identifier": "8/22/2023 10:50:28 AM M7",
+                                "location identifier": "M7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -13894,8 +13894,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM M08",
-                                "location identifier": "M08",
+                                "sample identifier": "8/22/2023 10:50:28 AM M8",
+                                "location identifier": "M8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -13941,8 +13941,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM M09",
-                                "location identifier": "M09",
+                                "sample identifier": "8/22/2023 10:50:28 AM M9",
+                                "location identifier": "M9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -14693,8 +14693,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM N01",
-                                "location identifier": "N01",
+                                "sample identifier": "8/22/2023 10:50:28 AM N1",
+                                "location identifier": "N1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -14740,8 +14740,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM N02",
-                                "location identifier": "N02",
+                                "sample identifier": "8/22/2023 10:50:28 AM N2",
+                                "location identifier": "N2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -14787,8 +14787,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM N03",
-                                "location identifier": "N03",
+                                "sample identifier": "8/22/2023 10:50:28 AM N3",
+                                "location identifier": "N3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -14834,8 +14834,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM N04",
-                                "location identifier": "N04",
+                                "sample identifier": "8/22/2023 10:50:28 AM N4",
+                                "location identifier": "N4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -14881,8 +14881,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM N05",
-                                "location identifier": "N05",
+                                "sample identifier": "8/22/2023 10:50:28 AM N5",
+                                "location identifier": "N5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -14928,8 +14928,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM N06",
-                                "location identifier": "N06",
+                                "sample identifier": "8/22/2023 10:50:28 AM N6",
+                                "location identifier": "N6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -14975,8 +14975,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM N07",
-                                "location identifier": "N07",
+                                "sample identifier": "8/22/2023 10:50:28 AM N7",
+                                "location identifier": "N7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -15022,8 +15022,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM N08",
-                                "location identifier": "N08",
+                                "sample identifier": "8/22/2023 10:50:28 AM N8",
+                                "location identifier": "N8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -15069,8 +15069,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM N09",
-                                "location identifier": "N09",
+                                "sample identifier": "8/22/2023 10:50:28 AM N9",
+                                "location identifier": "N9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -15821,8 +15821,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM O01",
-                                "location identifier": "O01",
+                                "sample identifier": "8/22/2023 10:50:28 AM O1",
+                                "location identifier": "O1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -15868,8 +15868,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM O02",
-                                "location identifier": "O02",
+                                "sample identifier": "8/22/2023 10:50:28 AM O2",
+                                "location identifier": "O2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -15915,8 +15915,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM O03",
-                                "location identifier": "O03",
+                                "sample identifier": "8/22/2023 10:50:28 AM O3",
+                                "location identifier": "O3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -15962,8 +15962,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM O04",
-                                "location identifier": "O04",
+                                "sample identifier": "8/22/2023 10:50:28 AM O4",
+                                "location identifier": "O4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -16009,8 +16009,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM O05",
-                                "location identifier": "O05",
+                                "sample identifier": "8/22/2023 10:50:28 AM O5",
+                                "location identifier": "O5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -16056,8 +16056,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM O06",
-                                "location identifier": "O06",
+                                "sample identifier": "8/22/2023 10:50:28 AM O6",
+                                "location identifier": "O6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -16103,8 +16103,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM O07",
-                                "location identifier": "O07",
+                                "sample identifier": "8/22/2023 10:50:28 AM O7",
+                                "location identifier": "O7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -16150,8 +16150,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM O08",
-                                "location identifier": "O08",
+                                "sample identifier": "8/22/2023 10:50:28 AM O8",
+                                "location identifier": "O8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -16197,8 +16197,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM O09",
-                                "location identifier": "O09",
+                                "sample identifier": "8/22/2023 10:50:28 AM O9",
+                                "location identifier": "O9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -16949,8 +16949,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM P01",
-                                "location identifier": "P01",
+                                "sample identifier": "8/22/2023 10:50:28 AM P1",
+                                "location identifier": "P1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -16996,8 +16996,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM P02",
-                                "location identifier": "P02",
+                                "sample identifier": "8/22/2023 10:50:28 AM P2",
+                                "location identifier": "P2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -17043,8 +17043,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM P03",
-                                "location identifier": "P03",
+                                "sample identifier": "8/22/2023 10:50:28 AM P3",
+                                "location identifier": "P3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -17090,8 +17090,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM P04",
-                                "location identifier": "P04",
+                                "sample identifier": "8/22/2023 10:50:28 AM P4",
+                                "location identifier": "P4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -17137,8 +17137,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM P05",
-                                "location identifier": "P05",
+                                "sample identifier": "8/22/2023 10:50:28 AM P5",
+                                "location identifier": "P5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -17184,8 +17184,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM P06",
-                                "location identifier": "P06",
+                                "sample identifier": "8/22/2023 10:50:28 AM P6",
+                                "location identifier": "P6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -17231,8 +17231,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM P07",
-                                "location identifier": "P07",
+                                "sample identifier": "8/22/2023 10:50:28 AM P7",
+                                "location identifier": "P7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -17278,8 +17278,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM P08",
-                                "location identifier": "P08",
+                                "sample identifier": "8/22/2023 10:50:28 AM P8",
+                                "location identifier": "P8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -17325,8 +17325,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:50:28 AM P09",
-                                "location identifier": "P09",
+                                "sample identifier": "8/22/2023 10:50:28 AM P9",
+                                "location identifier": "P9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:50:28 AM"
                             },
@@ -18077,8 +18077,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM A01",
-                                "location identifier": "A01",
+                                "sample identifier": "8/22/2023 10:57:39 AM A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -18124,8 +18124,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM A02",
-                                "location identifier": "A02",
+                                "sample identifier": "8/22/2023 10:57:39 AM A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -18171,8 +18171,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM A03",
-                                "location identifier": "A03",
+                                "sample identifier": "8/22/2023 10:57:39 AM A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -18218,8 +18218,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM A04",
-                                "location identifier": "A04",
+                                "sample identifier": "8/22/2023 10:57:39 AM A4",
+                                "location identifier": "A4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -18265,8 +18265,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM A05",
-                                "location identifier": "A05",
+                                "sample identifier": "8/22/2023 10:57:39 AM A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -18312,8 +18312,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM A06",
-                                "location identifier": "A06",
+                                "sample identifier": "8/22/2023 10:57:39 AM A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -18359,8 +18359,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM A07",
-                                "location identifier": "A07",
+                                "sample identifier": "8/22/2023 10:57:39 AM A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -18406,8 +18406,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM A08",
-                                "location identifier": "A08",
+                                "sample identifier": "8/22/2023 10:57:39 AM A8",
+                                "location identifier": "A8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -18453,8 +18453,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM A09",
-                                "location identifier": "A09",
+                                "sample identifier": "8/22/2023 10:57:39 AM A9",
+                                "location identifier": "A9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -19205,8 +19205,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM B01",
-                                "location identifier": "B01",
+                                "sample identifier": "8/22/2023 10:57:39 AM B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -19252,8 +19252,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM B02",
-                                "location identifier": "B02",
+                                "sample identifier": "8/22/2023 10:57:39 AM B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -19299,8 +19299,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM B03",
-                                "location identifier": "B03",
+                                "sample identifier": "8/22/2023 10:57:39 AM B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -19346,8 +19346,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM B04",
-                                "location identifier": "B04",
+                                "sample identifier": "8/22/2023 10:57:39 AM B4",
+                                "location identifier": "B4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -19393,8 +19393,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM B05",
-                                "location identifier": "B05",
+                                "sample identifier": "8/22/2023 10:57:39 AM B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -19440,8 +19440,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM B06",
-                                "location identifier": "B06",
+                                "sample identifier": "8/22/2023 10:57:39 AM B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -19487,8 +19487,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM B07",
-                                "location identifier": "B07",
+                                "sample identifier": "8/22/2023 10:57:39 AM B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -19534,8 +19534,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM B08",
-                                "location identifier": "B08",
+                                "sample identifier": "8/22/2023 10:57:39 AM B8",
+                                "location identifier": "B8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -19581,8 +19581,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM B09",
-                                "location identifier": "B09",
+                                "sample identifier": "8/22/2023 10:57:39 AM B9",
+                                "location identifier": "B9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -20333,8 +20333,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM C01",
-                                "location identifier": "C01",
+                                "sample identifier": "8/22/2023 10:57:39 AM C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -20380,8 +20380,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM C02",
-                                "location identifier": "C02",
+                                "sample identifier": "8/22/2023 10:57:39 AM C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -20427,8 +20427,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM C03",
-                                "location identifier": "C03",
+                                "sample identifier": "8/22/2023 10:57:39 AM C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -20474,8 +20474,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM C04",
-                                "location identifier": "C04",
+                                "sample identifier": "8/22/2023 10:57:39 AM C4",
+                                "location identifier": "C4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -20521,8 +20521,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM C05",
-                                "location identifier": "C05",
+                                "sample identifier": "8/22/2023 10:57:39 AM C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -20568,8 +20568,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM C06",
-                                "location identifier": "C06",
+                                "sample identifier": "8/22/2023 10:57:39 AM C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -20615,8 +20615,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM C07",
-                                "location identifier": "C07",
+                                "sample identifier": "8/22/2023 10:57:39 AM C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -20662,8 +20662,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM C08",
-                                "location identifier": "C08",
+                                "sample identifier": "8/22/2023 10:57:39 AM C8",
+                                "location identifier": "C8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -20709,8 +20709,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM C09",
-                                "location identifier": "C09",
+                                "sample identifier": "8/22/2023 10:57:39 AM C9",
+                                "location identifier": "C9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -21461,8 +21461,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM D01",
-                                "location identifier": "D01",
+                                "sample identifier": "8/22/2023 10:57:39 AM D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -21508,8 +21508,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM D02",
-                                "location identifier": "D02",
+                                "sample identifier": "8/22/2023 10:57:39 AM D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -21555,8 +21555,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM D03",
-                                "location identifier": "D03",
+                                "sample identifier": "8/22/2023 10:57:39 AM D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -21602,8 +21602,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM D04",
-                                "location identifier": "D04",
+                                "sample identifier": "8/22/2023 10:57:39 AM D4",
+                                "location identifier": "D4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -21649,8 +21649,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM D05",
-                                "location identifier": "D05",
+                                "sample identifier": "8/22/2023 10:57:39 AM D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -21696,8 +21696,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM D06",
-                                "location identifier": "D06",
+                                "sample identifier": "8/22/2023 10:57:39 AM D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -21743,8 +21743,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM D07",
-                                "location identifier": "D07",
+                                "sample identifier": "8/22/2023 10:57:39 AM D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -21790,8 +21790,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM D08",
-                                "location identifier": "D08",
+                                "sample identifier": "8/22/2023 10:57:39 AM D8",
+                                "location identifier": "D8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -21837,8 +21837,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM D09",
-                                "location identifier": "D09",
+                                "sample identifier": "8/22/2023 10:57:39 AM D9",
+                                "location identifier": "D9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -22589,8 +22589,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM E01",
-                                "location identifier": "E01",
+                                "sample identifier": "8/22/2023 10:57:39 AM E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -22636,8 +22636,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM E02",
-                                "location identifier": "E02",
+                                "sample identifier": "8/22/2023 10:57:39 AM E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -22683,8 +22683,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM E03",
-                                "location identifier": "E03",
+                                "sample identifier": "8/22/2023 10:57:39 AM E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -22730,8 +22730,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM E04",
-                                "location identifier": "E04",
+                                "sample identifier": "8/22/2023 10:57:39 AM E4",
+                                "location identifier": "E4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -22777,8 +22777,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM E05",
-                                "location identifier": "E05",
+                                "sample identifier": "8/22/2023 10:57:39 AM E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -22824,8 +22824,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM E06",
-                                "location identifier": "E06",
+                                "sample identifier": "8/22/2023 10:57:39 AM E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -22871,8 +22871,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM E07",
-                                "location identifier": "E07",
+                                "sample identifier": "8/22/2023 10:57:39 AM E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -22918,8 +22918,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM E08",
-                                "location identifier": "E08",
+                                "sample identifier": "8/22/2023 10:57:39 AM E8",
+                                "location identifier": "E8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -22965,8 +22965,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM E09",
-                                "location identifier": "E09",
+                                "sample identifier": "8/22/2023 10:57:39 AM E9",
+                                "location identifier": "E9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -23717,8 +23717,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM F01",
-                                "location identifier": "F01",
+                                "sample identifier": "8/22/2023 10:57:39 AM F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -23764,8 +23764,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM F02",
-                                "location identifier": "F02",
+                                "sample identifier": "8/22/2023 10:57:39 AM F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -23811,8 +23811,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM F03",
-                                "location identifier": "F03",
+                                "sample identifier": "8/22/2023 10:57:39 AM F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -23858,8 +23858,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM F04",
-                                "location identifier": "F04",
+                                "sample identifier": "8/22/2023 10:57:39 AM F4",
+                                "location identifier": "F4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -23905,8 +23905,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM F05",
-                                "location identifier": "F05",
+                                "sample identifier": "8/22/2023 10:57:39 AM F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -23952,8 +23952,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM F06",
-                                "location identifier": "F06",
+                                "sample identifier": "8/22/2023 10:57:39 AM F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -23999,8 +23999,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM F07",
-                                "location identifier": "F07",
+                                "sample identifier": "8/22/2023 10:57:39 AM F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -24046,8 +24046,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM F08",
-                                "location identifier": "F08",
+                                "sample identifier": "8/22/2023 10:57:39 AM F8",
+                                "location identifier": "F8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -24093,8 +24093,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM F09",
-                                "location identifier": "F09",
+                                "sample identifier": "8/22/2023 10:57:39 AM F9",
+                                "location identifier": "F9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -24845,8 +24845,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM G01",
-                                "location identifier": "G01",
+                                "sample identifier": "8/22/2023 10:57:39 AM G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -24892,8 +24892,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM G02",
-                                "location identifier": "G02",
+                                "sample identifier": "8/22/2023 10:57:39 AM G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -24939,8 +24939,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM G03",
-                                "location identifier": "G03",
+                                "sample identifier": "8/22/2023 10:57:39 AM G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -24986,8 +24986,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM G04",
-                                "location identifier": "G04",
+                                "sample identifier": "8/22/2023 10:57:39 AM G4",
+                                "location identifier": "G4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -25033,8 +25033,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM G05",
-                                "location identifier": "G05",
+                                "sample identifier": "8/22/2023 10:57:39 AM G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -25080,8 +25080,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM G06",
-                                "location identifier": "G06",
+                                "sample identifier": "8/22/2023 10:57:39 AM G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -25127,8 +25127,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM G07",
-                                "location identifier": "G07",
+                                "sample identifier": "8/22/2023 10:57:39 AM G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -25174,8 +25174,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM G08",
-                                "location identifier": "G08",
+                                "sample identifier": "8/22/2023 10:57:39 AM G8",
+                                "location identifier": "G8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -25221,8 +25221,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM G09",
-                                "location identifier": "G09",
+                                "sample identifier": "8/22/2023 10:57:39 AM G9",
+                                "location identifier": "G9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -25973,8 +25973,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM H01",
-                                "location identifier": "H01",
+                                "sample identifier": "8/22/2023 10:57:39 AM H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -26020,8 +26020,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM H02",
-                                "location identifier": "H02",
+                                "sample identifier": "8/22/2023 10:57:39 AM H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -26067,8 +26067,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM H03",
-                                "location identifier": "H03",
+                                "sample identifier": "8/22/2023 10:57:39 AM H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -26114,8 +26114,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM H04",
-                                "location identifier": "H04",
+                                "sample identifier": "8/22/2023 10:57:39 AM H4",
+                                "location identifier": "H4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -26161,8 +26161,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM H05",
-                                "location identifier": "H05",
+                                "sample identifier": "8/22/2023 10:57:39 AM H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -26208,8 +26208,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM H06",
-                                "location identifier": "H06",
+                                "sample identifier": "8/22/2023 10:57:39 AM H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -26255,8 +26255,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM H07",
-                                "location identifier": "H07",
+                                "sample identifier": "8/22/2023 10:57:39 AM H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -26302,8 +26302,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM H08",
-                                "location identifier": "H08",
+                                "sample identifier": "8/22/2023 10:57:39 AM H8",
+                                "location identifier": "H8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -26349,8 +26349,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM H09",
-                                "location identifier": "H09",
+                                "sample identifier": "8/22/2023 10:57:39 AM H9",
+                                "location identifier": "H9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -27101,8 +27101,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM I01",
-                                "location identifier": "I01",
+                                "sample identifier": "8/22/2023 10:57:39 AM I1",
+                                "location identifier": "I1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -27148,8 +27148,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM I02",
-                                "location identifier": "I02",
+                                "sample identifier": "8/22/2023 10:57:39 AM I2",
+                                "location identifier": "I2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -27195,8 +27195,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM I03",
-                                "location identifier": "I03",
+                                "sample identifier": "8/22/2023 10:57:39 AM I3",
+                                "location identifier": "I3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -27242,8 +27242,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM I04",
-                                "location identifier": "I04",
+                                "sample identifier": "8/22/2023 10:57:39 AM I4",
+                                "location identifier": "I4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -27289,8 +27289,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM I05",
-                                "location identifier": "I05",
+                                "sample identifier": "8/22/2023 10:57:39 AM I5",
+                                "location identifier": "I5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -27336,8 +27336,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM I06",
-                                "location identifier": "I06",
+                                "sample identifier": "8/22/2023 10:57:39 AM I6",
+                                "location identifier": "I6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -27383,8 +27383,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM I07",
-                                "location identifier": "I07",
+                                "sample identifier": "8/22/2023 10:57:39 AM I7",
+                                "location identifier": "I7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -27430,8 +27430,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM I08",
-                                "location identifier": "I08",
+                                "sample identifier": "8/22/2023 10:57:39 AM I8",
+                                "location identifier": "I8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -27477,8 +27477,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM I09",
-                                "location identifier": "I09",
+                                "sample identifier": "8/22/2023 10:57:39 AM I9",
+                                "location identifier": "I9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -28229,8 +28229,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM J01",
-                                "location identifier": "J01",
+                                "sample identifier": "8/22/2023 10:57:39 AM J1",
+                                "location identifier": "J1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -28276,8 +28276,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM J02",
-                                "location identifier": "J02",
+                                "sample identifier": "8/22/2023 10:57:39 AM J2",
+                                "location identifier": "J2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -28323,8 +28323,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM J03",
-                                "location identifier": "J03",
+                                "sample identifier": "8/22/2023 10:57:39 AM J3",
+                                "location identifier": "J3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -28370,8 +28370,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM J04",
-                                "location identifier": "J04",
+                                "sample identifier": "8/22/2023 10:57:39 AM J4",
+                                "location identifier": "J4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -28417,8 +28417,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM J05",
-                                "location identifier": "J05",
+                                "sample identifier": "8/22/2023 10:57:39 AM J5",
+                                "location identifier": "J5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -28464,8 +28464,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM J06",
-                                "location identifier": "J06",
+                                "sample identifier": "8/22/2023 10:57:39 AM J6",
+                                "location identifier": "J6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -28511,8 +28511,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM J07",
-                                "location identifier": "J07",
+                                "sample identifier": "8/22/2023 10:57:39 AM J7",
+                                "location identifier": "J7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -28558,8 +28558,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM J08",
-                                "location identifier": "J08",
+                                "sample identifier": "8/22/2023 10:57:39 AM J8",
+                                "location identifier": "J8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -28605,8 +28605,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM J09",
-                                "location identifier": "J09",
+                                "sample identifier": "8/22/2023 10:57:39 AM J9",
+                                "location identifier": "J9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -29357,8 +29357,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM K01",
-                                "location identifier": "K01",
+                                "sample identifier": "8/22/2023 10:57:39 AM K1",
+                                "location identifier": "K1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -29404,8 +29404,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM K02",
-                                "location identifier": "K02",
+                                "sample identifier": "8/22/2023 10:57:39 AM K2",
+                                "location identifier": "K2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -29451,8 +29451,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM K03",
-                                "location identifier": "K03",
+                                "sample identifier": "8/22/2023 10:57:39 AM K3",
+                                "location identifier": "K3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -29498,8 +29498,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM K04",
-                                "location identifier": "K04",
+                                "sample identifier": "8/22/2023 10:57:39 AM K4",
+                                "location identifier": "K4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -29545,8 +29545,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM K05",
-                                "location identifier": "K05",
+                                "sample identifier": "8/22/2023 10:57:39 AM K5",
+                                "location identifier": "K5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -29592,8 +29592,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM K06",
-                                "location identifier": "K06",
+                                "sample identifier": "8/22/2023 10:57:39 AM K6",
+                                "location identifier": "K6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -29639,8 +29639,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM K07",
-                                "location identifier": "K07",
+                                "sample identifier": "8/22/2023 10:57:39 AM K7",
+                                "location identifier": "K7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -29686,8 +29686,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM K08",
-                                "location identifier": "K08",
+                                "sample identifier": "8/22/2023 10:57:39 AM K8",
+                                "location identifier": "K8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -29733,8 +29733,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM K09",
-                                "location identifier": "K09",
+                                "sample identifier": "8/22/2023 10:57:39 AM K9",
+                                "location identifier": "K9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -30485,8 +30485,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM L01",
-                                "location identifier": "L01",
+                                "sample identifier": "8/22/2023 10:57:39 AM L1",
+                                "location identifier": "L1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -30532,8 +30532,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM L02",
-                                "location identifier": "L02",
+                                "sample identifier": "8/22/2023 10:57:39 AM L2",
+                                "location identifier": "L2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -30579,8 +30579,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM L03",
-                                "location identifier": "L03",
+                                "sample identifier": "8/22/2023 10:57:39 AM L3",
+                                "location identifier": "L3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -30626,8 +30626,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM L04",
-                                "location identifier": "L04",
+                                "sample identifier": "8/22/2023 10:57:39 AM L4",
+                                "location identifier": "L4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -30673,8 +30673,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM L05",
-                                "location identifier": "L05",
+                                "sample identifier": "8/22/2023 10:57:39 AM L5",
+                                "location identifier": "L5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -30720,8 +30720,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM L06",
-                                "location identifier": "L06",
+                                "sample identifier": "8/22/2023 10:57:39 AM L6",
+                                "location identifier": "L6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -30767,8 +30767,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM L07",
-                                "location identifier": "L07",
+                                "sample identifier": "8/22/2023 10:57:39 AM L7",
+                                "location identifier": "L7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -30814,8 +30814,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM L08",
-                                "location identifier": "L08",
+                                "sample identifier": "8/22/2023 10:57:39 AM L8",
+                                "location identifier": "L8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -30861,8 +30861,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM L09",
-                                "location identifier": "L09",
+                                "sample identifier": "8/22/2023 10:57:39 AM L9",
+                                "location identifier": "L9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -31613,8 +31613,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM M01",
-                                "location identifier": "M01",
+                                "sample identifier": "8/22/2023 10:57:39 AM M1",
+                                "location identifier": "M1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -31660,8 +31660,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM M02",
-                                "location identifier": "M02",
+                                "sample identifier": "8/22/2023 10:57:39 AM M2",
+                                "location identifier": "M2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -31707,8 +31707,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM M03",
-                                "location identifier": "M03",
+                                "sample identifier": "8/22/2023 10:57:39 AM M3",
+                                "location identifier": "M3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -31754,8 +31754,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM M04",
-                                "location identifier": "M04",
+                                "sample identifier": "8/22/2023 10:57:39 AM M4",
+                                "location identifier": "M4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -31801,8 +31801,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM M05",
-                                "location identifier": "M05",
+                                "sample identifier": "8/22/2023 10:57:39 AM M5",
+                                "location identifier": "M5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -31848,8 +31848,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM M06",
-                                "location identifier": "M06",
+                                "sample identifier": "8/22/2023 10:57:39 AM M6",
+                                "location identifier": "M6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -31895,8 +31895,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM M07",
-                                "location identifier": "M07",
+                                "sample identifier": "8/22/2023 10:57:39 AM M7",
+                                "location identifier": "M7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -31942,8 +31942,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM M08",
-                                "location identifier": "M08",
+                                "sample identifier": "8/22/2023 10:57:39 AM M8",
+                                "location identifier": "M8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -31989,8 +31989,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM M09",
-                                "location identifier": "M09",
+                                "sample identifier": "8/22/2023 10:57:39 AM M9",
+                                "location identifier": "M9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -32741,8 +32741,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM N01",
-                                "location identifier": "N01",
+                                "sample identifier": "8/22/2023 10:57:39 AM N1",
+                                "location identifier": "N1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -32788,8 +32788,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM N02",
-                                "location identifier": "N02",
+                                "sample identifier": "8/22/2023 10:57:39 AM N2",
+                                "location identifier": "N2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -32835,8 +32835,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM N03",
-                                "location identifier": "N03",
+                                "sample identifier": "8/22/2023 10:57:39 AM N3",
+                                "location identifier": "N3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -32882,8 +32882,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM N04",
-                                "location identifier": "N04",
+                                "sample identifier": "8/22/2023 10:57:39 AM N4",
+                                "location identifier": "N4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -32929,8 +32929,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM N05",
-                                "location identifier": "N05",
+                                "sample identifier": "8/22/2023 10:57:39 AM N5",
+                                "location identifier": "N5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -32976,8 +32976,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM N06",
-                                "location identifier": "N06",
+                                "sample identifier": "8/22/2023 10:57:39 AM N6",
+                                "location identifier": "N6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -33023,8 +33023,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM N07",
-                                "location identifier": "N07",
+                                "sample identifier": "8/22/2023 10:57:39 AM N7",
+                                "location identifier": "N7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -33070,8 +33070,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM N08",
-                                "location identifier": "N08",
+                                "sample identifier": "8/22/2023 10:57:39 AM N8",
+                                "location identifier": "N8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -33117,8 +33117,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM N09",
-                                "location identifier": "N09",
+                                "sample identifier": "8/22/2023 10:57:39 AM N9",
+                                "location identifier": "N9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -33869,8 +33869,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM O01",
-                                "location identifier": "O01",
+                                "sample identifier": "8/22/2023 10:57:39 AM O1",
+                                "location identifier": "O1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -33916,8 +33916,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM O02",
-                                "location identifier": "O02",
+                                "sample identifier": "8/22/2023 10:57:39 AM O2",
+                                "location identifier": "O2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -33963,8 +33963,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM O03",
-                                "location identifier": "O03",
+                                "sample identifier": "8/22/2023 10:57:39 AM O3",
+                                "location identifier": "O3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -34010,8 +34010,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM O04",
-                                "location identifier": "O04",
+                                "sample identifier": "8/22/2023 10:57:39 AM O4",
+                                "location identifier": "O4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -34057,8 +34057,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM O05",
-                                "location identifier": "O05",
+                                "sample identifier": "8/22/2023 10:57:39 AM O5",
+                                "location identifier": "O5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -34104,8 +34104,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM O06",
-                                "location identifier": "O06",
+                                "sample identifier": "8/22/2023 10:57:39 AM O6",
+                                "location identifier": "O6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -34151,8 +34151,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM O07",
-                                "location identifier": "O07",
+                                "sample identifier": "8/22/2023 10:57:39 AM O7",
+                                "location identifier": "O7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -34198,8 +34198,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM O08",
-                                "location identifier": "O08",
+                                "sample identifier": "8/22/2023 10:57:39 AM O8",
+                                "location identifier": "O8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -34245,8 +34245,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM O09",
-                                "location identifier": "O09",
+                                "sample identifier": "8/22/2023 10:57:39 AM O9",
+                                "location identifier": "O9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -34997,8 +34997,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM P01",
-                                "location identifier": "P01",
+                                "sample identifier": "8/22/2023 10:57:39 AM P1",
+                                "location identifier": "P1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -35044,8 +35044,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM P02",
-                                "location identifier": "P02",
+                                "sample identifier": "8/22/2023 10:57:39 AM P2",
+                                "location identifier": "P2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -35091,8 +35091,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM P03",
-                                "location identifier": "P03",
+                                "sample identifier": "8/22/2023 10:57:39 AM P3",
+                                "location identifier": "P3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -35138,8 +35138,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM P04",
-                                "location identifier": "P04",
+                                "sample identifier": "8/22/2023 10:57:39 AM P4",
+                                "location identifier": "P4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -35185,8 +35185,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM P05",
-                                "location identifier": "P05",
+                                "sample identifier": "8/22/2023 10:57:39 AM P5",
+                                "location identifier": "P5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -35232,8 +35232,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM P06",
-                                "location identifier": "P06",
+                                "sample identifier": "8/22/2023 10:57:39 AM P6",
+                                "location identifier": "P6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -35279,8 +35279,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM P07",
-                                "location identifier": "P07",
+                                "sample identifier": "8/22/2023 10:57:39 AM P7",
+                                "location identifier": "P7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -35326,8 +35326,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM P08",
-                                "location identifier": "P08",
+                                "sample identifier": "8/22/2023 10:57:39 AM P8",
+                                "location identifier": "P8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -35373,8 +35373,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:57:39 AM P09",
-                                "location identifier": "P09",
+                                "sample identifier": "8/22/2023 10:57:39 AM P9",
+                                "location identifier": "P9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:57:39 AM"
                             },
@@ -36109,7 +36109,7 @@
             "software name": "EnVision Workstation",
             "software version": "1.14.3049.1193",
             "ASM converter name": "allotropy_perkinelmer_envision",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.54"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example01.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example01.json
@@ -46,8 +46,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A01",
-                                "location identifier": "A01",
+                                "sample identifier": "Plate 1 A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -96,8 +96,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A01",
-                                "location identifier": "A01",
+                                "sample identifier": "Plate 1 A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -160,8 +160,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A02",
-                                "location identifier": "A02",
+                                "sample identifier": "Plate 1 A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -210,8 +210,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A02",
-                                "location identifier": "A02",
+                                "sample identifier": "Plate 1 A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -274,8 +274,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A03",
-                                "location identifier": "A03",
+                                "sample identifier": "Plate 1 A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -324,8 +324,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A03",
-                                "location identifier": "A03",
+                                "sample identifier": "Plate 1 A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -388,8 +388,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A05",
-                                "location identifier": "A05",
+                                "sample identifier": "Plate 1 A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -438,8 +438,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A05",
-                                "location identifier": "A05",
+                                "sample identifier": "Plate 1 A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -502,8 +502,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A06",
-                                "location identifier": "A06",
+                                "sample identifier": "Plate 1 A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -552,8 +552,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A06",
-                                "location identifier": "A06",
+                                "sample identifier": "Plate 1 A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -616,8 +616,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A07",
-                                "location identifier": "A07",
+                                "sample identifier": "Plate 1 A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -666,8 +666,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A07",
-                                "location identifier": "A07",
+                                "sample identifier": "Plate 1 A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -730,8 +730,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B01",
-                                "location identifier": "B01",
+                                "sample identifier": "Plate 1 B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -780,8 +780,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B01",
-                                "location identifier": "B01",
+                                "sample identifier": "Plate 1 B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -844,8 +844,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B02",
-                                "location identifier": "B02",
+                                "sample identifier": "Plate 1 B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -894,8 +894,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B02",
-                                "location identifier": "B02",
+                                "sample identifier": "Plate 1 B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -958,8 +958,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B03",
-                                "location identifier": "B03",
+                                "sample identifier": "Plate 1 B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1008,8 +1008,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B03",
-                                "location identifier": "B03",
+                                "sample identifier": "Plate 1 B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1072,8 +1072,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B05",
-                                "location identifier": "B05",
+                                "sample identifier": "Plate 1 B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1122,8 +1122,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B05",
-                                "location identifier": "B05",
+                                "sample identifier": "Plate 1 B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1186,8 +1186,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B06",
-                                "location identifier": "B06",
+                                "sample identifier": "Plate 1 B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1236,8 +1236,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B06",
-                                "location identifier": "B06",
+                                "sample identifier": "Plate 1 B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1300,8 +1300,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B07",
-                                "location identifier": "B07",
+                                "sample identifier": "Plate 1 B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1350,8 +1350,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B07",
-                                "location identifier": "B07",
+                                "sample identifier": "Plate 1 B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1414,8 +1414,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C01",
-                                "location identifier": "C01",
+                                "sample identifier": "Plate 1 C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1464,8 +1464,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C01",
-                                "location identifier": "C01",
+                                "sample identifier": "Plate 1 C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1528,8 +1528,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C02",
-                                "location identifier": "C02",
+                                "sample identifier": "Plate 1 C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1578,8 +1578,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C02",
-                                "location identifier": "C02",
+                                "sample identifier": "Plate 1 C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1642,8 +1642,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C03",
-                                "location identifier": "C03",
+                                "sample identifier": "Plate 1 C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1692,8 +1692,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C03",
-                                "location identifier": "C03",
+                                "sample identifier": "Plate 1 C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1756,8 +1756,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C05",
-                                "location identifier": "C05",
+                                "sample identifier": "Plate 1 C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1806,8 +1806,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C05",
-                                "location identifier": "C05",
+                                "sample identifier": "Plate 1 C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1870,8 +1870,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C06",
-                                "location identifier": "C06",
+                                "sample identifier": "Plate 1 C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1920,8 +1920,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C06",
-                                "location identifier": "C06",
+                                "sample identifier": "Plate 1 C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1984,8 +1984,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C07",
-                                "location identifier": "C07",
+                                "sample identifier": "Plate 1 C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2034,8 +2034,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C07",
-                                "location identifier": "C07",
+                                "sample identifier": "Plate 1 C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2098,8 +2098,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D01",
-                                "location identifier": "D01",
+                                "sample identifier": "Plate 1 D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2148,8 +2148,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D01",
-                                "location identifier": "D01",
+                                "sample identifier": "Plate 1 D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2212,8 +2212,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D02",
-                                "location identifier": "D02",
+                                "sample identifier": "Plate 1 D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2262,8 +2262,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D02",
-                                "location identifier": "D02",
+                                "sample identifier": "Plate 1 D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2326,8 +2326,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D03",
-                                "location identifier": "D03",
+                                "sample identifier": "Plate 1 D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2376,8 +2376,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D03",
-                                "location identifier": "D03",
+                                "sample identifier": "Plate 1 D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2440,8 +2440,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D05",
-                                "location identifier": "D05",
+                                "sample identifier": "Plate 1 D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2490,8 +2490,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D05",
-                                "location identifier": "D05",
+                                "sample identifier": "Plate 1 D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2554,8 +2554,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D06",
-                                "location identifier": "D06",
+                                "sample identifier": "Plate 1 D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2604,8 +2604,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D06",
-                                "location identifier": "D06",
+                                "sample identifier": "Plate 1 D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2668,8 +2668,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D07",
-                                "location identifier": "D07",
+                                "sample identifier": "Plate 1 D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2718,8 +2718,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D07",
-                                "location identifier": "D07",
+                                "sample identifier": "Plate 1 D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2782,8 +2782,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 E01",
-                                "location identifier": "E01",
+                                "sample identifier": "Plate 1 E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2832,8 +2832,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 E01",
-                                "location identifier": "E01",
+                                "sample identifier": "Plate 1 E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2896,8 +2896,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 E02",
-                                "location identifier": "E02",
+                                "sample identifier": "Plate 1 E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -2946,8 +2946,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 E02",
-                                "location identifier": "E02",
+                                "sample identifier": "Plate 1 E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3010,8 +3010,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 E03",
-                                "location identifier": "E03",
+                                "sample identifier": "Plate 1 E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3060,8 +3060,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 E03",
-                                "location identifier": "E03",
+                                "sample identifier": "Plate 1 E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3124,8 +3124,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 E05",
-                                "location identifier": "E05",
+                                "sample identifier": "Plate 1 E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3174,8 +3174,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 E05",
-                                "location identifier": "E05",
+                                "sample identifier": "Plate 1 E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3238,8 +3238,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 E06",
-                                "location identifier": "E06",
+                                "sample identifier": "Plate 1 E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3288,8 +3288,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 E06",
-                                "location identifier": "E06",
+                                "sample identifier": "Plate 1 E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3352,8 +3352,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 E07",
-                                "location identifier": "E07",
+                                "sample identifier": "Plate 1 E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3402,8 +3402,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 E07",
-                                "location identifier": "E07",
+                                "sample identifier": "Plate 1 E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3466,8 +3466,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 F01",
-                                "location identifier": "F01",
+                                "sample identifier": "Plate 1 F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3516,8 +3516,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 F01",
-                                "location identifier": "F01",
+                                "sample identifier": "Plate 1 F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3580,8 +3580,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 F02",
-                                "location identifier": "F02",
+                                "sample identifier": "Plate 1 F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3630,8 +3630,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 F02",
-                                "location identifier": "F02",
+                                "sample identifier": "Plate 1 F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3694,8 +3694,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 F03",
-                                "location identifier": "F03",
+                                "sample identifier": "Plate 1 F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3744,8 +3744,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 F03",
-                                "location identifier": "F03",
+                                "sample identifier": "Plate 1 F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3808,8 +3808,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 F05",
-                                "location identifier": "F05",
+                                "sample identifier": "Plate 1 F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3858,8 +3858,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 F05",
-                                "location identifier": "F05",
+                                "sample identifier": "Plate 1 F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3922,8 +3922,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 F06",
-                                "location identifier": "F06",
+                                "sample identifier": "Plate 1 F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -3972,8 +3972,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 F06",
-                                "location identifier": "F06",
+                                "sample identifier": "Plate 1 F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4036,8 +4036,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 F07",
-                                "location identifier": "F07",
+                                "sample identifier": "Plate 1 F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4086,8 +4086,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 F07",
-                                "location identifier": "F07",
+                                "sample identifier": "Plate 1 F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4150,8 +4150,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 G01",
-                                "location identifier": "G01",
+                                "sample identifier": "Plate 1 G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4200,8 +4200,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 G01",
-                                "location identifier": "G01",
+                                "sample identifier": "Plate 1 G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4264,8 +4264,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 G02",
-                                "location identifier": "G02",
+                                "sample identifier": "Plate 1 G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4314,8 +4314,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 G02",
-                                "location identifier": "G02",
+                                "sample identifier": "Plate 1 G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4378,8 +4378,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 G03",
-                                "location identifier": "G03",
+                                "sample identifier": "Plate 1 G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4428,8 +4428,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 G03",
-                                "location identifier": "G03",
+                                "sample identifier": "Plate 1 G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4492,8 +4492,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 G05",
-                                "location identifier": "G05",
+                                "sample identifier": "Plate 1 G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4542,8 +4542,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 G05",
-                                "location identifier": "G05",
+                                "sample identifier": "Plate 1 G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4606,8 +4606,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 G06",
-                                "location identifier": "G06",
+                                "sample identifier": "Plate 1 G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4656,8 +4656,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 G06",
-                                "location identifier": "G06",
+                                "sample identifier": "Plate 1 G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4720,8 +4720,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 G07",
-                                "location identifier": "G07",
+                                "sample identifier": "Plate 1 G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4770,8 +4770,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 G07",
-                                "location identifier": "G07",
+                                "sample identifier": "Plate 1 G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4834,8 +4834,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 H01",
-                                "location identifier": "H01",
+                                "sample identifier": "Plate 1 H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4884,8 +4884,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 H01",
-                                "location identifier": "H01",
+                                "sample identifier": "Plate 1 H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4948,8 +4948,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 H02",
-                                "location identifier": "H02",
+                                "sample identifier": "Plate 1 H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -4998,8 +4998,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 H02",
-                                "location identifier": "H02",
+                                "sample identifier": "Plate 1 H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -5062,8 +5062,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 H03",
-                                "location identifier": "H03",
+                                "sample identifier": "Plate 1 H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -5112,8 +5112,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 H03",
-                                "location identifier": "H03",
+                                "sample identifier": "Plate 1 H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -5176,8 +5176,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 H05",
-                                "location identifier": "H05",
+                                "sample identifier": "Plate 1 H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -5226,8 +5226,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 H05",
-                                "location identifier": "H05",
+                                "sample identifier": "Plate 1 H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -5290,8 +5290,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 H06",
-                                "location identifier": "H06",
+                                "sample identifier": "Plate 1 H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -5340,8 +5340,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 H06",
-                                "location identifier": "H06",
+                                "sample identifier": "Plate 1 H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -5404,8 +5404,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 H07",
-                                "location identifier": "H07",
+                                "sample identifier": "Plate 1 H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -5454,8 +5454,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 H07",
-                                "location identifier": "H07",
+                                "sample identifier": "Plate 1 H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -5485,7 +5485,7 @@
             "software name": "EnVision Workstation",
             "software version": "1.14.3049.1193",
             "ASM converter name": "allotropy_perkinelmer_envision",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.54"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example02.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example02.json
@@ -45,8 +45,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A01",
-                                "location identifier": "A01",
+                                "sample identifier": "Plate 1 A1",
+                                "location identifier": "A1",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -104,8 +104,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A02",
-                                "location identifier": "A02",
+                                "sample identifier": "Plate 1 A2",
+                                "location identifier": "A2",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -163,8 +163,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A03",
-                                "location identifier": "A03",
+                                "sample identifier": "Plate 1 A3",
+                                "location identifier": "A3",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -222,8 +222,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A04",
-                                "location identifier": "A04",
+                                "sample identifier": "Plate 1 A4",
+                                "location identifier": "A4",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -281,8 +281,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A05",
-                                "location identifier": "A05",
+                                "sample identifier": "Plate 1 A5",
+                                "location identifier": "A5",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -340,8 +340,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A06",
-                                "location identifier": "A06",
+                                "sample identifier": "Plate 1 A6",
+                                "location identifier": "A6",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -399,8 +399,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A07",
-                                "location identifier": "A07",
+                                "sample identifier": "Plate 1 A7",
+                                "location identifier": "A7",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -458,8 +458,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 A08",
-                                "location identifier": "A08",
+                                "sample identifier": "Plate 1 A8",
+                                "location identifier": "A8",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -517,8 +517,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B01",
-                                "location identifier": "B01",
+                                "sample identifier": "Plate 1 B1",
+                                "location identifier": "B1",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -576,8 +576,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B02",
-                                "location identifier": "B02",
+                                "sample identifier": "Plate 1 B2",
+                                "location identifier": "B2",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -635,8 +635,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B03",
-                                "location identifier": "B03",
+                                "sample identifier": "Plate 1 B3",
+                                "location identifier": "B3",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -694,8 +694,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B04",
-                                "location identifier": "B04",
+                                "sample identifier": "Plate 1 B4",
+                                "location identifier": "B4",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -753,8 +753,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B05",
-                                "location identifier": "B05",
+                                "sample identifier": "Plate 1 B5",
+                                "location identifier": "B5",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -812,8 +812,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B06",
-                                "location identifier": "B06",
+                                "sample identifier": "Plate 1 B6",
+                                "location identifier": "B6",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -871,8 +871,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B07",
-                                "location identifier": "B07",
+                                "sample identifier": "Plate 1 B7",
+                                "location identifier": "B7",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -930,8 +930,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 B08",
-                                "location identifier": "B08",
+                                "sample identifier": "Plate 1 B8",
+                                "location identifier": "B8",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -989,8 +989,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C01",
-                                "location identifier": "C01",
+                                "sample identifier": "Plate 1 C1",
+                                "location identifier": "C1",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1048,8 +1048,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C02",
-                                "location identifier": "C02",
+                                "sample identifier": "Plate 1 C2",
+                                "location identifier": "C2",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1107,8 +1107,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C03",
-                                "location identifier": "C03",
+                                "sample identifier": "Plate 1 C3",
+                                "location identifier": "C3",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1166,8 +1166,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C04",
-                                "location identifier": "C04",
+                                "sample identifier": "Plate 1 C4",
+                                "location identifier": "C4",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1225,8 +1225,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C05",
-                                "location identifier": "C05",
+                                "sample identifier": "Plate 1 C5",
+                                "location identifier": "C5",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1284,8 +1284,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C06",
-                                "location identifier": "C06",
+                                "sample identifier": "Plate 1 C6",
+                                "location identifier": "C6",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1343,8 +1343,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C07",
-                                "location identifier": "C07",
+                                "sample identifier": "Plate 1 C7",
+                                "location identifier": "C7",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1402,8 +1402,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 C08",
-                                "location identifier": "C08",
+                                "sample identifier": "Plate 1 C8",
+                                "location identifier": "C8",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1461,8 +1461,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D01",
-                                "location identifier": "D01",
+                                "sample identifier": "Plate 1 D1",
+                                "location identifier": "D1",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1520,8 +1520,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D02",
-                                "location identifier": "D02",
+                                "sample identifier": "Plate 1 D2",
+                                "location identifier": "D2",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1579,8 +1579,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D03",
-                                "location identifier": "D03",
+                                "sample identifier": "Plate 1 D3",
+                                "location identifier": "D3",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1638,8 +1638,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D04",
-                                "location identifier": "D04",
+                                "sample identifier": "Plate 1 D4",
+                                "location identifier": "D4",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1697,8 +1697,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D05",
-                                "location identifier": "D05",
+                                "sample identifier": "Plate 1 D5",
+                                "location identifier": "D5",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1756,8 +1756,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D06",
-                                "location identifier": "D06",
+                                "sample identifier": "Plate 1 D6",
+                                "location identifier": "D6",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1815,8 +1815,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D07",
-                                "location identifier": "D07",
+                                "sample identifier": "Plate 1 D7",
+                                "location identifier": "D7",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1874,8 +1874,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 1 D08",
-                                "location identifier": "D08",
+                                "sample identifier": "Plate 1 D8",
+                                "location identifier": "D8",
                                 "sample role type": "standard sample role",
                                 "well plate identifier": "Plate 1"
                             },
@@ -1933,8 +1933,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 A01",
-                                "location identifier": "A01",
+                                "sample identifier": "Plate 2 A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -1992,8 +1992,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 A02",
-                                "location identifier": "A02",
+                                "sample identifier": "Plate 2 A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2051,8 +2051,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 A03",
-                                "location identifier": "A03",
+                                "sample identifier": "Plate 2 A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2110,8 +2110,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 A04",
-                                "location identifier": "A04",
+                                "sample identifier": "Plate 2 A4",
+                                "location identifier": "A4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2169,8 +2169,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 A05",
-                                "location identifier": "A05",
+                                "sample identifier": "Plate 2 A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2228,8 +2228,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 A06",
-                                "location identifier": "A06",
+                                "sample identifier": "Plate 2 A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2287,8 +2287,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 A07",
-                                "location identifier": "A07",
+                                "sample identifier": "Plate 2 A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2346,8 +2346,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 A08",
-                                "location identifier": "A08",
+                                "sample identifier": "Plate 2 A8",
+                                "location identifier": "A8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2405,8 +2405,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 A09",
-                                "location identifier": "A09",
+                                "sample identifier": "Plate 2 A9",
+                                "location identifier": "A9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2641,8 +2641,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 B01",
-                                "location identifier": "B01",
+                                "sample identifier": "Plate 2 B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2700,8 +2700,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 B02",
-                                "location identifier": "B02",
+                                "sample identifier": "Plate 2 B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2759,8 +2759,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 B03",
-                                "location identifier": "B03",
+                                "sample identifier": "Plate 2 B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2818,8 +2818,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 B04",
-                                "location identifier": "B04",
+                                "sample identifier": "Plate 2 B4",
+                                "location identifier": "B4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2877,8 +2877,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 B05",
-                                "location identifier": "B05",
+                                "sample identifier": "Plate 2 B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2936,8 +2936,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 B06",
-                                "location identifier": "B06",
+                                "sample identifier": "Plate 2 B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -2995,8 +2995,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 B07",
-                                "location identifier": "B07",
+                                "sample identifier": "Plate 2 B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -3054,8 +3054,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 B08",
-                                "location identifier": "B08",
+                                "sample identifier": "Plate 2 B8",
+                                "location identifier": "B8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -3113,8 +3113,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 B09",
-                                "location identifier": "B09",
+                                "sample identifier": "Plate 2 B9",
+                                "location identifier": "B9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -3349,8 +3349,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 C01",
-                                "location identifier": "C01",
+                                "sample identifier": "Plate 2 C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -3408,8 +3408,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 C02",
-                                "location identifier": "C02",
+                                "sample identifier": "Plate 2 C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -3467,8 +3467,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 C03",
-                                "location identifier": "C03",
+                                "sample identifier": "Plate 2 C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -3526,8 +3526,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 C04",
-                                "location identifier": "C04",
+                                "sample identifier": "Plate 2 C4",
+                                "location identifier": "C4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -3585,8 +3585,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 C05",
-                                "location identifier": "C05",
+                                "sample identifier": "Plate 2 C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -3644,8 +3644,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 C06",
-                                "location identifier": "C06",
+                                "sample identifier": "Plate 2 C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -3703,8 +3703,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 C07",
-                                "location identifier": "C07",
+                                "sample identifier": "Plate 2 C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -3762,8 +3762,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 C08",
-                                "location identifier": "C08",
+                                "sample identifier": "Plate 2 C8",
+                                "location identifier": "C8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -3821,8 +3821,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 C09",
-                                "location identifier": "C09",
+                                "sample identifier": "Plate 2 C9",
+                                "location identifier": "C9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4057,8 +4057,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 D01",
-                                "location identifier": "D01",
+                                "sample identifier": "Plate 2 D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4116,8 +4116,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 D02",
-                                "location identifier": "D02",
+                                "sample identifier": "Plate 2 D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4175,8 +4175,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 D03",
-                                "location identifier": "D03",
+                                "sample identifier": "Plate 2 D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4234,8 +4234,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 D04",
-                                "location identifier": "D04",
+                                "sample identifier": "Plate 2 D4",
+                                "location identifier": "D4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4293,8 +4293,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 D05",
-                                "location identifier": "D05",
+                                "sample identifier": "Plate 2 D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4352,8 +4352,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 D06",
-                                "location identifier": "D06",
+                                "sample identifier": "Plate 2 D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4411,8 +4411,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 D07",
-                                "location identifier": "D07",
+                                "sample identifier": "Plate 2 D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4470,8 +4470,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 D08",
-                                "location identifier": "D08",
+                                "sample identifier": "Plate 2 D8",
+                                "location identifier": "D8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4529,8 +4529,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 D09",
-                                "location identifier": "D09",
+                                "sample identifier": "Plate 2 D9",
+                                "location identifier": "D9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4765,8 +4765,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 E01",
-                                "location identifier": "E01",
+                                "sample identifier": "Plate 2 E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4824,8 +4824,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 E02",
-                                "location identifier": "E02",
+                                "sample identifier": "Plate 2 E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4883,8 +4883,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 E03",
-                                "location identifier": "E03",
+                                "sample identifier": "Plate 2 E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -4942,8 +4942,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 E04",
-                                "location identifier": "E04",
+                                "sample identifier": "Plate 2 E4",
+                                "location identifier": "E4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5001,8 +5001,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 E05",
-                                "location identifier": "E05",
+                                "sample identifier": "Plate 2 E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5060,8 +5060,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 E06",
-                                "location identifier": "E06",
+                                "sample identifier": "Plate 2 E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5119,8 +5119,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 E07",
-                                "location identifier": "E07",
+                                "sample identifier": "Plate 2 E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5178,8 +5178,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 E08",
-                                "location identifier": "E08",
+                                "sample identifier": "Plate 2 E8",
+                                "location identifier": "E8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5237,8 +5237,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 E09",
-                                "location identifier": "E09",
+                                "sample identifier": "Plate 2 E9",
+                                "location identifier": "E9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5473,8 +5473,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 F01",
-                                "location identifier": "F01",
+                                "sample identifier": "Plate 2 F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5532,8 +5532,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 F02",
-                                "location identifier": "F02",
+                                "sample identifier": "Plate 2 F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5591,8 +5591,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 F03",
-                                "location identifier": "F03",
+                                "sample identifier": "Plate 2 F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5650,8 +5650,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 F04",
-                                "location identifier": "F04",
+                                "sample identifier": "Plate 2 F4",
+                                "location identifier": "F4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5709,8 +5709,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 F05",
-                                "location identifier": "F05",
+                                "sample identifier": "Plate 2 F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5768,8 +5768,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 F06",
-                                "location identifier": "F06",
+                                "sample identifier": "Plate 2 F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5827,8 +5827,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 F07",
-                                "location identifier": "F07",
+                                "sample identifier": "Plate 2 F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5886,8 +5886,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 F08",
-                                "location identifier": "F08",
+                                "sample identifier": "Plate 2 F8",
+                                "location identifier": "F8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -5945,8 +5945,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 F09",
-                                "location identifier": "F09",
+                                "sample identifier": "Plate 2 F9",
+                                "location identifier": "F9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -6181,8 +6181,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 G01",
-                                "location identifier": "G01",
+                                "sample identifier": "Plate 2 G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -6240,8 +6240,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 G02",
-                                "location identifier": "G02",
+                                "sample identifier": "Plate 2 G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -6299,8 +6299,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 G03",
-                                "location identifier": "G03",
+                                "sample identifier": "Plate 2 G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -6358,8 +6358,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 G04",
-                                "location identifier": "G04",
+                                "sample identifier": "Plate 2 G4",
+                                "location identifier": "G4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -6417,8 +6417,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 G05",
-                                "location identifier": "G05",
+                                "sample identifier": "Plate 2 G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -6476,8 +6476,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 G06",
-                                "location identifier": "G06",
+                                "sample identifier": "Plate 2 G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -6535,8 +6535,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 G07",
-                                "location identifier": "G07",
+                                "sample identifier": "Plate 2 G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -6594,8 +6594,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 G08",
-                                "location identifier": "G08",
+                                "sample identifier": "Plate 2 G8",
+                                "location identifier": "G8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -6653,8 +6653,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 G09",
-                                "location identifier": "G09",
+                                "sample identifier": "Plate 2 G9",
+                                "location identifier": "G9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -6889,8 +6889,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 H01",
-                                "location identifier": "H01",
+                                "sample identifier": "Plate 2 H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -6948,8 +6948,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 H02",
-                                "location identifier": "H02",
+                                "sample identifier": "Plate 2 H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -7007,8 +7007,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 H03",
-                                "location identifier": "H03",
+                                "sample identifier": "Plate 2 H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -7066,8 +7066,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 H04",
-                                "location identifier": "H04",
+                                "sample identifier": "Plate 2 H4",
+                                "location identifier": "H4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -7125,8 +7125,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 H05",
-                                "location identifier": "H05",
+                                "sample identifier": "Plate 2 H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -7184,8 +7184,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 H06",
-                                "location identifier": "H06",
+                                "sample identifier": "Plate 2 H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -7243,8 +7243,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 H07",
-                                "location identifier": "H07",
+                                "sample identifier": "Plate 2 H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -7302,8 +7302,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 H08",
-                                "location identifier": "H08",
+                                "sample identifier": "Plate 2 H8",
+                                "location identifier": "H8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -7361,8 +7361,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 2 H09",
-                                "location identifier": "H09",
+                                "sample identifier": "Plate 2 H9",
+                                "location identifier": "H9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 2"
                             },
@@ -7597,8 +7597,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 A01",
-                                "location identifier": "A01",
+                                "sample identifier": "Plate 3 A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -7656,8 +7656,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 A02",
-                                "location identifier": "A02",
+                                "sample identifier": "Plate 3 A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -7715,8 +7715,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 A03",
-                                "location identifier": "A03",
+                                "sample identifier": "Plate 3 A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -7774,8 +7774,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 A04",
-                                "location identifier": "A04",
+                                "sample identifier": "Plate 3 A4",
+                                "location identifier": "A4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -7833,8 +7833,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 A05",
-                                "location identifier": "A05",
+                                "sample identifier": "Plate 3 A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -7892,8 +7892,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 A06",
-                                "location identifier": "A06",
+                                "sample identifier": "Plate 3 A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -7951,8 +7951,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 A07",
-                                "location identifier": "A07",
+                                "sample identifier": "Plate 3 A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -8010,8 +8010,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 A08",
-                                "location identifier": "A08",
+                                "sample identifier": "Plate 3 A8",
+                                "location identifier": "A8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -8069,8 +8069,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 A09",
-                                "location identifier": "A09",
+                                "sample identifier": "Plate 3 A9",
+                                "location identifier": "A9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -8305,8 +8305,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 B01",
-                                "location identifier": "B01",
+                                "sample identifier": "Plate 3 B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -8364,8 +8364,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 B02",
-                                "location identifier": "B02",
+                                "sample identifier": "Plate 3 B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -8423,8 +8423,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 B03",
-                                "location identifier": "B03",
+                                "sample identifier": "Plate 3 B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -8482,8 +8482,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 B04",
-                                "location identifier": "B04",
+                                "sample identifier": "Plate 3 B4",
+                                "location identifier": "B4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -8541,8 +8541,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 B05",
-                                "location identifier": "B05",
+                                "sample identifier": "Plate 3 B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -8600,8 +8600,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 B06",
-                                "location identifier": "B06",
+                                "sample identifier": "Plate 3 B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -8659,8 +8659,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 B07",
-                                "location identifier": "B07",
+                                "sample identifier": "Plate 3 B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -8718,8 +8718,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 B08",
-                                "location identifier": "B08",
+                                "sample identifier": "Plate 3 B8",
+                                "location identifier": "B8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -8777,8 +8777,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 B09",
-                                "location identifier": "B09",
+                                "sample identifier": "Plate 3 B9",
+                                "location identifier": "B9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9013,8 +9013,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 C01",
-                                "location identifier": "C01",
+                                "sample identifier": "Plate 3 C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9072,8 +9072,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 C02",
-                                "location identifier": "C02",
+                                "sample identifier": "Plate 3 C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9131,8 +9131,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 C03",
-                                "location identifier": "C03",
+                                "sample identifier": "Plate 3 C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9190,8 +9190,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 C04",
-                                "location identifier": "C04",
+                                "sample identifier": "Plate 3 C4",
+                                "location identifier": "C4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9249,8 +9249,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 C05",
-                                "location identifier": "C05",
+                                "sample identifier": "Plate 3 C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9308,8 +9308,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 C06",
-                                "location identifier": "C06",
+                                "sample identifier": "Plate 3 C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9367,8 +9367,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 C07",
-                                "location identifier": "C07",
+                                "sample identifier": "Plate 3 C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9426,8 +9426,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 C08",
-                                "location identifier": "C08",
+                                "sample identifier": "Plate 3 C8",
+                                "location identifier": "C8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9485,8 +9485,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 C09",
-                                "location identifier": "C09",
+                                "sample identifier": "Plate 3 C9",
+                                "location identifier": "C9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9721,8 +9721,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 D01",
-                                "location identifier": "D01",
+                                "sample identifier": "Plate 3 D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9780,8 +9780,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 D02",
-                                "location identifier": "D02",
+                                "sample identifier": "Plate 3 D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9839,8 +9839,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 D03",
-                                "location identifier": "D03",
+                                "sample identifier": "Plate 3 D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9898,8 +9898,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 D04",
-                                "location identifier": "D04",
+                                "sample identifier": "Plate 3 D4",
+                                "location identifier": "D4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -9957,8 +9957,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 D05",
-                                "location identifier": "D05",
+                                "sample identifier": "Plate 3 D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10016,8 +10016,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 D06",
-                                "location identifier": "D06",
+                                "sample identifier": "Plate 3 D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10075,8 +10075,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 D07",
-                                "location identifier": "D07",
+                                "sample identifier": "Plate 3 D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10134,8 +10134,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 D08",
-                                "location identifier": "D08",
+                                "sample identifier": "Plate 3 D8",
+                                "location identifier": "D8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10193,8 +10193,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 D09",
-                                "location identifier": "D09",
+                                "sample identifier": "Plate 3 D9",
+                                "location identifier": "D9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10429,8 +10429,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 E01",
-                                "location identifier": "E01",
+                                "sample identifier": "Plate 3 E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10488,8 +10488,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 E02",
-                                "location identifier": "E02",
+                                "sample identifier": "Plate 3 E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10547,8 +10547,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 E03",
-                                "location identifier": "E03",
+                                "sample identifier": "Plate 3 E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10606,8 +10606,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 E04",
-                                "location identifier": "E04",
+                                "sample identifier": "Plate 3 E4",
+                                "location identifier": "E4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10665,8 +10665,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 E05",
-                                "location identifier": "E05",
+                                "sample identifier": "Plate 3 E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10724,8 +10724,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 E06",
-                                "location identifier": "E06",
+                                "sample identifier": "Plate 3 E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10783,8 +10783,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 E07",
-                                "location identifier": "E07",
+                                "sample identifier": "Plate 3 E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10842,8 +10842,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 E08",
-                                "location identifier": "E08",
+                                "sample identifier": "Plate 3 E8",
+                                "location identifier": "E8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -10901,8 +10901,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 E09",
-                                "location identifier": "E09",
+                                "sample identifier": "Plate 3 E9",
+                                "location identifier": "E9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -11137,8 +11137,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 F01",
-                                "location identifier": "F01",
+                                "sample identifier": "Plate 3 F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -11196,8 +11196,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 F02",
-                                "location identifier": "F02",
+                                "sample identifier": "Plate 3 F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -11255,8 +11255,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 F03",
-                                "location identifier": "F03",
+                                "sample identifier": "Plate 3 F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -11314,8 +11314,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 F04",
-                                "location identifier": "F04",
+                                "sample identifier": "Plate 3 F4",
+                                "location identifier": "F4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -11373,8 +11373,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 F05",
-                                "location identifier": "F05",
+                                "sample identifier": "Plate 3 F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -11432,8 +11432,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 F06",
-                                "location identifier": "F06",
+                                "sample identifier": "Plate 3 F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -11491,8 +11491,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 F07",
-                                "location identifier": "F07",
+                                "sample identifier": "Plate 3 F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -11550,8 +11550,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 F08",
-                                "location identifier": "F08",
+                                "sample identifier": "Plate 3 F8",
+                                "location identifier": "F8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -11609,8 +11609,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 F09",
-                                "location identifier": "F09",
+                                "sample identifier": "Plate 3 F9",
+                                "location identifier": "F9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -11845,8 +11845,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 G01",
-                                "location identifier": "G01",
+                                "sample identifier": "Plate 3 G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -11904,8 +11904,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 G02",
-                                "location identifier": "G02",
+                                "sample identifier": "Plate 3 G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -11963,8 +11963,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 G03",
-                                "location identifier": "G03",
+                                "sample identifier": "Plate 3 G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12022,8 +12022,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 G04",
-                                "location identifier": "G04",
+                                "sample identifier": "Plate 3 G4",
+                                "location identifier": "G4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12081,8 +12081,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 G05",
-                                "location identifier": "G05",
+                                "sample identifier": "Plate 3 G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12140,8 +12140,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 G06",
-                                "location identifier": "G06",
+                                "sample identifier": "Plate 3 G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12199,8 +12199,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 G07",
-                                "location identifier": "G07",
+                                "sample identifier": "Plate 3 G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12258,8 +12258,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 G08",
-                                "location identifier": "G08",
+                                "sample identifier": "Plate 3 G8",
+                                "location identifier": "G8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12317,8 +12317,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 G09",
-                                "location identifier": "G09",
+                                "sample identifier": "Plate 3 G9",
+                                "location identifier": "G9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12553,8 +12553,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 H01",
-                                "location identifier": "H01",
+                                "sample identifier": "Plate 3 H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12612,8 +12612,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 H02",
-                                "location identifier": "H02",
+                                "sample identifier": "Plate 3 H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12671,8 +12671,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 H03",
-                                "location identifier": "H03",
+                                "sample identifier": "Plate 3 H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12730,8 +12730,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 H04",
-                                "location identifier": "H04",
+                                "sample identifier": "Plate 3 H4",
+                                "location identifier": "H4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12789,8 +12789,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 H05",
-                                "location identifier": "H05",
+                                "sample identifier": "Plate 3 H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12848,8 +12848,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 H06",
-                                "location identifier": "H06",
+                                "sample identifier": "Plate 3 H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12907,8 +12907,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 H07",
-                                "location identifier": "H07",
+                                "sample identifier": "Plate 3 H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -12966,8 +12966,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 H08",
-                                "location identifier": "H08",
+                                "sample identifier": "Plate 3 H8",
+                                "location identifier": "H8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -13025,8 +13025,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 3 H09",
-                                "location identifier": "H09",
+                                "sample identifier": "Plate 3 H9",
+                                "location identifier": "H9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 3"
                             },
@@ -13261,8 +13261,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 A01",
-                                "location identifier": "A01",
+                                "sample identifier": "Plate 4 A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -13320,8 +13320,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 A02",
-                                "location identifier": "A02",
+                                "sample identifier": "Plate 4 A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -13379,8 +13379,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 A03",
-                                "location identifier": "A03",
+                                "sample identifier": "Plate 4 A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -13438,8 +13438,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 A04",
-                                "location identifier": "A04",
+                                "sample identifier": "Plate 4 A4",
+                                "location identifier": "A4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -13497,8 +13497,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 A05",
-                                "location identifier": "A05",
+                                "sample identifier": "Plate 4 A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -13556,8 +13556,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 A06",
-                                "location identifier": "A06",
+                                "sample identifier": "Plate 4 A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -13615,8 +13615,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 A07",
-                                "location identifier": "A07",
+                                "sample identifier": "Plate 4 A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -13674,8 +13674,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 A08",
-                                "location identifier": "A08",
+                                "sample identifier": "Plate 4 A8",
+                                "location identifier": "A8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -13733,8 +13733,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 A09",
-                                "location identifier": "A09",
+                                "sample identifier": "Plate 4 A9",
+                                "location identifier": "A9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -13969,8 +13969,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 B01",
-                                "location identifier": "B01",
+                                "sample identifier": "Plate 4 B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14028,8 +14028,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 B02",
-                                "location identifier": "B02",
+                                "sample identifier": "Plate 4 B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14087,8 +14087,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 B03",
-                                "location identifier": "B03",
+                                "sample identifier": "Plate 4 B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14146,8 +14146,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 B04",
-                                "location identifier": "B04",
+                                "sample identifier": "Plate 4 B4",
+                                "location identifier": "B4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14205,8 +14205,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 B05",
-                                "location identifier": "B05",
+                                "sample identifier": "Plate 4 B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14264,8 +14264,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 B06",
-                                "location identifier": "B06",
+                                "sample identifier": "Plate 4 B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14323,8 +14323,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 B07",
-                                "location identifier": "B07",
+                                "sample identifier": "Plate 4 B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14382,8 +14382,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 B08",
-                                "location identifier": "B08",
+                                "sample identifier": "Plate 4 B8",
+                                "location identifier": "B8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14441,8 +14441,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 B09",
-                                "location identifier": "B09",
+                                "sample identifier": "Plate 4 B9",
+                                "location identifier": "B9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14677,8 +14677,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 C01",
-                                "location identifier": "C01",
+                                "sample identifier": "Plate 4 C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14736,8 +14736,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 C02",
-                                "location identifier": "C02",
+                                "sample identifier": "Plate 4 C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14795,8 +14795,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 C03",
-                                "location identifier": "C03",
+                                "sample identifier": "Plate 4 C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14854,8 +14854,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 C04",
-                                "location identifier": "C04",
+                                "sample identifier": "Plate 4 C4",
+                                "location identifier": "C4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14913,8 +14913,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 C05",
-                                "location identifier": "C05",
+                                "sample identifier": "Plate 4 C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -14972,8 +14972,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 C06",
-                                "location identifier": "C06",
+                                "sample identifier": "Plate 4 C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -15031,8 +15031,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 C07",
-                                "location identifier": "C07",
+                                "sample identifier": "Plate 4 C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -15090,8 +15090,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 C08",
-                                "location identifier": "C08",
+                                "sample identifier": "Plate 4 C8",
+                                "location identifier": "C8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -15149,8 +15149,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 C09",
-                                "location identifier": "C09",
+                                "sample identifier": "Plate 4 C9",
+                                "location identifier": "C9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -15385,8 +15385,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 D01",
-                                "location identifier": "D01",
+                                "sample identifier": "Plate 4 D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -15444,8 +15444,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 D02",
-                                "location identifier": "D02",
+                                "sample identifier": "Plate 4 D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -15503,8 +15503,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 D03",
-                                "location identifier": "D03",
+                                "sample identifier": "Plate 4 D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -15562,8 +15562,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 D04",
-                                "location identifier": "D04",
+                                "sample identifier": "Plate 4 D4",
+                                "location identifier": "D4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -15621,8 +15621,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 D05",
-                                "location identifier": "D05",
+                                "sample identifier": "Plate 4 D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -15680,8 +15680,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 D06",
-                                "location identifier": "D06",
+                                "sample identifier": "Plate 4 D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -15739,8 +15739,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 D07",
-                                "location identifier": "D07",
+                                "sample identifier": "Plate 4 D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -15798,8 +15798,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 D08",
-                                "location identifier": "D08",
+                                "sample identifier": "Plate 4 D8",
+                                "location identifier": "D8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -15857,8 +15857,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 D09",
-                                "location identifier": "D09",
+                                "sample identifier": "Plate 4 D9",
+                                "location identifier": "D9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16093,8 +16093,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 E01",
-                                "location identifier": "E01",
+                                "sample identifier": "Plate 4 E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16152,8 +16152,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 E02",
-                                "location identifier": "E02",
+                                "sample identifier": "Plate 4 E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16211,8 +16211,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 E03",
-                                "location identifier": "E03",
+                                "sample identifier": "Plate 4 E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16270,8 +16270,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 E04",
-                                "location identifier": "E04",
+                                "sample identifier": "Plate 4 E4",
+                                "location identifier": "E4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16329,8 +16329,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 E05",
-                                "location identifier": "E05",
+                                "sample identifier": "Plate 4 E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16388,8 +16388,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 E06",
-                                "location identifier": "E06",
+                                "sample identifier": "Plate 4 E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16447,8 +16447,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 E07",
-                                "location identifier": "E07",
+                                "sample identifier": "Plate 4 E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16506,8 +16506,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 E08",
-                                "location identifier": "E08",
+                                "sample identifier": "Plate 4 E8",
+                                "location identifier": "E8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16565,8 +16565,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 E09",
-                                "location identifier": "E09",
+                                "sample identifier": "Plate 4 E9",
+                                "location identifier": "E9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16801,8 +16801,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 F01",
-                                "location identifier": "F01",
+                                "sample identifier": "Plate 4 F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16860,8 +16860,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 F02",
-                                "location identifier": "F02",
+                                "sample identifier": "Plate 4 F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16919,8 +16919,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 F03",
-                                "location identifier": "F03",
+                                "sample identifier": "Plate 4 F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -16978,8 +16978,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 F04",
-                                "location identifier": "F04",
+                                "sample identifier": "Plate 4 F4",
+                                "location identifier": "F4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17037,8 +17037,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 F05",
-                                "location identifier": "F05",
+                                "sample identifier": "Plate 4 F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17096,8 +17096,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 F06",
-                                "location identifier": "F06",
+                                "sample identifier": "Plate 4 F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17155,8 +17155,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 F07",
-                                "location identifier": "F07",
+                                "sample identifier": "Plate 4 F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17214,8 +17214,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 F08",
-                                "location identifier": "F08",
+                                "sample identifier": "Plate 4 F8",
+                                "location identifier": "F8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17273,8 +17273,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 F09",
-                                "location identifier": "F09",
+                                "sample identifier": "Plate 4 F9",
+                                "location identifier": "F9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17509,8 +17509,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 G01",
-                                "location identifier": "G01",
+                                "sample identifier": "Plate 4 G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17568,8 +17568,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 G02",
-                                "location identifier": "G02",
+                                "sample identifier": "Plate 4 G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17627,8 +17627,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 G03",
-                                "location identifier": "G03",
+                                "sample identifier": "Plate 4 G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17686,8 +17686,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 G04",
-                                "location identifier": "G04",
+                                "sample identifier": "Plate 4 G4",
+                                "location identifier": "G4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17745,8 +17745,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 G05",
-                                "location identifier": "G05",
+                                "sample identifier": "Plate 4 G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17804,8 +17804,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 G06",
-                                "location identifier": "G06",
+                                "sample identifier": "Plate 4 G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17863,8 +17863,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 G07",
-                                "location identifier": "G07",
+                                "sample identifier": "Plate 4 G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17922,8 +17922,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 G08",
-                                "location identifier": "G08",
+                                "sample identifier": "Plate 4 G8",
+                                "location identifier": "G8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -17981,8 +17981,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 G09",
-                                "location identifier": "G09",
+                                "sample identifier": "Plate 4 G9",
+                                "location identifier": "G9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -18217,8 +18217,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 H01",
-                                "location identifier": "H01",
+                                "sample identifier": "Plate 4 H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -18276,8 +18276,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 H02",
-                                "location identifier": "H02",
+                                "sample identifier": "Plate 4 H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -18335,8 +18335,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 H03",
-                                "location identifier": "H03",
+                                "sample identifier": "Plate 4 H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -18394,8 +18394,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 H04",
-                                "location identifier": "H04",
+                                "sample identifier": "Plate 4 H4",
+                                "location identifier": "H4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -18453,8 +18453,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 H05",
-                                "location identifier": "H05",
+                                "sample identifier": "Plate 4 H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -18512,8 +18512,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 H06",
-                                "location identifier": "H06",
+                                "sample identifier": "Plate 4 H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -18571,8 +18571,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 H07",
-                                "location identifier": "H07",
+                                "sample identifier": "Plate 4 H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -18630,8 +18630,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 H08",
-                                "location identifier": "H08",
+                                "sample identifier": "Plate 4 H8",
+                                "location identifier": "H8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -18689,8 +18689,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 4 H09",
-                                "location identifier": "H09",
+                                "sample identifier": "Plate 4 H9",
+                                "location identifier": "H9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 4"
                             },
@@ -18925,8 +18925,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 A01",
-                                "location identifier": "A01",
+                                "sample identifier": "Plate 5 A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -18984,8 +18984,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 A02",
-                                "location identifier": "A02",
+                                "sample identifier": "Plate 5 A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19043,8 +19043,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 A03",
-                                "location identifier": "A03",
+                                "sample identifier": "Plate 5 A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19102,8 +19102,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 A04",
-                                "location identifier": "A04",
+                                "sample identifier": "Plate 5 A4",
+                                "location identifier": "A4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19161,8 +19161,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 A05",
-                                "location identifier": "A05",
+                                "sample identifier": "Plate 5 A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19220,8 +19220,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 A06",
-                                "location identifier": "A06",
+                                "sample identifier": "Plate 5 A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19279,8 +19279,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 A07",
-                                "location identifier": "A07",
+                                "sample identifier": "Plate 5 A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19338,8 +19338,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 A08",
-                                "location identifier": "A08",
+                                "sample identifier": "Plate 5 A8",
+                                "location identifier": "A8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19397,8 +19397,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 A09",
-                                "location identifier": "A09",
+                                "sample identifier": "Plate 5 A9",
+                                "location identifier": "A9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19633,8 +19633,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 B01",
-                                "location identifier": "B01",
+                                "sample identifier": "Plate 5 B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19692,8 +19692,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 B02",
-                                "location identifier": "B02",
+                                "sample identifier": "Plate 5 B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19751,8 +19751,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 B03",
-                                "location identifier": "B03",
+                                "sample identifier": "Plate 5 B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19810,8 +19810,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 B04",
-                                "location identifier": "B04",
+                                "sample identifier": "Plate 5 B4",
+                                "location identifier": "B4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19869,8 +19869,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 B05",
-                                "location identifier": "B05",
+                                "sample identifier": "Plate 5 B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19928,8 +19928,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 B06",
-                                "location identifier": "B06",
+                                "sample identifier": "Plate 5 B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -19987,8 +19987,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 B07",
-                                "location identifier": "B07",
+                                "sample identifier": "Plate 5 B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -20046,8 +20046,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 B08",
-                                "location identifier": "B08",
+                                "sample identifier": "Plate 5 B8",
+                                "location identifier": "B8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -20105,8 +20105,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 B09",
-                                "location identifier": "B09",
+                                "sample identifier": "Plate 5 B9",
+                                "location identifier": "B9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -20341,8 +20341,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 C01",
-                                "location identifier": "C01",
+                                "sample identifier": "Plate 5 C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -20400,8 +20400,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 C02",
-                                "location identifier": "C02",
+                                "sample identifier": "Plate 5 C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -20459,8 +20459,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 C03",
-                                "location identifier": "C03",
+                                "sample identifier": "Plate 5 C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -20518,8 +20518,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 C04",
-                                "location identifier": "C04",
+                                "sample identifier": "Plate 5 C4",
+                                "location identifier": "C4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -20577,8 +20577,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 C05",
-                                "location identifier": "C05",
+                                "sample identifier": "Plate 5 C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -20636,8 +20636,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 C06",
-                                "location identifier": "C06",
+                                "sample identifier": "Plate 5 C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -20695,8 +20695,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 C07",
-                                "location identifier": "C07",
+                                "sample identifier": "Plate 5 C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -20754,8 +20754,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 C08",
-                                "location identifier": "C08",
+                                "sample identifier": "Plate 5 C8",
+                                "location identifier": "C8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -20813,8 +20813,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 C09",
-                                "location identifier": "C09",
+                                "sample identifier": "Plate 5 C9",
+                                "location identifier": "C9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21049,8 +21049,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 D01",
-                                "location identifier": "D01",
+                                "sample identifier": "Plate 5 D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21108,8 +21108,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 D02",
-                                "location identifier": "D02",
+                                "sample identifier": "Plate 5 D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21167,8 +21167,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 D03",
-                                "location identifier": "D03",
+                                "sample identifier": "Plate 5 D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21226,8 +21226,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 D04",
-                                "location identifier": "D04",
+                                "sample identifier": "Plate 5 D4",
+                                "location identifier": "D4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21285,8 +21285,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 D05",
-                                "location identifier": "D05",
+                                "sample identifier": "Plate 5 D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21344,8 +21344,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 D06",
-                                "location identifier": "D06",
+                                "sample identifier": "Plate 5 D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21403,8 +21403,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 D07",
-                                "location identifier": "D07",
+                                "sample identifier": "Plate 5 D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21462,8 +21462,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 D08",
-                                "location identifier": "D08",
+                                "sample identifier": "Plate 5 D8",
+                                "location identifier": "D8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21521,8 +21521,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 D09",
-                                "location identifier": "D09",
+                                "sample identifier": "Plate 5 D9",
+                                "location identifier": "D9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21757,8 +21757,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 E01",
-                                "location identifier": "E01",
+                                "sample identifier": "Plate 5 E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21816,8 +21816,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 E02",
-                                "location identifier": "E02",
+                                "sample identifier": "Plate 5 E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21875,8 +21875,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 E03",
-                                "location identifier": "E03",
+                                "sample identifier": "Plate 5 E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21934,8 +21934,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 E04",
-                                "location identifier": "E04",
+                                "sample identifier": "Plate 5 E4",
+                                "location identifier": "E4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -21993,8 +21993,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 E05",
-                                "location identifier": "E05",
+                                "sample identifier": "Plate 5 E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22052,8 +22052,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 E06",
-                                "location identifier": "E06",
+                                "sample identifier": "Plate 5 E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22111,8 +22111,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 E07",
-                                "location identifier": "E07",
+                                "sample identifier": "Plate 5 E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22170,8 +22170,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 E08",
-                                "location identifier": "E08",
+                                "sample identifier": "Plate 5 E8",
+                                "location identifier": "E8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22229,8 +22229,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 E09",
-                                "location identifier": "E09",
+                                "sample identifier": "Plate 5 E9",
+                                "location identifier": "E9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22465,8 +22465,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 F01",
-                                "location identifier": "F01",
+                                "sample identifier": "Plate 5 F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22524,8 +22524,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 F02",
-                                "location identifier": "F02",
+                                "sample identifier": "Plate 5 F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22583,8 +22583,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 F03",
-                                "location identifier": "F03",
+                                "sample identifier": "Plate 5 F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22642,8 +22642,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 F04",
-                                "location identifier": "F04",
+                                "sample identifier": "Plate 5 F4",
+                                "location identifier": "F4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22701,8 +22701,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 F05",
-                                "location identifier": "F05",
+                                "sample identifier": "Plate 5 F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22760,8 +22760,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 F06",
-                                "location identifier": "F06",
+                                "sample identifier": "Plate 5 F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22819,8 +22819,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 F07",
-                                "location identifier": "F07",
+                                "sample identifier": "Plate 5 F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22878,8 +22878,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 F08",
-                                "location identifier": "F08",
+                                "sample identifier": "Plate 5 F8",
+                                "location identifier": "F8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -22937,8 +22937,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 F09",
-                                "location identifier": "F09",
+                                "sample identifier": "Plate 5 F9",
+                                "location identifier": "F9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -23173,8 +23173,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 G01",
-                                "location identifier": "G01",
+                                "sample identifier": "Plate 5 G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -23232,8 +23232,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 G02",
-                                "location identifier": "G02",
+                                "sample identifier": "Plate 5 G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -23291,8 +23291,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 G03",
-                                "location identifier": "G03",
+                                "sample identifier": "Plate 5 G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -23350,8 +23350,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 G04",
-                                "location identifier": "G04",
+                                "sample identifier": "Plate 5 G4",
+                                "location identifier": "G4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -23409,8 +23409,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 G05",
-                                "location identifier": "G05",
+                                "sample identifier": "Plate 5 G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -23468,8 +23468,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 G06",
-                                "location identifier": "G06",
+                                "sample identifier": "Plate 5 G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -23527,8 +23527,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 G07",
-                                "location identifier": "G07",
+                                "sample identifier": "Plate 5 G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -23586,8 +23586,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 G08",
-                                "location identifier": "G08",
+                                "sample identifier": "Plate 5 G8",
+                                "location identifier": "G8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -23645,8 +23645,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 G09",
-                                "location identifier": "G09",
+                                "sample identifier": "Plate 5 G9",
+                                "location identifier": "G9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -23881,8 +23881,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 H01",
-                                "location identifier": "H01",
+                                "sample identifier": "Plate 5 H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -23940,8 +23940,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 H02",
-                                "location identifier": "H02",
+                                "sample identifier": "Plate 5 H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -23999,8 +23999,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 H03",
-                                "location identifier": "H03",
+                                "sample identifier": "Plate 5 H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -24058,8 +24058,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 H04",
-                                "location identifier": "H04",
+                                "sample identifier": "Plate 5 H4",
+                                "location identifier": "H4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -24117,8 +24117,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 H05",
-                                "location identifier": "H05",
+                                "sample identifier": "Plate 5 H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -24176,8 +24176,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 H06",
-                                "location identifier": "H06",
+                                "sample identifier": "Plate 5 H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -24235,8 +24235,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 H07",
-                                "location identifier": "H07",
+                                "sample identifier": "Plate 5 H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -24294,8 +24294,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 H08",
-                                "location identifier": "H08",
+                                "sample identifier": "Plate 5 H8",
+                                "location identifier": "H8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -24353,8 +24353,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "Plate 5 H09",
-                                "location identifier": "H09",
+                                "sample identifier": "Plate 5 H9",
+                                "location identifier": "H9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "Plate 5"
                             },
@@ -24557,7 +24557,7 @@
             "software name": "EnVision Workstation",
             "software version": "1.13.3009.1409",
             "ASM converter name": "allotropy_perkinelmer_envision",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.54"
         }
     }
 }

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example03.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example03.json
@@ -25,8 +25,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool A01",
-                                "location identifier": "A01",
+                                "sample identifier": "LoP_pool A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -68,8 +68,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool A02",
-                                "location identifier": "A02",
+                                "sample identifier": "LoP_pool A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -111,8 +111,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool A03",
-                                "location identifier": "A03",
+                                "sample identifier": "LoP_pool A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -154,8 +154,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool A04",
-                                "location identifier": "A04",
+                                "sample identifier": "LoP_pool A4",
+                                "location identifier": "A4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -197,8 +197,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool A05",
-                                "location identifier": "A05",
+                                "sample identifier": "LoP_pool A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -240,8 +240,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool A06",
-                                "location identifier": "A06",
+                                "sample identifier": "LoP_pool A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -283,8 +283,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool A07",
-                                "location identifier": "A07",
+                                "sample identifier": "LoP_pool A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -326,8 +326,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool A08",
-                                "location identifier": "A08",
+                                "sample identifier": "LoP_pool A8",
+                                "location identifier": "A8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -369,8 +369,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool A09",
-                                "location identifier": "A09",
+                                "sample identifier": "LoP_pool A9",
+                                "location identifier": "A9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -1057,8 +1057,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool B01",
-                                "location identifier": "B01",
+                                "sample identifier": "LoP_pool B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -1100,8 +1100,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool B02",
-                                "location identifier": "B02",
+                                "sample identifier": "LoP_pool B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -1143,8 +1143,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool B03",
-                                "location identifier": "B03",
+                                "sample identifier": "LoP_pool B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -1186,8 +1186,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool B04",
-                                "location identifier": "B04",
+                                "sample identifier": "LoP_pool B4",
+                                "location identifier": "B4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -1229,8 +1229,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool B05",
-                                "location identifier": "B05",
+                                "sample identifier": "LoP_pool B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -1272,8 +1272,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool B06",
-                                "location identifier": "B06",
+                                "sample identifier": "LoP_pool B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -1315,8 +1315,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool B07",
-                                "location identifier": "B07",
+                                "sample identifier": "LoP_pool B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -1358,8 +1358,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool B08",
-                                "location identifier": "B08",
+                                "sample identifier": "LoP_pool B8",
+                                "location identifier": "B8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -1401,8 +1401,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool B09",
-                                "location identifier": "B09",
+                                "sample identifier": "LoP_pool B9",
+                                "location identifier": "B9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -2089,8 +2089,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool C01",
-                                "location identifier": "C01",
+                                "sample identifier": "LoP_pool C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -2132,8 +2132,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool C02",
-                                "location identifier": "C02",
+                                "sample identifier": "LoP_pool C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -2175,8 +2175,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool C03",
-                                "location identifier": "C03",
+                                "sample identifier": "LoP_pool C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -2218,8 +2218,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool C04",
-                                "location identifier": "C04",
+                                "sample identifier": "LoP_pool C4",
+                                "location identifier": "C4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -2261,8 +2261,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool C05",
-                                "location identifier": "C05",
+                                "sample identifier": "LoP_pool C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -2304,8 +2304,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool C06",
-                                "location identifier": "C06",
+                                "sample identifier": "LoP_pool C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -2347,8 +2347,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool C07",
-                                "location identifier": "C07",
+                                "sample identifier": "LoP_pool C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -2390,8 +2390,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool C08",
-                                "location identifier": "C08",
+                                "sample identifier": "LoP_pool C8",
+                                "location identifier": "C8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -2433,8 +2433,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool C09",
-                                "location identifier": "C09",
+                                "sample identifier": "LoP_pool C9",
+                                "location identifier": "C9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -3121,8 +3121,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool D01",
-                                "location identifier": "D01",
+                                "sample identifier": "LoP_pool D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -3164,8 +3164,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool D02",
-                                "location identifier": "D02",
+                                "sample identifier": "LoP_pool D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -3207,8 +3207,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool D03",
-                                "location identifier": "D03",
+                                "sample identifier": "LoP_pool D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -3250,8 +3250,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool D04",
-                                "location identifier": "D04",
+                                "sample identifier": "LoP_pool D4",
+                                "location identifier": "D4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -3293,8 +3293,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool D05",
-                                "location identifier": "D05",
+                                "sample identifier": "LoP_pool D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -3336,8 +3336,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool D06",
-                                "location identifier": "D06",
+                                "sample identifier": "LoP_pool D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -3379,8 +3379,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool D07",
-                                "location identifier": "D07",
+                                "sample identifier": "LoP_pool D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -3422,8 +3422,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool D08",
-                                "location identifier": "D08",
+                                "sample identifier": "LoP_pool D8",
+                                "location identifier": "D8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -3465,8 +3465,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool D09",
-                                "location identifier": "D09",
+                                "sample identifier": "LoP_pool D9",
+                                "location identifier": "D9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -4153,8 +4153,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool E01",
-                                "location identifier": "E01",
+                                "sample identifier": "LoP_pool E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -4196,8 +4196,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool E02",
-                                "location identifier": "E02",
+                                "sample identifier": "LoP_pool E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -4239,8 +4239,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool E03",
-                                "location identifier": "E03",
+                                "sample identifier": "LoP_pool E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -4282,8 +4282,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool E04",
-                                "location identifier": "E04",
+                                "sample identifier": "LoP_pool E4",
+                                "location identifier": "E4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -4325,8 +4325,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool E05",
-                                "location identifier": "E05",
+                                "sample identifier": "LoP_pool E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -4368,8 +4368,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool E06",
-                                "location identifier": "E06",
+                                "sample identifier": "LoP_pool E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -4411,8 +4411,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool E07",
-                                "location identifier": "E07",
+                                "sample identifier": "LoP_pool E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -4454,8 +4454,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool E08",
-                                "location identifier": "E08",
+                                "sample identifier": "LoP_pool E8",
+                                "location identifier": "E8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -4497,8 +4497,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool E09",
-                                "location identifier": "E09",
+                                "sample identifier": "LoP_pool E9",
+                                "location identifier": "E9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -5185,8 +5185,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool F01",
-                                "location identifier": "F01",
+                                "sample identifier": "LoP_pool F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -5228,8 +5228,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool F02",
-                                "location identifier": "F02",
+                                "sample identifier": "LoP_pool F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -5271,8 +5271,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool F03",
-                                "location identifier": "F03",
+                                "sample identifier": "LoP_pool F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -5314,8 +5314,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool F04",
-                                "location identifier": "F04",
+                                "sample identifier": "LoP_pool F4",
+                                "location identifier": "F4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -5357,8 +5357,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool F05",
-                                "location identifier": "F05",
+                                "sample identifier": "LoP_pool F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -5400,8 +5400,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool F06",
-                                "location identifier": "F06",
+                                "sample identifier": "LoP_pool F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -5443,8 +5443,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool F07",
-                                "location identifier": "F07",
+                                "sample identifier": "LoP_pool F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -5486,8 +5486,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool F08",
-                                "location identifier": "F08",
+                                "sample identifier": "LoP_pool F8",
+                                "location identifier": "F8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -5529,8 +5529,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool F09",
-                                "location identifier": "F09",
+                                "sample identifier": "LoP_pool F9",
+                                "location identifier": "F9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -6217,8 +6217,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool G01",
-                                "location identifier": "G01",
+                                "sample identifier": "LoP_pool G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -6260,8 +6260,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool G02",
-                                "location identifier": "G02",
+                                "sample identifier": "LoP_pool G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -6303,8 +6303,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool G03",
-                                "location identifier": "G03",
+                                "sample identifier": "LoP_pool G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -6346,8 +6346,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool G04",
-                                "location identifier": "G04",
+                                "sample identifier": "LoP_pool G4",
+                                "location identifier": "G4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -6389,8 +6389,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool G05",
-                                "location identifier": "G05",
+                                "sample identifier": "LoP_pool G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -6432,8 +6432,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool G06",
-                                "location identifier": "G06",
+                                "sample identifier": "LoP_pool G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -6475,8 +6475,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool G07",
-                                "location identifier": "G07",
+                                "sample identifier": "LoP_pool G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -6518,8 +6518,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool G08",
-                                "location identifier": "G08",
+                                "sample identifier": "LoP_pool G8",
+                                "location identifier": "G8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -6561,8 +6561,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool G09",
-                                "location identifier": "G09",
+                                "sample identifier": "LoP_pool G9",
+                                "location identifier": "G9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -7249,8 +7249,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool H01",
-                                "location identifier": "H01",
+                                "sample identifier": "LoP_pool H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -7292,8 +7292,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool H02",
-                                "location identifier": "H02",
+                                "sample identifier": "LoP_pool H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -7335,8 +7335,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool H03",
-                                "location identifier": "H03",
+                                "sample identifier": "LoP_pool H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -7378,8 +7378,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool H04",
-                                "location identifier": "H04",
+                                "sample identifier": "LoP_pool H4",
+                                "location identifier": "H4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -7421,8 +7421,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool H05",
-                                "location identifier": "H05",
+                                "sample identifier": "LoP_pool H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -7464,8 +7464,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool H06",
-                                "location identifier": "H06",
+                                "sample identifier": "LoP_pool H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -7507,8 +7507,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool H07",
-                                "location identifier": "H07",
+                                "sample identifier": "LoP_pool H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -7550,8 +7550,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool H08",
-                                "location identifier": "H08",
+                                "sample identifier": "LoP_pool H8",
+                                "location identifier": "H8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -7593,8 +7593,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool H09",
-                                "location identifier": "H09",
+                                "sample identifier": "LoP_pool H9",
+                                "location identifier": "H9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -8281,8 +8281,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool I01",
-                                "location identifier": "I01",
+                                "sample identifier": "LoP_pool I1",
+                                "location identifier": "I1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -8324,8 +8324,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool I02",
-                                "location identifier": "I02",
+                                "sample identifier": "LoP_pool I2",
+                                "location identifier": "I2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -8367,8 +8367,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool I03",
-                                "location identifier": "I03",
+                                "sample identifier": "LoP_pool I3",
+                                "location identifier": "I3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -8410,8 +8410,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool I04",
-                                "location identifier": "I04",
+                                "sample identifier": "LoP_pool I4",
+                                "location identifier": "I4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -8453,8 +8453,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool I05",
-                                "location identifier": "I05",
+                                "sample identifier": "LoP_pool I5",
+                                "location identifier": "I5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -8496,8 +8496,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool I06",
-                                "location identifier": "I06",
+                                "sample identifier": "LoP_pool I6",
+                                "location identifier": "I6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -8539,8 +8539,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool I07",
-                                "location identifier": "I07",
+                                "sample identifier": "LoP_pool I7",
+                                "location identifier": "I7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -8582,8 +8582,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool I08",
-                                "location identifier": "I08",
+                                "sample identifier": "LoP_pool I8",
+                                "location identifier": "I8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -8625,8 +8625,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool I09",
-                                "location identifier": "I09",
+                                "sample identifier": "LoP_pool I9",
+                                "location identifier": "I9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -9313,8 +9313,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool J01",
-                                "location identifier": "J01",
+                                "sample identifier": "LoP_pool J1",
+                                "location identifier": "J1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -9356,8 +9356,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool J02",
-                                "location identifier": "J02",
+                                "sample identifier": "LoP_pool J2",
+                                "location identifier": "J2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -9399,8 +9399,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool J03",
-                                "location identifier": "J03",
+                                "sample identifier": "LoP_pool J3",
+                                "location identifier": "J3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -9442,8 +9442,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool J04",
-                                "location identifier": "J04",
+                                "sample identifier": "LoP_pool J4",
+                                "location identifier": "J4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -9485,8 +9485,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool J05",
-                                "location identifier": "J05",
+                                "sample identifier": "LoP_pool J5",
+                                "location identifier": "J5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -9528,8 +9528,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool J06",
-                                "location identifier": "J06",
+                                "sample identifier": "LoP_pool J6",
+                                "location identifier": "J6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -9571,8 +9571,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool J07",
-                                "location identifier": "J07",
+                                "sample identifier": "LoP_pool J7",
+                                "location identifier": "J7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -9614,8 +9614,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool J08",
-                                "location identifier": "J08",
+                                "sample identifier": "LoP_pool J8",
+                                "location identifier": "J8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -9657,8 +9657,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool J09",
-                                "location identifier": "J09",
+                                "sample identifier": "LoP_pool J9",
+                                "location identifier": "J9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -10345,8 +10345,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool K01",
-                                "location identifier": "K01",
+                                "sample identifier": "LoP_pool K1",
+                                "location identifier": "K1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -10388,8 +10388,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool K02",
-                                "location identifier": "K02",
+                                "sample identifier": "LoP_pool K2",
+                                "location identifier": "K2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -10431,8 +10431,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool K03",
-                                "location identifier": "K03",
+                                "sample identifier": "LoP_pool K3",
+                                "location identifier": "K3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -10474,8 +10474,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool K04",
-                                "location identifier": "K04",
+                                "sample identifier": "LoP_pool K4",
+                                "location identifier": "K4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -10517,8 +10517,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool K05",
-                                "location identifier": "K05",
+                                "sample identifier": "LoP_pool K5",
+                                "location identifier": "K5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -10560,8 +10560,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool K06",
-                                "location identifier": "K06",
+                                "sample identifier": "LoP_pool K6",
+                                "location identifier": "K6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -10603,8 +10603,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool K07",
-                                "location identifier": "K07",
+                                "sample identifier": "LoP_pool K7",
+                                "location identifier": "K7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -10646,8 +10646,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool K08",
-                                "location identifier": "K08",
+                                "sample identifier": "LoP_pool K8",
+                                "location identifier": "K8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -10689,8 +10689,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool K09",
-                                "location identifier": "K09",
+                                "sample identifier": "LoP_pool K9",
+                                "location identifier": "K9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -11377,8 +11377,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool L01",
-                                "location identifier": "L01",
+                                "sample identifier": "LoP_pool L1",
+                                "location identifier": "L1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -11420,8 +11420,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool L02",
-                                "location identifier": "L02",
+                                "sample identifier": "LoP_pool L2",
+                                "location identifier": "L2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -11463,8 +11463,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool L03",
-                                "location identifier": "L03",
+                                "sample identifier": "LoP_pool L3",
+                                "location identifier": "L3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -11506,8 +11506,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool L04",
-                                "location identifier": "L04",
+                                "sample identifier": "LoP_pool L4",
+                                "location identifier": "L4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -11549,8 +11549,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool L05",
-                                "location identifier": "L05",
+                                "sample identifier": "LoP_pool L5",
+                                "location identifier": "L5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -11592,8 +11592,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool L06",
-                                "location identifier": "L06",
+                                "sample identifier": "LoP_pool L6",
+                                "location identifier": "L6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -11635,8 +11635,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool L07",
-                                "location identifier": "L07",
+                                "sample identifier": "LoP_pool L7",
+                                "location identifier": "L7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -11678,8 +11678,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool L08",
-                                "location identifier": "L08",
+                                "sample identifier": "LoP_pool L8",
+                                "location identifier": "L8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -11721,8 +11721,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool L09",
-                                "location identifier": "L09",
+                                "sample identifier": "LoP_pool L9",
+                                "location identifier": "L9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -12409,8 +12409,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool M01",
-                                "location identifier": "M01",
+                                "sample identifier": "LoP_pool M1",
+                                "location identifier": "M1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -12452,8 +12452,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool M02",
-                                "location identifier": "M02",
+                                "sample identifier": "LoP_pool M2",
+                                "location identifier": "M2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -12495,8 +12495,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool M03",
-                                "location identifier": "M03",
+                                "sample identifier": "LoP_pool M3",
+                                "location identifier": "M3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -12538,8 +12538,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool M04",
-                                "location identifier": "M04",
+                                "sample identifier": "LoP_pool M4",
+                                "location identifier": "M4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -12581,8 +12581,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool M05",
-                                "location identifier": "M05",
+                                "sample identifier": "LoP_pool M5",
+                                "location identifier": "M5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -12624,8 +12624,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool M06",
-                                "location identifier": "M06",
+                                "sample identifier": "LoP_pool M6",
+                                "location identifier": "M6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -12667,8 +12667,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool M07",
-                                "location identifier": "M07",
+                                "sample identifier": "LoP_pool M7",
+                                "location identifier": "M7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -12710,8 +12710,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool M08",
-                                "location identifier": "M08",
+                                "sample identifier": "LoP_pool M8",
+                                "location identifier": "M8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -12753,8 +12753,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool M09",
-                                "location identifier": "M09",
+                                "sample identifier": "LoP_pool M9",
+                                "location identifier": "M9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -13441,8 +13441,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool N01",
-                                "location identifier": "N01",
+                                "sample identifier": "LoP_pool N1",
+                                "location identifier": "N1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -13484,8 +13484,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool N02",
-                                "location identifier": "N02",
+                                "sample identifier": "LoP_pool N2",
+                                "location identifier": "N2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -13527,8 +13527,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool N03",
-                                "location identifier": "N03",
+                                "sample identifier": "LoP_pool N3",
+                                "location identifier": "N3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -13570,8 +13570,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool N04",
-                                "location identifier": "N04",
+                                "sample identifier": "LoP_pool N4",
+                                "location identifier": "N4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -13613,8 +13613,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool N05",
-                                "location identifier": "N05",
+                                "sample identifier": "LoP_pool N5",
+                                "location identifier": "N5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -13656,8 +13656,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool N06",
-                                "location identifier": "N06",
+                                "sample identifier": "LoP_pool N6",
+                                "location identifier": "N6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -13699,8 +13699,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool N07",
-                                "location identifier": "N07",
+                                "sample identifier": "LoP_pool N7",
+                                "location identifier": "N7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -13742,8 +13742,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool N08",
-                                "location identifier": "N08",
+                                "sample identifier": "LoP_pool N8",
+                                "location identifier": "N8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -13785,8 +13785,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool N09",
-                                "location identifier": "N09",
+                                "sample identifier": "LoP_pool N9",
+                                "location identifier": "N9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -14473,8 +14473,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool O01",
-                                "location identifier": "O01",
+                                "sample identifier": "LoP_pool O1",
+                                "location identifier": "O1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -14516,8 +14516,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool O02",
-                                "location identifier": "O02",
+                                "sample identifier": "LoP_pool O2",
+                                "location identifier": "O2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -14559,8 +14559,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool O03",
-                                "location identifier": "O03",
+                                "sample identifier": "LoP_pool O3",
+                                "location identifier": "O3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -14602,8 +14602,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool O04",
-                                "location identifier": "O04",
+                                "sample identifier": "LoP_pool O4",
+                                "location identifier": "O4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -14645,8 +14645,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool O05",
-                                "location identifier": "O05",
+                                "sample identifier": "LoP_pool O5",
+                                "location identifier": "O5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -14688,8 +14688,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool O06",
-                                "location identifier": "O06",
+                                "sample identifier": "LoP_pool O6",
+                                "location identifier": "O6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -14731,8 +14731,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool O07",
-                                "location identifier": "O07",
+                                "sample identifier": "LoP_pool O7",
+                                "location identifier": "O7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -14774,8 +14774,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool O08",
-                                "location identifier": "O08",
+                                "sample identifier": "LoP_pool O8",
+                                "location identifier": "O8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -14817,8 +14817,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool O09",
-                                "location identifier": "O09",
+                                "sample identifier": "LoP_pool O9",
+                                "location identifier": "O9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -15505,8 +15505,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool P01",
-                                "location identifier": "P01",
+                                "sample identifier": "LoP_pool P1",
+                                "location identifier": "P1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -15548,8 +15548,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool P02",
-                                "location identifier": "P02",
+                                "sample identifier": "LoP_pool P2",
+                                "location identifier": "P2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -15591,8 +15591,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool P03",
-                                "location identifier": "P03",
+                                "sample identifier": "LoP_pool P3",
+                                "location identifier": "P3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -15634,8 +15634,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool P04",
-                                "location identifier": "P04",
+                                "sample identifier": "LoP_pool P4",
+                                "location identifier": "P4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -15677,8 +15677,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool P05",
-                                "location identifier": "P05",
+                                "sample identifier": "LoP_pool P5",
+                                "location identifier": "P5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -15720,8 +15720,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool P06",
-                                "location identifier": "P06",
+                                "sample identifier": "LoP_pool P6",
+                                "location identifier": "P6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -15763,8 +15763,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool P07",
-                                "location identifier": "P07",
+                                "sample identifier": "LoP_pool P7",
+                                "location identifier": "P7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -15806,8 +15806,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool P08",
-                                "location identifier": "P08",
+                                "sample identifier": "LoP_pool P8",
+                                "location identifier": "P8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -15849,8 +15849,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "LoP_pool P09",
-                                "location identifier": "P09",
+                                "sample identifier": "LoP_pool P9",
+                                "location identifier": "P9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "LoP_pool"
                             },
@@ -16525,7 +16525,7 @@
             "software name": "EnVision Workstation",
             "software version": "1.14.3049.1193",
             "ASM converter name": "allotropy_perkinelmer_envision",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.54"
         }
     }
 }

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example04.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example04.json
@@ -25,8 +25,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 A01",
-                                "location identifier": "A01",
+                                "sample identifier": "81 A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -68,8 +68,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 A02",
-                                "location identifier": "A02",
+                                "sample identifier": "81 A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -111,8 +111,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 A03",
-                                "location identifier": "A03",
+                                "sample identifier": "81 A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -154,8 +154,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 A04",
-                                "location identifier": "A04",
+                                "sample identifier": "81 A4",
+                                "location identifier": "A4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -197,8 +197,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 A05",
-                                "location identifier": "A05",
+                                "sample identifier": "81 A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -240,8 +240,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 A06",
-                                "location identifier": "A06",
+                                "sample identifier": "81 A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -283,8 +283,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 A07",
-                                "location identifier": "A07",
+                                "sample identifier": "81 A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -326,8 +326,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 A08",
-                                "location identifier": "A08",
+                                "sample identifier": "81 A8",
+                                "location identifier": "A8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -369,8 +369,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 A09",
-                                "location identifier": "A09",
+                                "sample identifier": "81 A9",
+                                "location identifier": "A9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -1057,8 +1057,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 B01",
-                                "location identifier": "B01",
+                                "sample identifier": "81 B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -1100,8 +1100,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 B02",
-                                "location identifier": "B02",
+                                "sample identifier": "81 B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -1143,8 +1143,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 B03",
-                                "location identifier": "B03",
+                                "sample identifier": "81 B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -1186,8 +1186,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 B04",
-                                "location identifier": "B04",
+                                "sample identifier": "81 B4",
+                                "location identifier": "B4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -1229,8 +1229,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 B05",
-                                "location identifier": "B05",
+                                "sample identifier": "81 B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -1272,8 +1272,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 B06",
-                                "location identifier": "B06",
+                                "sample identifier": "81 B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -1315,8 +1315,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 B07",
-                                "location identifier": "B07",
+                                "sample identifier": "81 B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -1358,8 +1358,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 B08",
-                                "location identifier": "B08",
+                                "sample identifier": "81 B8",
+                                "location identifier": "B8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -1401,8 +1401,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 B09",
-                                "location identifier": "B09",
+                                "sample identifier": "81 B9",
+                                "location identifier": "B9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -2089,8 +2089,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 C01",
-                                "location identifier": "C01",
+                                "sample identifier": "81 C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -2132,8 +2132,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 C02",
-                                "location identifier": "C02",
+                                "sample identifier": "81 C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -2175,8 +2175,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 C03",
-                                "location identifier": "C03",
+                                "sample identifier": "81 C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -2218,8 +2218,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 C04",
-                                "location identifier": "C04",
+                                "sample identifier": "81 C4",
+                                "location identifier": "C4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -2261,8 +2261,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 C05",
-                                "location identifier": "C05",
+                                "sample identifier": "81 C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -2304,8 +2304,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 C06",
-                                "location identifier": "C06",
+                                "sample identifier": "81 C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -2347,8 +2347,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 C07",
-                                "location identifier": "C07",
+                                "sample identifier": "81 C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -2390,8 +2390,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 C08",
-                                "location identifier": "C08",
+                                "sample identifier": "81 C8",
+                                "location identifier": "C8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -2433,8 +2433,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 C09",
-                                "location identifier": "C09",
+                                "sample identifier": "81 C9",
+                                "location identifier": "C9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -3121,8 +3121,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 D01",
-                                "location identifier": "D01",
+                                "sample identifier": "81 D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -3164,8 +3164,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 D02",
-                                "location identifier": "D02",
+                                "sample identifier": "81 D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -3207,8 +3207,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 D03",
-                                "location identifier": "D03",
+                                "sample identifier": "81 D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -3250,8 +3250,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 D04",
-                                "location identifier": "D04",
+                                "sample identifier": "81 D4",
+                                "location identifier": "D4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -3293,8 +3293,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 D05",
-                                "location identifier": "D05",
+                                "sample identifier": "81 D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -3336,8 +3336,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 D06",
-                                "location identifier": "D06",
+                                "sample identifier": "81 D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -3379,8 +3379,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 D07",
-                                "location identifier": "D07",
+                                "sample identifier": "81 D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -3422,8 +3422,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 D08",
-                                "location identifier": "D08",
+                                "sample identifier": "81 D8",
+                                "location identifier": "D8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -3465,8 +3465,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 D09",
-                                "location identifier": "D09",
+                                "sample identifier": "81 D9",
+                                "location identifier": "D9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -4153,8 +4153,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 E01",
-                                "location identifier": "E01",
+                                "sample identifier": "81 E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -4196,8 +4196,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 E02",
-                                "location identifier": "E02",
+                                "sample identifier": "81 E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -4239,8 +4239,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 E03",
-                                "location identifier": "E03",
+                                "sample identifier": "81 E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -4282,8 +4282,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 E04",
-                                "location identifier": "E04",
+                                "sample identifier": "81 E4",
+                                "location identifier": "E4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -4325,8 +4325,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 E05",
-                                "location identifier": "E05",
+                                "sample identifier": "81 E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -4368,8 +4368,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 E06",
-                                "location identifier": "E06",
+                                "sample identifier": "81 E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -4411,8 +4411,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 E07",
-                                "location identifier": "E07",
+                                "sample identifier": "81 E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -4454,8 +4454,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 E08",
-                                "location identifier": "E08",
+                                "sample identifier": "81 E8",
+                                "location identifier": "E8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -4497,8 +4497,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 E09",
-                                "location identifier": "E09",
+                                "sample identifier": "81 E9",
+                                "location identifier": "E9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -5185,8 +5185,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 F01",
-                                "location identifier": "F01",
+                                "sample identifier": "81 F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -5228,8 +5228,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 F02",
-                                "location identifier": "F02",
+                                "sample identifier": "81 F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -5271,8 +5271,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 F03",
-                                "location identifier": "F03",
+                                "sample identifier": "81 F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -5314,8 +5314,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 F04",
-                                "location identifier": "F04",
+                                "sample identifier": "81 F4",
+                                "location identifier": "F4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -5357,8 +5357,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 F05",
-                                "location identifier": "F05",
+                                "sample identifier": "81 F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -5400,8 +5400,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 F06",
-                                "location identifier": "F06",
+                                "sample identifier": "81 F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -5443,8 +5443,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 F07",
-                                "location identifier": "F07",
+                                "sample identifier": "81 F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -5486,8 +5486,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 F08",
-                                "location identifier": "F08",
+                                "sample identifier": "81 F8",
+                                "location identifier": "F8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -5529,8 +5529,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 F09",
-                                "location identifier": "F09",
+                                "sample identifier": "81 F9",
+                                "location identifier": "F9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -6217,8 +6217,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 G01",
-                                "location identifier": "G01",
+                                "sample identifier": "81 G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -6260,8 +6260,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 G02",
-                                "location identifier": "G02",
+                                "sample identifier": "81 G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -6303,8 +6303,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 G03",
-                                "location identifier": "G03",
+                                "sample identifier": "81 G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -6346,8 +6346,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 G04",
-                                "location identifier": "G04",
+                                "sample identifier": "81 G4",
+                                "location identifier": "G4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -6389,8 +6389,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 G05",
-                                "location identifier": "G05",
+                                "sample identifier": "81 G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -6432,8 +6432,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 G06",
-                                "location identifier": "G06",
+                                "sample identifier": "81 G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -6475,8 +6475,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 G07",
-                                "location identifier": "G07",
+                                "sample identifier": "81 G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -6518,8 +6518,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 G08",
-                                "location identifier": "G08",
+                                "sample identifier": "81 G8",
+                                "location identifier": "G8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -6561,8 +6561,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 G09",
-                                "location identifier": "G09",
+                                "sample identifier": "81 G9",
+                                "location identifier": "G9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -7249,8 +7249,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 H01",
-                                "location identifier": "H01",
+                                "sample identifier": "81 H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -7292,8 +7292,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 H02",
-                                "location identifier": "H02",
+                                "sample identifier": "81 H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -7335,8 +7335,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 H03",
-                                "location identifier": "H03",
+                                "sample identifier": "81 H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -7378,8 +7378,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 H04",
-                                "location identifier": "H04",
+                                "sample identifier": "81 H4",
+                                "location identifier": "H4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -7421,8 +7421,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 H05",
-                                "location identifier": "H05",
+                                "sample identifier": "81 H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -7464,8 +7464,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 H06",
-                                "location identifier": "H06",
+                                "sample identifier": "81 H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -7507,8 +7507,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 H07",
-                                "location identifier": "H07",
+                                "sample identifier": "81 H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -7550,8 +7550,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 H08",
-                                "location identifier": "H08",
+                                "sample identifier": "81 H8",
+                                "location identifier": "H8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -7593,8 +7593,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 H09",
-                                "location identifier": "H09",
+                                "sample identifier": "81 H9",
+                                "location identifier": "H9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -8281,8 +8281,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 I01",
-                                "location identifier": "I01",
+                                "sample identifier": "81 I1",
+                                "location identifier": "I1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -8324,8 +8324,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 I02",
-                                "location identifier": "I02",
+                                "sample identifier": "81 I2",
+                                "location identifier": "I2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -8367,8 +8367,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 I03",
-                                "location identifier": "I03",
+                                "sample identifier": "81 I3",
+                                "location identifier": "I3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -8410,8 +8410,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 I04",
-                                "location identifier": "I04",
+                                "sample identifier": "81 I4",
+                                "location identifier": "I4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -8453,8 +8453,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 I05",
-                                "location identifier": "I05",
+                                "sample identifier": "81 I5",
+                                "location identifier": "I5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -8496,8 +8496,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 I06",
-                                "location identifier": "I06",
+                                "sample identifier": "81 I6",
+                                "location identifier": "I6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -8539,8 +8539,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 I07",
-                                "location identifier": "I07",
+                                "sample identifier": "81 I7",
+                                "location identifier": "I7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -8582,8 +8582,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 I08",
-                                "location identifier": "I08",
+                                "sample identifier": "81 I8",
+                                "location identifier": "I8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -8625,8 +8625,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 I09",
-                                "location identifier": "I09",
+                                "sample identifier": "81 I9",
+                                "location identifier": "I9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -9313,8 +9313,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 J01",
-                                "location identifier": "J01",
+                                "sample identifier": "81 J1",
+                                "location identifier": "J1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -9356,8 +9356,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 J02",
-                                "location identifier": "J02",
+                                "sample identifier": "81 J2",
+                                "location identifier": "J2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -9399,8 +9399,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 J03",
-                                "location identifier": "J03",
+                                "sample identifier": "81 J3",
+                                "location identifier": "J3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -9442,8 +9442,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 J04",
-                                "location identifier": "J04",
+                                "sample identifier": "81 J4",
+                                "location identifier": "J4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -9485,8 +9485,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 J05",
-                                "location identifier": "J05",
+                                "sample identifier": "81 J5",
+                                "location identifier": "J5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -9528,8 +9528,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 J06",
-                                "location identifier": "J06",
+                                "sample identifier": "81 J6",
+                                "location identifier": "J6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -9571,8 +9571,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 J07",
-                                "location identifier": "J07",
+                                "sample identifier": "81 J7",
+                                "location identifier": "J7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -9614,8 +9614,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 J08",
-                                "location identifier": "J08",
+                                "sample identifier": "81 J8",
+                                "location identifier": "J8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -9657,8 +9657,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 J09",
-                                "location identifier": "J09",
+                                "sample identifier": "81 J9",
+                                "location identifier": "J9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -10345,8 +10345,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 K01",
-                                "location identifier": "K01",
+                                "sample identifier": "81 K1",
+                                "location identifier": "K1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -10388,8 +10388,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 K02",
-                                "location identifier": "K02",
+                                "sample identifier": "81 K2",
+                                "location identifier": "K2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -10431,8 +10431,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 K03",
-                                "location identifier": "K03",
+                                "sample identifier": "81 K3",
+                                "location identifier": "K3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -10474,8 +10474,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 K04",
-                                "location identifier": "K04",
+                                "sample identifier": "81 K4",
+                                "location identifier": "K4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -10517,8 +10517,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 K05",
-                                "location identifier": "K05",
+                                "sample identifier": "81 K5",
+                                "location identifier": "K5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -10560,8 +10560,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 K06",
-                                "location identifier": "K06",
+                                "sample identifier": "81 K6",
+                                "location identifier": "K6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -10603,8 +10603,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 K07",
-                                "location identifier": "K07",
+                                "sample identifier": "81 K7",
+                                "location identifier": "K7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -10646,8 +10646,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 K08",
-                                "location identifier": "K08",
+                                "sample identifier": "81 K8",
+                                "location identifier": "K8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -10689,8 +10689,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 K09",
-                                "location identifier": "K09",
+                                "sample identifier": "81 K9",
+                                "location identifier": "K9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -11377,8 +11377,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 L01",
-                                "location identifier": "L01",
+                                "sample identifier": "81 L1",
+                                "location identifier": "L1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -11420,8 +11420,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 L02",
-                                "location identifier": "L02",
+                                "sample identifier": "81 L2",
+                                "location identifier": "L2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -11463,8 +11463,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 L03",
-                                "location identifier": "L03",
+                                "sample identifier": "81 L3",
+                                "location identifier": "L3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -11506,8 +11506,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 L04",
-                                "location identifier": "L04",
+                                "sample identifier": "81 L4",
+                                "location identifier": "L4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -11549,8 +11549,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 L05",
-                                "location identifier": "L05",
+                                "sample identifier": "81 L5",
+                                "location identifier": "L5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -11592,8 +11592,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 L06",
-                                "location identifier": "L06",
+                                "sample identifier": "81 L6",
+                                "location identifier": "L6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -11635,8 +11635,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 L07",
-                                "location identifier": "L07",
+                                "sample identifier": "81 L7",
+                                "location identifier": "L7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -11678,8 +11678,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 L08",
-                                "location identifier": "L08",
+                                "sample identifier": "81 L8",
+                                "location identifier": "L8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -11721,8 +11721,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 L09",
-                                "location identifier": "L09",
+                                "sample identifier": "81 L9",
+                                "location identifier": "L9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -12409,8 +12409,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 M01",
-                                "location identifier": "M01",
+                                "sample identifier": "81 M1",
+                                "location identifier": "M1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -12452,8 +12452,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 M02",
-                                "location identifier": "M02",
+                                "sample identifier": "81 M2",
+                                "location identifier": "M2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -12495,8 +12495,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 M03",
-                                "location identifier": "M03",
+                                "sample identifier": "81 M3",
+                                "location identifier": "M3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -12538,8 +12538,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 M04",
-                                "location identifier": "M04",
+                                "sample identifier": "81 M4",
+                                "location identifier": "M4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -12581,8 +12581,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 M05",
-                                "location identifier": "M05",
+                                "sample identifier": "81 M5",
+                                "location identifier": "M5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -12624,8 +12624,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 M06",
-                                "location identifier": "M06",
+                                "sample identifier": "81 M6",
+                                "location identifier": "M6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -12667,8 +12667,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 M07",
-                                "location identifier": "M07",
+                                "sample identifier": "81 M7",
+                                "location identifier": "M7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -12710,8 +12710,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 M08",
-                                "location identifier": "M08",
+                                "sample identifier": "81 M8",
+                                "location identifier": "M8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -12753,8 +12753,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 M09",
-                                "location identifier": "M09",
+                                "sample identifier": "81 M9",
+                                "location identifier": "M9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -13441,8 +13441,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 N01",
-                                "location identifier": "N01",
+                                "sample identifier": "81 N1",
+                                "location identifier": "N1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -13484,8 +13484,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 N02",
-                                "location identifier": "N02",
+                                "sample identifier": "81 N2",
+                                "location identifier": "N2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -13527,8 +13527,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 N03",
-                                "location identifier": "N03",
+                                "sample identifier": "81 N3",
+                                "location identifier": "N3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -13570,8 +13570,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 N04",
-                                "location identifier": "N04",
+                                "sample identifier": "81 N4",
+                                "location identifier": "N4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -13613,8 +13613,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 N05",
-                                "location identifier": "N05",
+                                "sample identifier": "81 N5",
+                                "location identifier": "N5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -13656,8 +13656,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 N06",
-                                "location identifier": "N06",
+                                "sample identifier": "81 N6",
+                                "location identifier": "N6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -13699,8 +13699,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 N07",
-                                "location identifier": "N07",
+                                "sample identifier": "81 N7",
+                                "location identifier": "N7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -13742,8 +13742,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 N08",
-                                "location identifier": "N08",
+                                "sample identifier": "81 N8",
+                                "location identifier": "N8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -13785,8 +13785,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 N09",
-                                "location identifier": "N09",
+                                "sample identifier": "81 N9",
+                                "location identifier": "N9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -14473,8 +14473,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 O01",
-                                "location identifier": "O01",
+                                "sample identifier": "81 O1",
+                                "location identifier": "O1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -14516,8 +14516,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 O02",
-                                "location identifier": "O02",
+                                "sample identifier": "81 O2",
+                                "location identifier": "O2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -14559,8 +14559,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 O03",
-                                "location identifier": "O03",
+                                "sample identifier": "81 O3",
+                                "location identifier": "O3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -14602,8 +14602,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 O04",
-                                "location identifier": "O04",
+                                "sample identifier": "81 O4",
+                                "location identifier": "O4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -14645,8 +14645,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 O05",
-                                "location identifier": "O05",
+                                "sample identifier": "81 O5",
+                                "location identifier": "O5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -14688,8 +14688,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 O06",
-                                "location identifier": "O06",
+                                "sample identifier": "81 O6",
+                                "location identifier": "O6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -14731,8 +14731,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 O07",
-                                "location identifier": "O07",
+                                "sample identifier": "81 O7",
+                                "location identifier": "O7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -14774,8 +14774,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 O08",
-                                "location identifier": "O08",
+                                "sample identifier": "81 O8",
+                                "location identifier": "O8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -14817,8 +14817,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 O09",
-                                "location identifier": "O09",
+                                "sample identifier": "81 O9",
+                                "location identifier": "O9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -15505,8 +15505,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 P01",
-                                "location identifier": "P01",
+                                "sample identifier": "81 P1",
+                                "location identifier": "P1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -15548,8 +15548,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 P02",
-                                "location identifier": "P02",
+                                "sample identifier": "81 P2",
+                                "location identifier": "P2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -15591,8 +15591,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 P03",
-                                "location identifier": "P03",
+                                "sample identifier": "81 P3",
+                                "location identifier": "P3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -15634,8 +15634,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 P04",
-                                "location identifier": "P04",
+                                "sample identifier": "81 P4",
+                                "location identifier": "P4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -15677,8 +15677,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 P05",
-                                "location identifier": "P05",
+                                "sample identifier": "81 P5",
+                                "location identifier": "P5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -15720,8 +15720,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 P06",
-                                "location identifier": "P06",
+                                "sample identifier": "81 P6",
+                                "location identifier": "P6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -15763,8 +15763,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 P07",
-                                "location identifier": "P07",
+                                "sample identifier": "81 P7",
+                                "location identifier": "P7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -15806,8 +15806,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 P08",
-                                "location identifier": "P08",
+                                "sample identifier": "81 P8",
+                                "location identifier": "P8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -15849,8 +15849,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "81 P09",
-                                "location identifier": "P09",
+                                "sample identifier": "81 P9",
+                                "location identifier": "P9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "81"
                             },
@@ -16537,8 +16537,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM A01",
-                                "location identifier": "A01",
+                                "sample identifier": "8/22/2023 10:46:25 AM A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -16580,8 +16580,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM A02",
-                                "location identifier": "A02",
+                                "sample identifier": "8/22/2023 10:46:25 AM A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -16623,8 +16623,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM A03",
-                                "location identifier": "A03",
+                                "sample identifier": "8/22/2023 10:46:25 AM A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -16666,8 +16666,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM A04",
-                                "location identifier": "A04",
+                                "sample identifier": "8/22/2023 10:46:25 AM A4",
+                                "location identifier": "A4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -16709,8 +16709,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM A05",
-                                "location identifier": "A05",
+                                "sample identifier": "8/22/2023 10:46:25 AM A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -16752,8 +16752,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM A06",
-                                "location identifier": "A06",
+                                "sample identifier": "8/22/2023 10:46:25 AM A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -16795,8 +16795,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM A07",
-                                "location identifier": "A07",
+                                "sample identifier": "8/22/2023 10:46:25 AM A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -16838,8 +16838,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM A08",
-                                "location identifier": "A08",
+                                "sample identifier": "8/22/2023 10:46:25 AM A8",
+                                "location identifier": "A8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -16881,8 +16881,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM A09",
-                                "location identifier": "A09",
+                                "sample identifier": "8/22/2023 10:46:25 AM A9",
+                                "location identifier": "A9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -17569,8 +17569,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM B01",
-                                "location identifier": "B01",
+                                "sample identifier": "8/22/2023 10:46:25 AM B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -17612,8 +17612,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM B02",
-                                "location identifier": "B02",
+                                "sample identifier": "8/22/2023 10:46:25 AM B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -17655,8 +17655,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM B03",
-                                "location identifier": "B03",
+                                "sample identifier": "8/22/2023 10:46:25 AM B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -17698,8 +17698,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM B04",
-                                "location identifier": "B04",
+                                "sample identifier": "8/22/2023 10:46:25 AM B4",
+                                "location identifier": "B4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -17741,8 +17741,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM B05",
-                                "location identifier": "B05",
+                                "sample identifier": "8/22/2023 10:46:25 AM B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -17784,8 +17784,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM B06",
-                                "location identifier": "B06",
+                                "sample identifier": "8/22/2023 10:46:25 AM B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -17827,8 +17827,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM B07",
-                                "location identifier": "B07",
+                                "sample identifier": "8/22/2023 10:46:25 AM B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -17870,8 +17870,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM B08",
-                                "location identifier": "B08",
+                                "sample identifier": "8/22/2023 10:46:25 AM B8",
+                                "location identifier": "B8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -17913,8 +17913,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM B09",
-                                "location identifier": "B09",
+                                "sample identifier": "8/22/2023 10:46:25 AM B9",
+                                "location identifier": "B9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -18601,8 +18601,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM C01",
-                                "location identifier": "C01",
+                                "sample identifier": "8/22/2023 10:46:25 AM C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -18644,8 +18644,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM C02",
-                                "location identifier": "C02",
+                                "sample identifier": "8/22/2023 10:46:25 AM C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -18687,8 +18687,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM C03",
-                                "location identifier": "C03",
+                                "sample identifier": "8/22/2023 10:46:25 AM C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -18730,8 +18730,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM C04",
-                                "location identifier": "C04",
+                                "sample identifier": "8/22/2023 10:46:25 AM C4",
+                                "location identifier": "C4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -18773,8 +18773,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM C05",
-                                "location identifier": "C05",
+                                "sample identifier": "8/22/2023 10:46:25 AM C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -18816,8 +18816,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM C06",
-                                "location identifier": "C06",
+                                "sample identifier": "8/22/2023 10:46:25 AM C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -18859,8 +18859,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM C07",
-                                "location identifier": "C07",
+                                "sample identifier": "8/22/2023 10:46:25 AM C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -18902,8 +18902,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM C08",
-                                "location identifier": "C08",
+                                "sample identifier": "8/22/2023 10:46:25 AM C8",
+                                "location identifier": "C8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -18945,8 +18945,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM C09",
-                                "location identifier": "C09",
+                                "sample identifier": "8/22/2023 10:46:25 AM C9",
+                                "location identifier": "C9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -19633,8 +19633,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM D01",
-                                "location identifier": "D01",
+                                "sample identifier": "8/22/2023 10:46:25 AM D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -19676,8 +19676,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM D02",
-                                "location identifier": "D02",
+                                "sample identifier": "8/22/2023 10:46:25 AM D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -19719,8 +19719,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM D03",
-                                "location identifier": "D03",
+                                "sample identifier": "8/22/2023 10:46:25 AM D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -19762,8 +19762,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM D04",
-                                "location identifier": "D04",
+                                "sample identifier": "8/22/2023 10:46:25 AM D4",
+                                "location identifier": "D4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -19805,8 +19805,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM D05",
-                                "location identifier": "D05",
+                                "sample identifier": "8/22/2023 10:46:25 AM D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -19848,8 +19848,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM D06",
-                                "location identifier": "D06",
+                                "sample identifier": "8/22/2023 10:46:25 AM D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -19891,8 +19891,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM D07",
-                                "location identifier": "D07",
+                                "sample identifier": "8/22/2023 10:46:25 AM D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -19934,8 +19934,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM D08",
-                                "location identifier": "D08",
+                                "sample identifier": "8/22/2023 10:46:25 AM D8",
+                                "location identifier": "D8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -19977,8 +19977,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM D09",
-                                "location identifier": "D09",
+                                "sample identifier": "8/22/2023 10:46:25 AM D9",
+                                "location identifier": "D9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -20665,8 +20665,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM E01",
-                                "location identifier": "E01",
+                                "sample identifier": "8/22/2023 10:46:25 AM E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -20708,8 +20708,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM E02",
-                                "location identifier": "E02",
+                                "sample identifier": "8/22/2023 10:46:25 AM E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -20751,8 +20751,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM E03",
-                                "location identifier": "E03",
+                                "sample identifier": "8/22/2023 10:46:25 AM E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -20794,8 +20794,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM E04",
-                                "location identifier": "E04",
+                                "sample identifier": "8/22/2023 10:46:25 AM E4",
+                                "location identifier": "E4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -20837,8 +20837,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM E05",
-                                "location identifier": "E05",
+                                "sample identifier": "8/22/2023 10:46:25 AM E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -20880,8 +20880,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM E06",
-                                "location identifier": "E06",
+                                "sample identifier": "8/22/2023 10:46:25 AM E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -20923,8 +20923,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM E07",
-                                "location identifier": "E07",
+                                "sample identifier": "8/22/2023 10:46:25 AM E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -20966,8 +20966,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM E08",
-                                "location identifier": "E08",
+                                "sample identifier": "8/22/2023 10:46:25 AM E8",
+                                "location identifier": "E8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -21009,8 +21009,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM E09",
-                                "location identifier": "E09",
+                                "sample identifier": "8/22/2023 10:46:25 AM E9",
+                                "location identifier": "E9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -21697,8 +21697,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM F01",
-                                "location identifier": "F01",
+                                "sample identifier": "8/22/2023 10:46:25 AM F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -21740,8 +21740,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM F02",
-                                "location identifier": "F02",
+                                "sample identifier": "8/22/2023 10:46:25 AM F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -21783,8 +21783,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM F03",
-                                "location identifier": "F03",
+                                "sample identifier": "8/22/2023 10:46:25 AM F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -21826,8 +21826,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM F04",
-                                "location identifier": "F04",
+                                "sample identifier": "8/22/2023 10:46:25 AM F4",
+                                "location identifier": "F4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -21869,8 +21869,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM F05",
-                                "location identifier": "F05",
+                                "sample identifier": "8/22/2023 10:46:25 AM F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -21912,8 +21912,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM F06",
-                                "location identifier": "F06",
+                                "sample identifier": "8/22/2023 10:46:25 AM F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -21955,8 +21955,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM F07",
-                                "location identifier": "F07",
+                                "sample identifier": "8/22/2023 10:46:25 AM F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -21998,8 +21998,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM F08",
-                                "location identifier": "F08",
+                                "sample identifier": "8/22/2023 10:46:25 AM F8",
+                                "location identifier": "F8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -22041,8 +22041,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM F09",
-                                "location identifier": "F09",
+                                "sample identifier": "8/22/2023 10:46:25 AM F9",
+                                "location identifier": "F9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -22729,8 +22729,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM G01",
-                                "location identifier": "G01",
+                                "sample identifier": "8/22/2023 10:46:25 AM G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -22772,8 +22772,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM G02",
-                                "location identifier": "G02",
+                                "sample identifier": "8/22/2023 10:46:25 AM G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -22815,8 +22815,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM G03",
-                                "location identifier": "G03",
+                                "sample identifier": "8/22/2023 10:46:25 AM G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -22858,8 +22858,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM G04",
-                                "location identifier": "G04",
+                                "sample identifier": "8/22/2023 10:46:25 AM G4",
+                                "location identifier": "G4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -22901,8 +22901,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM G05",
-                                "location identifier": "G05",
+                                "sample identifier": "8/22/2023 10:46:25 AM G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -22944,8 +22944,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM G06",
-                                "location identifier": "G06",
+                                "sample identifier": "8/22/2023 10:46:25 AM G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -22987,8 +22987,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM G07",
-                                "location identifier": "G07",
+                                "sample identifier": "8/22/2023 10:46:25 AM G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -23030,8 +23030,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM G08",
-                                "location identifier": "G08",
+                                "sample identifier": "8/22/2023 10:46:25 AM G8",
+                                "location identifier": "G8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -23073,8 +23073,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM G09",
-                                "location identifier": "G09",
+                                "sample identifier": "8/22/2023 10:46:25 AM G9",
+                                "location identifier": "G9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -23761,8 +23761,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM H01",
-                                "location identifier": "H01",
+                                "sample identifier": "8/22/2023 10:46:25 AM H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -23804,8 +23804,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM H02",
-                                "location identifier": "H02",
+                                "sample identifier": "8/22/2023 10:46:25 AM H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -23847,8 +23847,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM H03",
-                                "location identifier": "H03",
+                                "sample identifier": "8/22/2023 10:46:25 AM H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -23890,8 +23890,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM H04",
-                                "location identifier": "H04",
+                                "sample identifier": "8/22/2023 10:46:25 AM H4",
+                                "location identifier": "H4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -23933,8 +23933,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM H05",
-                                "location identifier": "H05",
+                                "sample identifier": "8/22/2023 10:46:25 AM H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -23976,8 +23976,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM H06",
-                                "location identifier": "H06",
+                                "sample identifier": "8/22/2023 10:46:25 AM H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -24019,8 +24019,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM H07",
-                                "location identifier": "H07",
+                                "sample identifier": "8/22/2023 10:46:25 AM H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -24062,8 +24062,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM H08",
-                                "location identifier": "H08",
+                                "sample identifier": "8/22/2023 10:46:25 AM H8",
+                                "location identifier": "H8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -24105,8 +24105,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM H09",
-                                "location identifier": "H09",
+                                "sample identifier": "8/22/2023 10:46:25 AM H9",
+                                "location identifier": "H9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -24793,8 +24793,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM I01",
-                                "location identifier": "I01",
+                                "sample identifier": "8/22/2023 10:46:25 AM I1",
+                                "location identifier": "I1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -24836,8 +24836,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM I02",
-                                "location identifier": "I02",
+                                "sample identifier": "8/22/2023 10:46:25 AM I2",
+                                "location identifier": "I2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -24879,8 +24879,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM I03",
-                                "location identifier": "I03",
+                                "sample identifier": "8/22/2023 10:46:25 AM I3",
+                                "location identifier": "I3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -24922,8 +24922,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM I04",
-                                "location identifier": "I04",
+                                "sample identifier": "8/22/2023 10:46:25 AM I4",
+                                "location identifier": "I4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -24965,8 +24965,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM I05",
-                                "location identifier": "I05",
+                                "sample identifier": "8/22/2023 10:46:25 AM I5",
+                                "location identifier": "I5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -25008,8 +25008,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM I06",
-                                "location identifier": "I06",
+                                "sample identifier": "8/22/2023 10:46:25 AM I6",
+                                "location identifier": "I6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -25051,8 +25051,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM I07",
-                                "location identifier": "I07",
+                                "sample identifier": "8/22/2023 10:46:25 AM I7",
+                                "location identifier": "I7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -25094,8 +25094,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM I08",
-                                "location identifier": "I08",
+                                "sample identifier": "8/22/2023 10:46:25 AM I8",
+                                "location identifier": "I8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -25137,8 +25137,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM I09",
-                                "location identifier": "I09",
+                                "sample identifier": "8/22/2023 10:46:25 AM I9",
+                                "location identifier": "I9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -25825,8 +25825,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM J01",
-                                "location identifier": "J01",
+                                "sample identifier": "8/22/2023 10:46:25 AM J1",
+                                "location identifier": "J1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -25868,8 +25868,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM J02",
-                                "location identifier": "J02",
+                                "sample identifier": "8/22/2023 10:46:25 AM J2",
+                                "location identifier": "J2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -25911,8 +25911,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM J03",
-                                "location identifier": "J03",
+                                "sample identifier": "8/22/2023 10:46:25 AM J3",
+                                "location identifier": "J3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -25954,8 +25954,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM J04",
-                                "location identifier": "J04",
+                                "sample identifier": "8/22/2023 10:46:25 AM J4",
+                                "location identifier": "J4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -25997,8 +25997,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM J05",
-                                "location identifier": "J05",
+                                "sample identifier": "8/22/2023 10:46:25 AM J5",
+                                "location identifier": "J5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -26040,8 +26040,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM J06",
-                                "location identifier": "J06",
+                                "sample identifier": "8/22/2023 10:46:25 AM J6",
+                                "location identifier": "J6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -26083,8 +26083,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM J07",
-                                "location identifier": "J07",
+                                "sample identifier": "8/22/2023 10:46:25 AM J7",
+                                "location identifier": "J7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -26126,8 +26126,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM J08",
-                                "location identifier": "J08",
+                                "sample identifier": "8/22/2023 10:46:25 AM J8",
+                                "location identifier": "J8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -26169,8 +26169,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM J09",
-                                "location identifier": "J09",
+                                "sample identifier": "8/22/2023 10:46:25 AM J9",
+                                "location identifier": "J9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -26857,8 +26857,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM K01",
-                                "location identifier": "K01",
+                                "sample identifier": "8/22/2023 10:46:25 AM K1",
+                                "location identifier": "K1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -26900,8 +26900,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM K02",
-                                "location identifier": "K02",
+                                "sample identifier": "8/22/2023 10:46:25 AM K2",
+                                "location identifier": "K2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -26943,8 +26943,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM K03",
-                                "location identifier": "K03",
+                                "sample identifier": "8/22/2023 10:46:25 AM K3",
+                                "location identifier": "K3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -26986,8 +26986,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM K04",
-                                "location identifier": "K04",
+                                "sample identifier": "8/22/2023 10:46:25 AM K4",
+                                "location identifier": "K4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -27029,8 +27029,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM K05",
-                                "location identifier": "K05",
+                                "sample identifier": "8/22/2023 10:46:25 AM K5",
+                                "location identifier": "K5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -27072,8 +27072,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM K06",
-                                "location identifier": "K06",
+                                "sample identifier": "8/22/2023 10:46:25 AM K6",
+                                "location identifier": "K6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -27115,8 +27115,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM K07",
-                                "location identifier": "K07",
+                                "sample identifier": "8/22/2023 10:46:25 AM K7",
+                                "location identifier": "K7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -27158,8 +27158,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM K08",
-                                "location identifier": "K08",
+                                "sample identifier": "8/22/2023 10:46:25 AM K8",
+                                "location identifier": "K8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -27201,8 +27201,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM K09",
-                                "location identifier": "K09",
+                                "sample identifier": "8/22/2023 10:46:25 AM K9",
+                                "location identifier": "K9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -27889,8 +27889,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM L01",
-                                "location identifier": "L01",
+                                "sample identifier": "8/22/2023 10:46:25 AM L1",
+                                "location identifier": "L1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -27932,8 +27932,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM L02",
-                                "location identifier": "L02",
+                                "sample identifier": "8/22/2023 10:46:25 AM L2",
+                                "location identifier": "L2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -27975,8 +27975,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM L03",
-                                "location identifier": "L03",
+                                "sample identifier": "8/22/2023 10:46:25 AM L3",
+                                "location identifier": "L3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -28018,8 +28018,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM L04",
-                                "location identifier": "L04",
+                                "sample identifier": "8/22/2023 10:46:25 AM L4",
+                                "location identifier": "L4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -28061,8 +28061,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM L05",
-                                "location identifier": "L05",
+                                "sample identifier": "8/22/2023 10:46:25 AM L5",
+                                "location identifier": "L5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -28104,8 +28104,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM L06",
-                                "location identifier": "L06",
+                                "sample identifier": "8/22/2023 10:46:25 AM L6",
+                                "location identifier": "L6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -28147,8 +28147,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM L07",
-                                "location identifier": "L07",
+                                "sample identifier": "8/22/2023 10:46:25 AM L7",
+                                "location identifier": "L7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -28190,8 +28190,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM L08",
-                                "location identifier": "L08",
+                                "sample identifier": "8/22/2023 10:46:25 AM L8",
+                                "location identifier": "L8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -28233,8 +28233,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM L09",
-                                "location identifier": "L09",
+                                "sample identifier": "8/22/2023 10:46:25 AM L9",
+                                "location identifier": "L9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -28921,8 +28921,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM M01",
-                                "location identifier": "M01",
+                                "sample identifier": "8/22/2023 10:46:25 AM M1",
+                                "location identifier": "M1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -28964,8 +28964,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM M02",
-                                "location identifier": "M02",
+                                "sample identifier": "8/22/2023 10:46:25 AM M2",
+                                "location identifier": "M2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -29007,8 +29007,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM M03",
-                                "location identifier": "M03",
+                                "sample identifier": "8/22/2023 10:46:25 AM M3",
+                                "location identifier": "M3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -29050,8 +29050,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM M04",
-                                "location identifier": "M04",
+                                "sample identifier": "8/22/2023 10:46:25 AM M4",
+                                "location identifier": "M4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -29093,8 +29093,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM M05",
-                                "location identifier": "M05",
+                                "sample identifier": "8/22/2023 10:46:25 AM M5",
+                                "location identifier": "M5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -29136,8 +29136,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM M06",
-                                "location identifier": "M06",
+                                "sample identifier": "8/22/2023 10:46:25 AM M6",
+                                "location identifier": "M6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -29179,8 +29179,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM M07",
-                                "location identifier": "M07",
+                                "sample identifier": "8/22/2023 10:46:25 AM M7",
+                                "location identifier": "M7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -29222,8 +29222,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM M08",
-                                "location identifier": "M08",
+                                "sample identifier": "8/22/2023 10:46:25 AM M8",
+                                "location identifier": "M8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -29265,8 +29265,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM M09",
-                                "location identifier": "M09",
+                                "sample identifier": "8/22/2023 10:46:25 AM M9",
+                                "location identifier": "M9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -29953,8 +29953,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM N01",
-                                "location identifier": "N01",
+                                "sample identifier": "8/22/2023 10:46:25 AM N1",
+                                "location identifier": "N1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -29996,8 +29996,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM N02",
-                                "location identifier": "N02",
+                                "sample identifier": "8/22/2023 10:46:25 AM N2",
+                                "location identifier": "N2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -30039,8 +30039,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM N03",
-                                "location identifier": "N03",
+                                "sample identifier": "8/22/2023 10:46:25 AM N3",
+                                "location identifier": "N3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -30082,8 +30082,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM N04",
-                                "location identifier": "N04",
+                                "sample identifier": "8/22/2023 10:46:25 AM N4",
+                                "location identifier": "N4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -30125,8 +30125,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM N05",
-                                "location identifier": "N05",
+                                "sample identifier": "8/22/2023 10:46:25 AM N5",
+                                "location identifier": "N5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -30168,8 +30168,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM N06",
-                                "location identifier": "N06",
+                                "sample identifier": "8/22/2023 10:46:25 AM N6",
+                                "location identifier": "N6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -30211,8 +30211,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM N07",
-                                "location identifier": "N07",
+                                "sample identifier": "8/22/2023 10:46:25 AM N7",
+                                "location identifier": "N7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -30254,8 +30254,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM N08",
-                                "location identifier": "N08",
+                                "sample identifier": "8/22/2023 10:46:25 AM N8",
+                                "location identifier": "N8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -30297,8 +30297,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM N09",
-                                "location identifier": "N09",
+                                "sample identifier": "8/22/2023 10:46:25 AM N9",
+                                "location identifier": "N9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -30985,8 +30985,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM O01",
-                                "location identifier": "O01",
+                                "sample identifier": "8/22/2023 10:46:25 AM O1",
+                                "location identifier": "O1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -31028,8 +31028,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM O02",
-                                "location identifier": "O02",
+                                "sample identifier": "8/22/2023 10:46:25 AM O2",
+                                "location identifier": "O2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -31071,8 +31071,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM O03",
-                                "location identifier": "O03",
+                                "sample identifier": "8/22/2023 10:46:25 AM O3",
+                                "location identifier": "O3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -31114,8 +31114,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM O04",
-                                "location identifier": "O04",
+                                "sample identifier": "8/22/2023 10:46:25 AM O4",
+                                "location identifier": "O4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -31157,8 +31157,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM O05",
-                                "location identifier": "O05",
+                                "sample identifier": "8/22/2023 10:46:25 AM O5",
+                                "location identifier": "O5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -31200,8 +31200,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM O06",
-                                "location identifier": "O06",
+                                "sample identifier": "8/22/2023 10:46:25 AM O6",
+                                "location identifier": "O6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -31243,8 +31243,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM O07",
-                                "location identifier": "O07",
+                                "sample identifier": "8/22/2023 10:46:25 AM O7",
+                                "location identifier": "O7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -31286,8 +31286,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM O08",
-                                "location identifier": "O08",
+                                "sample identifier": "8/22/2023 10:46:25 AM O8",
+                                "location identifier": "O8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -31329,8 +31329,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM O09",
-                                "location identifier": "O09",
+                                "sample identifier": "8/22/2023 10:46:25 AM O9",
+                                "location identifier": "O9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -32017,8 +32017,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM P01",
-                                "location identifier": "P01",
+                                "sample identifier": "8/22/2023 10:46:25 AM P1",
+                                "location identifier": "P1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -32060,8 +32060,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM P02",
-                                "location identifier": "P02",
+                                "sample identifier": "8/22/2023 10:46:25 AM P2",
+                                "location identifier": "P2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -32103,8 +32103,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM P03",
-                                "location identifier": "P03",
+                                "sample identifier": "8/22/2023 10:46:25 AM P3",
+                                "location identifier": "P3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -32146,8 +32146,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM P04",
-                                "location identifier": "P04",
+                                "sample identifier": "8/22/2023 10:46:25 AM P4",
+                                "location identifier": "P4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -32189,8 +32189,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM P05",
-                                "location identifier": "P05",
+                                "sample identifier": "8/22/2023 10:46:25 AM P5",
+                                "location identifier": "P5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -32232,8 +32232,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM P06",
-                                "location identifier": "P06",
+                                "sample identifier": "8/22/2023 10:46:25 AM P6",
+                                "location identifier": "P6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -32275,8 +32275,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM P07",
-                                "location identifier": "P07",
+                                "sample identifier": "8/22/2023 10:46:25 AM P7",
+                                "location identifier": "P7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -32318,8 +32318,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM P08",
-                                "location identifier": "P08",
+                                "sample identifier": "8/22/2023 10:46:25 AM P8",
+                                "location identifier": "P8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -32361,8 +32361,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 10:46:25 AM P09",
-                                "location identifier": "P09",
+                                "sample identifier": "8/22/2023 10:46:25 AM P9",
+                                "location identifier": "P9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 10:46:25 AM"
                             },
@@ -33037,7 +33037,7 @@
             "software name": "EnVision Workstation",
             "software version": "1.14.3049.1193",
             "ASM converter name": "allotropy_perkinelmer_envision",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.54"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_luminescence_example01.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_luminescence_example01.json
@@ -24,8 +24,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM A01",
-                                "location identifier": "A01",
+                                "sample identifier": "8/22/2023 11:01:43 AM A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -66,8 +66,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM A02",
-                                "location identifier": "A02",
+                                "sample identifier": "8/22/2023 11:01:43 AM A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -108,8 +108,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM A03",
-                                "location identifier": "A03",
+                                "sample identifier": "8/22/2023 11:01:43 AM A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -150,8 +150,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM A04",
-                                "location identifier": "A04",
+                                "sample identifier": "8/22/2023 11:01:43 AM A4",
+                                "location identifier": "A4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -192,8 +192,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM A05",
-                                "location identifier": "A05",
+                                "sample identifier": "8/22/2023 11:01:43 AM A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -234,8 +234,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM A06",
-                                "location identifier": "A06",
+                                "sample identifier": "8/22/2023 11:01:43 AM A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -276,8 +276,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM A07",
-                                "location identifier": "A07",
+                                "sample identifier": "8/22/2023 11:01:43 AM A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -318,8 +318,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM A08",
-                                "location identifier": "A08",
+                                "sample identifier": "8/22/2023 11:01:43 AM A8",
+                                "location identifier": "A8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -360,8 +360,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM A09",
-                                "location identifier": "A09",
+                                "sample identifier": "8/22/2023 11:01:43 AM A9",
+                                "location identifier": "A9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -1032,8 +1032,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM B01",
-                                "location identifier": "B01",
+                                "sample identifier": "8/22/2023 11:01:43 AM B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -1074,8 +1074,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM B02",
-                                "location identifier": "B02",
+                                "sample identifier": "8/22/2023 11:01:43 AM B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -1116,8 +1116,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM B03",
-                                "location identifier": "B03",
+                                "sample identifier": "8/22/2023 11:01:43 AM B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -1158,8 +1158,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM B04",
-                                "location identifier": "B04",
+                                "sample identifier": "8/22/2023 11:01:43 AM B4",
+                                "location identifier": "B4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -1200,8 +1200,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM B05",
-                                "location identifier": "B05",
+                                "sample identifier": "8/22/2023 11:01:43 AM B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -1242,8 +1242,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM B06",
-                                "location identifier": "B06",
+                                "sample identifier": "8/22/2023 11:01:43 AM B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -1284,8 +1284,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM B07",
-                                "location identifier": "B07",
+                                "sample identifier": "8/22/2023 11:01:43 AM B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -1326,8 +1326,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM B08",
-                                "location identifier": "B08",
+                                "sample identifier": "8/22/2023 11:01:43 AM B8",
+                                "location identifier": "B8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -1368,8 +1368,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM B09",
-                                "location identifier": "B09",
+                                "sample identifier": "8/22/2023 11:01:43 AM B9",
+                                "location identifier": "B9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -2040,8 +2040,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM C01",
-                                "location identifier": "C01",
+                                "sample identifier": "8/22/2023 11:01:43 AM C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -2082,8 +2082,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM C02",
-                                "location identifier": "C02",
+                                "sample identifier": "8/22/2023 11:01:43 AM C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -2124,8 +2124,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM C03",
-                                "location identifier": "C03",
+                                "sample identifier": "8/22/2023 11:01:43 AM C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -2166,8 +2166,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM C04",
-                                "location identifier": "C04",
+                                "sample identifier": "8/22/2023 11:01:43 AM C4",
+                                "location identifier": "C4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -2208,8 +2208,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM C05",
-                                "location identifier": "C05",
+                                "sample identifier": "8/22/2023 11:01:43 AM C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -2250,8 +2250,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM C06",
-                                "location identifier": "C06",
+                                "sample identifier": "8/22/2023 11:01:43 AM C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -2292,8 +2292,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM C07",
-                                "location identifier": "C07",
+                                "sample identifier": "8/22/2023 11:01:43 AM C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -2334,8 +2334,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM C08",
-                                "location identifier": "C08",
+                                "sample identifier": "8/22/2023 11:01:43 AM C8",
+                                "location identifier": "C8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -2376,8 +2376,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM C09",
-                                "location identifier": "C09",
+                                "sample identifier": "8/22/2023 11:01:43 AM C9",
+                                "location identifier": "C9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -3048,8 +3048,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM D01",
-                                "location identifier": "D01",
+                                "sample identifier": "8/22/2023 11:01:43 AM D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -3090,8 +3090,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM D02",
-                                "location identifier": "D02",
+                                "sample identifier": "8/22/2023 11:01:43 AM D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -3132,8 +3132,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM D03",
-                                "location identifier": "D03",
+                                "sample identifier": "8/22/2023 11:01:43 AM D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -3174,8 +3174,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM D04",
-                                "location identifier": "D04",
+                                "sample identifier": "8/22/2023 11:01:43 AM D4",
+                                "location identifier": "D4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -3216,8 +3216,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM D05",
-                                "location identifier": "D05",
+                                "sample identifier": "8/22/2023 11:01:43 AM D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -3258,8 +3258,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM D06",
-                                "location identifier": "D06",
+                                "sample identifier": "8/22/2023 11:01:43 AM D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -3300,8 +3300,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM D07",
-                                "location identifier": "D07",
+                                "sample identifier": "8/22/2023 11:01:43 AM D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -3342,8 +3342,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM D08",
-                                "location identifier": "D08",
+                                "sample identifier": "8/22/2023 11:01:43 AM D8",
+                                "location identifier": "D8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -3384,8 +3384,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM D09",
-                                "location identifier": "D09",
+                                "sample identifier": "8/22/2023 11:01:43 AM D9",
+                                "location identifier": "D9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -4056,8 +4056,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM E01",
-                                "location identifier": "E01",
+                                "sample identifier": "8/22/2023 11:01:43 AM E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -4098,8 +4098,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM E02",
-                                "location identifier": "E02",
+                                "sample identifier": "8/22/2023 11:01:43 AM E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -4140,8 +4140,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM E03",
-                                "location identifier": "E03",
+                                "sample identifier": "8/22/2023 11:01:43 AM E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -4182,8 +4182,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM E04",
-                                "location identifier": "E04",
+                                "sample identifier": "8/22/2023 11:01:43 AM E4",
+                                "location identifier": "E4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -4224,8 +4224,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM E05",
-                                "location identifier": "E05",
+                                "sample identifier": "8/22/2023 11:01:43 AM E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -4266,8 +4266,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM E06",
-                                "location identifier": "E06",
+                                "sample identifier": "8/22/2023 11:01:43 AM E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -4308,8 +4308,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM E07",
-                                "location identifier": "E07",
+                                "sample identifier": "8/22/2023 11:01:43 AM E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -4350,8 +4350,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM E08",
-                                "location identifier": "E08",
+                                "sample identifier": "8/22/2023 11:01:43 AM E8",
+                                "location identifier": "E8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -4392,8 +4392,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM E09",
-                                "location identifier": "E09",
+                                "sample identifier": "8/22/2023 11:01:43 AM E9",
+                                "location identifier": "E9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -5064,8 +5064,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM F01",
-                                "location identifier": "F01",
+                                "sample identifier": "8/22/2023 11:01:43 AM F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -5106,8 +5106,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM F02",
-                                "location identifier": "F02",
+                                "sample identifier": "8/22/2023 11:01:43 AM F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -5148,8 +5148,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM F03",
-                                "location identifier": "F03",
+                                "sample identifier": "8/22/2023 11:01:43 AM F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -5190,8 +5190,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM F04",
-                                "location identifier": "F04",
+                                "sample identifier": "8/22/2023 11:01:43 AM F4",
+                                "location identifier": "F4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -5232,8 +5232,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM F05",
-                                "location identifier": "F05",
+                                "sample identifier": "8/22/2023 11:01:43 AM F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -5274,8 +5274,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM F06",
-                                "location identifier": "F06",
+                                "sample identifier": "8/22/2023 11:01:43 AM F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -5316,8 +5316,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM F07",
-                                "location identifier": "F07",
+                                "sample identifier": "8/22/2023 11:01:43 AM F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -5358,8 +5358,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM F08",
-                                "location identifier": "F08",
+                                "sample identifier": "8/22/2023 11:01:43 AM F8",
+                                "location identifier": "F8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -5400,8 +5400,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM F09",
-                                "location identifier": "F09",
+                                "sample identifier": "8/22/2023 11:01:43 AM F9",
+                                "location identifier": "F9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -6072,8 +6072,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM G01",
-                                "location identifier": "G01",
+                                "sample identifier": "8/22/2023 11:01:43 AM G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -6114,8 +6114,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM G02",
-                                "location identifier": "G02",
+                                "sample identifier": "8/22/2023 11:01:43 AM G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -6156,8 +6156,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM G03",
-                                "location identifier": "G03",
+                                "sample identifier": "8/22/2023 11:01:43 AM G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -6198,8 +6198,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM G04",
-                                "location identifier": "G04",
+                                "sample identifier": "8/22/2023 11:01:43 AM G4",
+                                "location identifier": "G4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -6240,8 +6240,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM G05",
-                                "location identifier": "G05",
+                                "sample identifier": "8/22/2023 11:01:43 AM G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -6282,8 +6282,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM G06",
-                                "location identifier": "G06",
+                                "sample identifier": "8/22/2023 11:01:43 AM G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -6324,8 +6324,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM G07",
-                                "location identifier": "G07",
+                                "sample identifier": "8/22/2023 11:01:43 AM G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -6366,8 +6366,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM G08",
-                                "location identifier": "G08",
+                                "sample identifier": "8/22/2023 11:01:43 AM G8",
+                                "location identifier": "G8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -6408,8 +6408,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM G09",
-                                "location identifier": "G09",
+                                "sample identifier": "8/22/2023 11:01:43 AM G9",
+                                "location identifier": "G9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -7080,8 +7080,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM H01",
-                                "location identifier": "H01",
+                                "sample identifier": "8/22/2023 11:01:43 AM H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -7122,8 +7122,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM H02",
-                                "location identifier": "H02",
+                                "sample identifier": "8/22/2023 11:01:43 AM H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -7164,8 +7164,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM H03",
-                                "location identifier": "H03",
+                                "sample identifier": "8/22/2023 11:01:43 AM H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -7206,8 +7206,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM H04",
-                                "location identifier": "H04",
+                                "sample identifier": "8/22/2023 11:01:43 AM H4",
+                                "location identifier": "H4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -7248,8 +7248,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM H05",
-                                "location identifier": "H05",
+                                "sample identifier": "8/22/2023 11:01:43 AM H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -7290,8 +7290,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM H06",
-                                "location identifier": "H06",
+                                "sample identifier": "8/22/2023 11:01:43 AM H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -7332,8 +7332,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM H07",
-                                "location identifier": "H07",
+                                "sample identifier": "8/22/2023 11:01:43 AM H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -7374,8 +7374,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM H08",
-                                "location identifier": "H08",
+                                "sample identifier": "8/22/2023 11:01:43 AM H8",
+                                "location identifier": "H8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -7416,8 +7416,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM H09",
-                                "location identifier": "H09",
+                                "sample identifier": "8/22/2023 11:01:43 AM H9",
+                                "location identifier": "H9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -8088,8 +8088,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM I01",
-                                "location identifier": "I01",
+                                "sample identifier": "8/22/2023 11:01:43 AM I1",
+                                "location identifier": "I1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -8130,8 +8130,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM I02",
-                                "location identifier": "I02",
+                                "sample identifier": "8/22/2023 11:01:43 AM I2",
+                                "location identifier": "I2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -8172,8 +8172,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM I03",
-                                "location identifier": "I03",
+                                "sample identifier": "8/22/2023 11:01:43 AM I3",
+                                "location identifier": "I3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -8214,8 +8214,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM I04",
-                                "location identifier": "I04",
+                                "sample identifier": "8/22/2023 11:01:43 AM I4",
+                                "location identifier": "I4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -8256,8 +8256,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM I05",
-                                "location identifier": "I05",
+                                "sample identifier": "8/22/2023 11:01:43 AM I5",
+                                "location identifier": "I5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -8298,8 +8298,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM I06",
-                                "location identifier": "I06",
+                                "sample identifier": "8/22/2023 11:01:43 AM I6",
+                                "location identifier": "I6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -8340,8 +8340,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM I07",
-                                "location identifier": "I07",
+                                "sample identifier": "8/22/2023 11:01:43 AM I7",
+                                "location identifier": "I7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -8382,8 +8382,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM I08",
-                                "location identifier": "I08",
+                                "sample identifier": "8/22/2023 11:01:43 AM I8",
+                                "location identifier": "I8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -8424,8 +8424,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM I09",
-                                "location identifier": "I09",
+                                "sample identifier": "8/22/2023 11:01:43 AM I9",
+                                "location identifier": "I9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -9096,8 +9096,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM J01",
-                                "location identifier": "J01",
+                                "sample identifier": "8/22/2023 11:01:43 AM J1",
+                                "location identifier": "J1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -9138,8 +9138,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM J02",
-                                "location identifier": "J02",
+                                "sample identifier": "8/22/2023 11:01:43 AM J2",
+                                "location identifier": "J2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -9180,8 +9180,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM J03",
-                                "location identifier": "J03",
+                                "sample identifier": "8/22/2023 11:01:43 AM J3",
+                                "location identifier": "J3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -9222,8 +9222,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM J04",
-                                "location identifier": "J04",
+                                "sample identifier": "8/22/2023 11:01:43 AM J4",
+                                "location identifier": "J4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -9264,8 +9264,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM J05",
-                                "location identifier": "J05",
+                                "sample identifier": "8/22/2023 11:01:43 AM J5",
+                                "location identifier": "J5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -9306,8 +9306,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM J06",
-                                "location identifier": "J06",
+                                "sample identifier": "8/22/2023 11:01:43 AM J6",
+                                "location identifier": "J6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -9348,8 +9348,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM J07",
-                                "location identifier": "J07",
+                                "sample identifier": "8/22/2023 11:01:43 AM J7",
+                                "location identifier": "J7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -9390,8 +9390,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM J08",
-                                "location identifier": "J08",
+                                "sample identifier": "8/22/2023 11:01:43 AM J8",
+                                "location identifier": "J8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -9432,8 +9432,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM J09",
-                                "location identifier": "J09",
+                                "sample identifier": "8/22/2023 11:01:43 AM J9",
+                                "location identifier": "J9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -10104,8 +10104,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM K01",
-                                "location identifier": "K01",
+                                "sample identifier": "8/22/2023 11:01:43 AM K1",
+                                "location identifier": "K1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -10146,8 +10146,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM K02",
-                                "location identifier": "K02",
+                                "sample identifier": "8/22/2023 11:01:43 AM K2",
+                                "location identifier": "K2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -10188,8 +10188,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM K03",
-                                "location identifier": "K03",
+                                "sample identifier": "8/22/2023 11:01:43 AM K3",
+                                "location identifier": "K3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -10230,8 +10230,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM K04",
-                                "location identifier": "K04",
+                                "sample identifier": "8/22/2023 11:01:43 AM K4",
+                                "location identifier": "K4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -10272,8 +10272,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM K05",
-                                "location identifier": "K05",
+                                "sample identifier": "8/22/2023 11:01:43 AM K5",
+                                "location identifier": "K5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -10314,8 +10314,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM K06",
-                                "location identifier": "K06",
+                                "sample identifier": "8/22/2023 11:01:43 AM K6",
+                                "location identifier": "K6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -10356,8 +10356,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM K07",
-                                "location identifier": "K07",
+                                "sample identifier": "8/22/2023 11:01:43 AM K7",
+                                "location identifier": "K7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -10398,8 +10398,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM K08",
-                                "location identifier": "K08",
+                                "sample identifier": "8/22/2023 11:01:43 AM K8",
+                                "location identifier": "K8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -10440,8 +10440,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM K09",
-                                "location identifier": "K09",
+                                "sample identifier": "8/22/2023 11:01:43 AM K9",
+                                "location identifier": "K9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -11112,8 +11112,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM L01",
-                                "location identifier": "L01",
+                                "sample identifier": "8/22/2023 11:01:43 AM L1",
+                                "location identifier": "L1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -11154,8 +11154,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM L02",
-                                "location identifier": "L02",
+                                "sample identifier": "8/22/2023 11:01:43 AM L2",
+                                "location identifier": "L2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -11196,8 +11196,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM L03",
-                                "location identifier": "L03",
+                                "sample identifier": "8/22/2023 11:01:43 AM L3",
+                                "location identifier": "L3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -11238,8 +11238,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM L04",
-                                "location identifier": "L04",
+                                "sample identifier": "8/22/2023 11:01:43 AM L4",
+                                "location identifier": "L4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -11280,8 +11280,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM L05",
-                                "location identifier": "L05",
+                                "sample identifier": "8/22/2023 11:01:43 AM L5",
+                                "location identifier": "L5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -11322,8 +11322,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM L06",
-                                "location identifier": "L06",
+                                "sample identifier": "8/22/2023 11:01:43 AM L6",
+                                "location identifier": "L6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -11364,8 +11364,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM L07",
-                                "location identifier": "L07",
+                                "sample identifier": "8/22/2023 11:01:43 AM L7",
+                                "location identifier": "L7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -11406,8 +11406,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM L08",
-                                "location identifier": "L08",
+                                "sample identifier": "8/22/2023 11:01:43 AM L8",
+                                "location identifier": "L8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -11448,8 +11448,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM L09",
-                                "location identifier": "L09",
+                                "sample identifier": "8/22/2023 11:01:43 AM L9",
+                                "location identifier": "L9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -12120,8 +12120,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM M01",
-                                "location identifier": "M01",
+                                "sample identifier": "8/22/2023 11:01:43 AM M1",
+                                "location identifier": "M1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -12162,8 +12162,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM M02",
-                                "location identifier": "M02",
+                                "sample identifier": "8/22/2023 11:01:43 AM M2",
+                                "location identifier": "M2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -12204,8 +12204,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM M03",
-                                "location identifier": "M03",
+                                "sample identifier": "8/22/2023 11:01:43 AM M3",
+                                "location identifier": "M3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -12246,8 +12246,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM M04",
-                                "location identifier": "M04",
+                                "sample identifier": "8/22/2023 11:01:43 AM M4",
+                                "location identifier": "M4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -12288,8 +12288,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM M05",
-                                "location identifier": "M05",
+                                "sample identifier": "8/22/2023 11:01:43 AM M5",
+                                "location identifier": "M5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -12330,8 +12330,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM M06",
-                                "location identifier": "M06",
+                                "sample identifier": "8/22/2023 11:01:43 AM M6",
+                                "location identifier": "M6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -12372,8 +12372,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM M07",
-                                "location identifier": "M07",
+                                "sample identifier": "8/22/2023 11:01:43 AM M7",
+                                "location identifier": "M7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -12414,8 +12414,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM M08",
-                                "location identifier": "M08",
+                                "sample identifier": "8/22/2023 11:01:43 AM M8",
+                                "location identifier": "M8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -12456,8 +12456,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM M09",
-                                "location identifier": "M09",
+                                "sample identifier": "8/22/2023 11:01:43 AM M9",
+                                "location identifier": "M9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -13128,8 +13128,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM N01",
-                                "location identifier": "N01",
+                                "sample identifier": "8/22/2023 11:01:43 AM N1",
+                                "location identifier": "N1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -13170,8 +13170,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM N02",
-                                "location identifier": "N02",
+                                "sample identifier": "8/22/2023 11:01:43 AM N2",
+                                "location identifier": "N2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -13212,8 +13212,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM N03",
-                                "location identifier": "N03",
+                                "sample identifier": "8/22/2023 11:01:43 AM N3",
+                                "location identifier": "N3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -13254,8 +13254,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM N04",
-                                "location identifier": "N04",
+                                "sample identifier": "8/22/2023 11:01:43 AM N4",
+                                "location identifier": "N4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -13296,8 +13296,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM N05",
-                                "location identifier": "N05",
+                                "sample identifier": "8/22/2023 11:01:43 AM N5",
+                                "location identifier": "N5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -13338,8 +13338,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM N06",
-                                "location identifier": "N06",
+                                "sample identifier": "8/22/2023 11:01:43 AM N6",
+                                "location identifier": "N6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -13380,8 +13380,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM N07",
-                                "location identifier": "N07",
+                                "sample identifier": "8/22/2023 11:01:43 AM N7",
+                                "location identifier": "N7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -13422,8 +13422,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM N08",
-                                "location identifier": "N08",
+                                "sample identifier": "8/22/2023 11:01:43 AM N8",
+                                "location identifier": "N8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -13464,8 +13464,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM N09",
-                                "location identifier": "N09",
+                                "sample identifier": "8/22/2023 11:01:43 AM N9",
+                                "location identifier": "N9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -14136,8 +14136,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM O01",
-                                "location identifier": "O01",
+                                "sample identifier": "8/22/2023 11:01:43 AM O1",
+                                "location identifier": "O1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -14178,8 +14178,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM O02",
-                                "location identifier": "O02",
+                                "sample identifier": "8/22/2023 11:01:43 AM O2",
+                                "location identifier": "O2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -14220,8 +14220,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM O03",
-                                "location identifier": "O03",
+                                "sample identifier": "8/22/2023 11:01:43 AM O3",
+                                "location identifier": "O3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -14262,8 +14262,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM O04",
-                                "location identifier": "O04",
+                                "sample identifier": "8/22/2023 11:01:43 AM O4",
+                                "location identifier": "O4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -14304,8 +14304,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM O05",
-                                "location identifier": "O05",
+                                "sample identifier": "8/22/2023 11:01:43 AM O5",
+                                "location identifier": "O5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -14346,8 +14346,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM O06",
-                                "location identifier": "O06",
+                                "sample identifier": "8/22/2023 11:01:43 AM O6",
+                                "location identifier": "O6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -14388,8 +14388,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM O07",
-                                "location identifier": "O07",
+                                "sample identifier": "8/22/2023 11:01:43 AM O7",
+                                "location identifier": "O7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -14430,8 +14430,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM O08",
-                                "location identifier": "O08",
+                                "sample identifier": "8/22/2023 11:01:43 AM O8",
+                                "location identifier": "O8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -14472,8 +14472,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM O09",
-                                "location identifier": "O09",
+                                "sample identifier": "8/22/2023 11:01:43 AM O9",
+                                "location identifier": "O9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -15144,8 +15144,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM P01",
-                                "location identifier": "P01",
+                                "sample identifier": "8/22/2023 11:01:43 AM P1",
+                                "location identifier": "P1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -15186,8 +15186,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM P02",
-                                "location identifier": "P02",
+                                "sample identifier": "8/22/2023 11:01:43 AM P2",
+                                "location identifier": "P2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -15228,8 +15228,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM P03",
-                                "location identifier": "P03",
+                                "sample identifier": "8/22/2023 11:01:43 AM P3",
+                                "location identifier": "P3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -15270,8 +15270,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM P04",
-                                "location identifier": "P04",
+                                "sample identifier": "8/22/2023 11:01:43 AM P4",
+                                "location identifier": "P4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -15312,8 +15312,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM P05",
-                                "location identifier": "P05",
+                                "sample identifier": "8/22/2023 11:01:43 AM P5",
+                                "location identifier": "P5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -15354,8 +15354,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM P06",
-                                "location identifier": "P06",
+                                "sample identifier": "8/22/2023 11:01:43 AM P6",
+                                "location identifier": "P6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -15396,8 +15396,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM P07",
-                                "location identifier": "P07",
+                                "sample identifier": "8/22/2023 11:01:43 AM P7",
+                                "location identifier": "P7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -15438,8 +15438,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM P08",
-                                "location identifier": "P08",
+                                "sample identifier": "8/22/2023 11:01:43 AM P8",
+                                "location identifier": "P8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -15480,8 +15480,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 11:01:43 AM P09",
-                                "location identifier": "P09",
+                                "sample identifier": "8/22/2023 11:01:43 AM P9",
+                                "location identifier": "P9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 11:01:43 AM"
                             },
@@ -16152,8 +16152,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM A01",
-                                "location identifier": "A01",
+                                "sample identifier": "8/22/2023 12:16:57 PM A1",
+                                "location identifier": "A1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -16194,8 +16194,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM A02",
-                                "location identifier": "A02",
+                                "sample identifier": "8/22/2023 12:16:57 PM A2",
+                                "location identifier": "A2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -16236,8 +16236,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM A03",
-                                "location identifier": "A03",
+                                "sample identifier": "8/22/2023 12:16:57 PM A3",
+                                "location identifier": "A3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -16278,8 +16278,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM A04",
-                                "location identifier": "A04",
+                                "sample identifier": "8/22/2023 12:16:57 PM A4",
+                                "location identifier": "A4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -16320,8 +16320,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM A05",
-                                "location identifier": "A05",
+                                "sample identifier": "8/22/2023 12:16:57 PM A5",
+                                "location identifier": "A5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -16362,8 +16362,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM A06",
-                                "location identifier": "A06",
+                                "sample identifier": "8/22/2023 12:16:57 PM A6",
+                                "location identifier": "A6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -16404,8 +16404,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM A07",
-                                "location identifier": "A07",
+                                "sample identifier": "8/22/2023 12:16:57 PM A7",
+                                "location identifier": "A7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -16446,8 +16446,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM A08",
-                                "location identifier": "A08",
+                                "sample identifier": "8/22/2023 12:16:57 PM A8",
+                                "location identifier": "A8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -16488,8 +16488,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM A09",
-                                "location identifier": "A09",
+                                "sample identifier": "8/22/2023 12:16:57 PM A9",
+                                "location identifier": "A9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -17160,8 +17160,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM B01",
-                                "location identifier": "B01",
+                                "sample identifier": "8/22/2023 12:16:57 PM B1",
+                                "location identifier": "B1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -17202,8 +17202,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM B02",
-                                "location identifier": "B02",
+                                "sample identifier": "8/22/2023 12:16:57 PM B2",
+                                "location identifier": "B2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -17244,8 +17244,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM B03",
-                                "location identifier": "B03",
+                                "sample identifier": "8/22/2023 12:16:57 PM B3",
+                                "location identifier": "B3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -17286,8 +17286,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM B04",
-                                "location identifier": "B04",
+                                "sample identifier": "8/22/2023 12:16:57 PM B4",
+                                "location identifier": "B4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -17328,8 +17328,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM B05",
-                                "location identifier": "B05",
+                                "sample identifier": "8/22/2023 12:16:57 PM B5",
+                                "location identifier": "B5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -17370,8 +17370,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM B06",
-                                "location identifier": "B06",
+                                "sample identifier": "8/22/2023 12:16:57 PM B6",
+                                "location identifier": "B6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -17412,8 +17412,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM B07",
-                                "location identifier": "B07",
+                                "sample identifier": "8/22/2023 12:16:57 PM B7",
+                                "location identifier": "B7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -17454,8 +17454,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM B08",
-                                "location identifier": "B08",
+                                "sample identifier": "8/22/2023 12:16:57 PM B8",
+                                "location identifier": "B8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -17496,8 +17496,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM B09",
-                                "location identifier": "B09",
+                                "sample identifier": "8/22/2023 12:16:57 PM B9",
+                                "location identifier": "B9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -18168,8 +18168,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM C01",
-                                "location identifier": "C01",
+                                "sample identifier": "8/22/2023 12:16:57 PM C1",
+                                "location identifier": "C1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -18210,8 +18210,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM C02",
-                                "location identifier": "C02",
+                                "sample identifier": "8/22/2023 12:16:57 PM C2",
+                                "location identifier": "C2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -18252,8 +18252,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM C03",
-                                "location identifier": "C03",
+                                "sample identifier": "8/22/2023 12:16:57 PM C3",
+                                "location identifier": "C3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -18294,8 +18294,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM C04",
-                                "location identifier": "C04",
+                                "sample identifier": "8/22/2023 12:16:57 PM C4",
+                                "location identifier": "C4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -18336,8 +18336,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM C05",
-                                "location identifier": "C05",
+                                "sample identifier": "8/22/2023 12:16:57 PM C5",
+                                "location identifier": "C5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -18378,8 +18378,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM C06",
-                                "location identifier": "C06",
+                                "sample identifier": "8/22/2023 12:16:57 PM C6",
+                                "location identifier": "C6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -18420,8 +18420,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM C07",
-                                "location identifier": "C07",
+                                "sample identifier": "8/22/2023 12:16:57 PM C7",
+                                "location identifier": "C7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -18462,8 +18462,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM C08",
-                                "location identifier": "C08",
+                                "sample identifier": "8/22/2023 12:16:57 PM C8",
+                                "location identifier": "C8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -18504,8 +18504,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM C09",
-                                "location identifier": "C09",
+                                "sample identifier": "8/22/2023 12:16:57 PM C9",
+                                "location identifier": "C9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -19176,8 +19176,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM D01",
-                                "location identifier": "D01",
+                                "sample identifier": "8/22/2023 12:16:57 PM D1",
+                                "location identifier": "D1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -19218,8 +19218,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM D02",
-                                "location identifier": "D02",
+                                "sample identifier": "8/22/2023 12:16:57 PM D2",
+                                "location identifier": "D2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -19260,8 +19260,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM D03",
-                                "location identifier": "D03",
+                                "sample identifier": "8/22/2023 12:16:57 PM D3",
+                                "location identifier": "D3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -19302,8 +19302,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM D04",
-                                "location identifier": "D04",
+                                "sample identifier": "8/22/2023 12:16:57 PM D4",
+                                "location identifier": "D4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -19344,8 +19344,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM D05",
-                                "location identifier": "D05",
+                                "sample identifier": "8/22/2023 12:16:57 PM D5",
+                                "location identifier": "D5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -19386,8 +19386,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM D06",
-                                "location identifier": "D06",
+                                "sample identifier": "8/22/2023 12:16:57 PM D6",
+                                "location identifier": "D6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -19428,8 +19428,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM D07",
-                                "location identifier": "D07",
+                                "sample identifier": "8/22/2023 12:16:57 PM D7",
+                                "location identifier": "D7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -19470,8 +19470,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM D08",
-                                "location identifier": "D08",
+                                "sample identifier": "8/22/2023 12:16:57 PM D8",
+                                "location identifier": "D8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -19512,8 +19512,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM D09",
-                                "location identifier": "D09",
+                                "sample identifier": "8/22/2023 12:16:57 PM D9",
+                                "location identifier": "D9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -20184,8 +20184,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM E01",
-                                "location identifier": "E01",
+                                "sample identifier": "8/22/2023 12:16:57 PM E1",
+                                "location identifier": "E1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -20226,8 +20226,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM E02",
-                                "location identifier": "E02",
+                                "sample identifier": "8/22/2023 12:16:57 PM E2",
+                                "location identifier": "E2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -20268,8 +20268,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM E03",
-                                "location identifier": "E03",
+                                "sample identifier": "8/22/2023 12:16:57 PM E3",
+                                "location identifier": "E3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -20310,8 +20310,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM E04",
-                                "location identifier": "E04",
+                                "sample identifier": "8/22/2023 12:16:57 PM E4",
+                                "location identifier": "E4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -20352,8 +20352,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM E05",
-                                "location identifier": "E05",
+                                "sample identifier": "8/22/2023 12:16:57 PM E5",
+                                "location identifier": "E5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -20394,8 +20394,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM E06",
-                                "location identifier": "E06",
+                                "sample identifier": "8/22/2023 12:16:57 PM E6",
+                                "location identifier": "E6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -20436,8 +20436,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM E07",
-                                "location identifier": "E07",
+                                "sample identifier": "8/22/2023 12:16:57 PM E7",
+                                "location identifier": "E7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -20478,8 +20478,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM E08",
-                                "location identifier": "E08",
+                                "sample identifier": "8/22/2023 12:16:57 PM E8",
+                                "location identifier": "E8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -20520,8 +20520,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM E09",
-                                "location identifier": "E09",
+                                "sample identifier": "8/22/2023 12:16:57 PM E9",
+                                "location identifier": "E9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -21192,8 +21192,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM F01",
-                                "location identifier": "F01",
+                                "sample identifier": "8/22/2023 12:16:57 PM F1",
+                                "location identifier": "F1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -21234,8 +21234,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM F02",
-                                "location identifier": "F02",
+                                "sample identifier": "8/22/2023 12:16:57 PM F2",
+                                "location identifier": "F2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -21276,8 +21276,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM F03",
-                                "location identifier": "F03",
+                                "sample identifier": "8/22/2023 12:16:57 PM F3",
+                                "location identifier": "F3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -21318,8 +21318,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM F04",
-                                "location identifier": "F04",
+                                "sample identifier": "8/22/2023 12:16:57 PM F4",
+                                "location identifier": "F4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -21360,8 +21360,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM F05",
-                                "location identifier": "F05",
+                                "sample identifier": "8/22/2023 12:16:57 PM F5",
+                                "location identifier": "F5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -21402,8 +21402,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM F06",
-                                "location identifier": "F06",
+                                "sample identifier": "8/22/2023 12:16:57 PM F6",
+                                "location identifier": "F6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -21444,8 +21444,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM F07",
-                                "location identifier": "F07",
+                                "sample identifier": "8/22/2023 12:16:57 PM F7",
+                                "location identifier": "F7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -21486,8 +21486,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM F08",
-                                "location identifier": "F08",
+                                "sample identifier": "8/22/2023 12:16:57 PM F8",
+                                "location identifier": "F8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -21528,8 +21528,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM F09",
-                                "location identifier": "F09",
+                                "sample identifier": "8/22/2023 12:16:57 PM F9",
+                                "location identifier": "F9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -22200,8 +22200,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM G01",
-                                "location identifier": "G01",
+                                "sample identifier": "8/22/2023 12:16:57 PM G1",
+                                "location identifier": "G1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -22242,8 +22242,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM G02",
-                                "location identifier": "G02",
+                                "sample identifier": "8/22/2023 12:16:57 PM G2",
+                                "location identifier": "G2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -22284,8 +22284,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM G03",
-                                "location identifier": "G03",
+                                "sample identifier": "8/22/2023 12:16:57 PM G3",
+                                "location identifier": "G3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -22326,8 +22326,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM G04",
-                                "location identifier": "G04",
+                                "sample identifier": "8/22/2023 12:16:57 PM G4",
+                                "location identifier": "G4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -22368,8 +22368,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM G05",
-                                "location identifier": "G05",
+                                "sample identifier": "8/22/2023 12:16:57 PM G5",
+                                "location identifier": "G5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -22410,8 +22410,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM G06",
-                                "location identifier": "G06",
+                                "sample identifier": "8/22/2023 12:16:57 PM G6",
+                                "location identifier": "G6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -22452,8 +22452,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM G07",
-                                "location identifier": "G07",
+                                "sample identifier": "8/22/2023 12:16:57 PM G7",
+                                "location identifier": "G7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -22494,8 +22494,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM G08",
-                                "location identifier": "G08",
+                                "sample identifier": "8/22/2023 12:16:57 PM G8",
+                                "location identifier": "G8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -22536,8 +22536,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM G09",
-                                "location identifier": "G09",
+                                "sample identifier": "8/22/2023 12:16:57 PM G9",
+                                "location identifier": "G9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -23208,8 +23208,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM H01",
-                                "location identifier": "H01",
+                                "sample identifier": "8/22/2023 12:16:57 PM H1",
+                                "location identifier": "H1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -23250,8 +23250,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM H02",
-                                "location identifier": "H02",
+                                "sample identifier": "8/22/2023 12:16:57 PM H2",
+                                "location identifier": "H2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -23292,8 +23292,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM H03",
-                                "location identifier": "H03",
+                                "sample identifier": "8/22/2023 12:16:57 PM H3",
+                                "location identifier": "H3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -23334,8 +23334,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM H04",
-                                "location identifier": "H04",
+                                "sample identifier": "8/22/2023 12:16:57 PM H4",
+                                "location identifier": "H4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -23376,8 +23376,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM H05",
-                                "location identifier": "H05",
+                                "sample identifier": "8/22/2023 12:16:57 PM H5",
+                                "location identifier": "H5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -23418,8 +23418,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM H06",
-                                "location identifier": "H06",
+                                "sample identifier": "8/22/2023 12:16:57 PM H6",
+                                "location identifier": "H6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -23460,8 +23460,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM H07",
-                                "location identifier": "H07",
+                                "sample identifier": "8/22/2023 12:16:57 PM H7",
+                                "location identifier": "H7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -23502,8 +23502,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM H08",
-                                "location identifier": "H08",
+                                "sample identifier": "8/22/2023 12:16:57 PM H8",
+                                "location identifier": "H8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -23544,8 +23544,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM H09",
-                                "location identifier": "H09",
+                                "sample identifier": "8/22/2023 12:16:57 PM H9",
+                                "location identifier": "H9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -24216,8 +24216,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM I01",
-                                "location identifier": "I01",
+                                "sample identifier": "8/22/2023 12:16:57 PM I1",
+                                "location identifier": "I1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -24258,8 +24258,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM I02",
-                                "location identifier": "I02",
+                                "sample identifier": "8/22/2023 12:16:57 PM I2",
+                                "location identifier": "I2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -24300,8 +24300,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM I03",
-                                "location identifier": "I03",
+                                "sample identifier": "8/22/2023 12:16:57 PM I3",
+                                "location identifier": "I3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -24342,8 +24342,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM I04",
-                                "location identifier": "I04",
+                                "sample identifier": "8/22/2023 12:16:57 PM I4",
+                                "location identifier": "I4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -24384,8 +24384,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM I05",
-                                "location identifier": "I05",
+                                "sample identifier": "8/22/2023 12:16:57 PM I5",
+                                "location identifier": "I5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -24426,8 +24426,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM I06",
-                                "location identifier": "I06",
+                                "sample identifier": "8/22/2023 12:16:57 PM I6",
+                                "location identifier": "I6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -24468,8 +24468,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM I07",
-                                "location identifier": "I07",
+                                "sample identifier": "8/22/2023 12:16:57 PM I7",
+                                "location identifier": "I7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -24510,8 +24510,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM I08",
-                                "location identifier": "I08",
+                                "sample identifier": "8/22/2023 12:16:57 PM I8",
+                                "location identifier": "I8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -24552,8 +24552,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM I09",
-                                "location identifier": "I09",
+                                "sample identifier": "8/22/2023 12:16:57 PM I9",
+                                "location identifier": "I9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -25224,8 +25224,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM J01",
-                                "location identifier": "J01",
+                                "sample identifier": "8/22/2023 12:16:57 PM J1",
+                                "location identifier": "J1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -25266,8 +25266,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM J02",
-                                "location identifier": "J02",
+                                "sample identifier": "8/22/2023 12:16:57 PM J2",
+                                "location identifier": "J2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -25308,8 +25308,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM J03",
-                                "location identifier": "J03",
+                                "sample identifier": "8/22/2023 12:16:57 PM J3",
+                                "location identifier": "J3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -25350,8 +25350,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM J04",
-                                "location identifier": "J04",
+                                "sample identifier": "8/22/2023 12:16:57 PM J4",
+                                "location identifier": "J4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -25392,8 +25392,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM J05",
-                                "location identifier": "J05",
+                                "sample identifier": "8/22/2023 12:16:57 PM J5",
+                                "location identifier": "J5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -25434,8 +25434,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM J06",
-                                "location identifier": "J06",
+                                "sample identifier": "8/22/2023 12:16:57 PM J6",
+                                "location identifier": "J6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -25476,8 +25476,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM J07",
-                                "location identifier": "J07",
+                                "sample identifier": "8/22/2023 12:16:57 PM J7",
+                                "location identifier": "J7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -25518,8 +25518,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM J08",
-                                "location identifier": "J08",
+                                "sample identifier": "8/22/2023 12:16:57 PM J8",
+                                "location identifier": "J8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -25560,8 +25560,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM J09",
-                                "location identifier": "J09",
+                                "sample identifier": "8/22/2023 12:16:57 PM J9",
+                                "location identifier": "J9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -26232,8 +26232,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM K01",
-                                "location identifier": "K01",
+                                "sample identifier": "8/22/2023 12:16:57 PM K1",
+                                "location identifier": "K1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -26274,8 +26274,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM K02",
-                                "location identifier": "K02",
+                                "sample identifier": "8/22/2023 12:16:57 PM K2",
+                                "location identifier": "K2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -26316,8 +26316,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM K03",
-                                "location identifier": "K03",
+                                "sample identifier": "8/22/2023 12:16:57 PM K3",
+                                "location identifier": "K3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -26358,8 +26358,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM K04",
-                                "location identifier": "K04",
+                                "sample identifier": "8/22/2023 12:16:57 PM K4",
+                                "location identifier": "K4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -26400,8 +26400,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM K05",
-                                "location identifier": "K05",
+                                "sample identifier": "8/22/2023 12:16:57 PM K5",
+                                "location identifier": "K5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -26442,8 +26442,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM K06",
-                                "location identifier": "K06",
+                                "sample identifier": "8/22/2023 12:16:57 PM K6",
+                                "location identifier": "K6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -26484,8 +26484,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM K07",
-                                "location identifier": "K07",
+                                "sample identifier": "8/22/2023 12:16:57 PM K7",
+                                "location identifier": "K7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -26526,8 +26526,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM K08",
-                                "location identifier": "K08",
+                                "sample identifier": "8/22/2023 12:16:57 PM K8",
+                                "location identifier": "K8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -26568,8 +26568,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM K09",
-                                "location identifier": "K09",
+                                "sample identifier": "8/22/2023 12:16:57 PM K9",
+                                "location identifier": "K9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -27240,8 +27240,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM L01",
-                                "location identifier": "L01",
+                                "sample identifier": "8/22/2023 12:16:57 PM L1",
+                                "location identifier": "L1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -27282,8 +27282,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM L02",
-                                "location identifier": "L02",
+                                "sample identifier": "8/22/2023 12:16:57 PM L2",
+                                "location identifier": "L2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -27324,8 +27324,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM L03",
-                                "location identifier": "L03",
+                                "sample identifier": "8/22/2023 12:16:57 PM L3",
+                                "location identifier": "L3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -27366,8 +27366,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM L04",
-                                "location identifier": "L04",
+                                "sample identifier": "8/22/2023 12:16:57 PM L4",
+                                "location identifier": "L4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -27408,8 +27408,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM L05",
-                                "location identifier": "L05",
+                                "sample identifier": "8/22/2023 12:16:57 PM L5",
+                                "location identifier": "L5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -27450,8 +27450,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM L06",
-                                "location identifier": "L06",
+                                "sample identifier": "8/22/2023 12:16:57 PM L6",
+                                "location identifier": "L6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -27492,8 +27492,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM L07",
-                                "location identifier": "L07",
+                                "sample identifier": "8/22/2023 12:16:57 PM L7",
+                                "location identifier": "L7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -27534,8 +27534,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM L08",
-                                "location identifier": "L08",
+                                "sample identifier": "8/22/2023 12:16:57 PM L8",
+                                "location identifier": "L8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -27576,8 +27576,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM L09",
-                                "location identifier": "L09",
+                                "sample identifier": "8/22/2023 12:16:57 PM L9",
+                                "location identifier": "L9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -28248,8 +28248,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM M01",
-                                "location identifier": "M01",
+                                "sample identifier": "8/22/2023 12:16:57 PM M1",
+                                "location identifier": "M1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -28290,8 +28290,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM M02",
-                                "location identifier": "M02",
+                                "sample identifier": "8/22/2023 12:16:57 PM M2",
+                                "location identifier": "M2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -28332,8 +28332,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM M03",
-                                "location identifier": "M03",
+                                "sample identifier": "8/22/2023 12:16:57 PM M3",
+                                "location identifier": "M3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -28374,8 +28374,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM M04",
-                                "location identifier": "M04",
+                                "sample identifier": "8/22/2023 12:16:57 PM M4",
+                                "location identifier": "M4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -28416,8 +28416,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM M05",
-                                "location identifier": "M05",
+                                "sample identifier": "8/22/2023 12:16:57 PM M5",
+                                "location identifier": "M5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -28458,8 +28458,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM M06",
-                                "location identifier": "M06",
+                                "sample identifier": "8/22/2023 12:16:57 PM M6",
+                                "location identifier": "M6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -28500,8 +28500,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM M07",
-                                "location identifier": "M07",
+                                "sample identifier": "8/22/2023 12:16:57 PM M7",
+                                "location identifier": "M7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -28542,8 +28542,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM M08",
-                                "location identifier": "M08",
+                                "sample identifier": "8/22/2023 12:16:57 PM M8",
+                                "location identifier": "M8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -28584,8 +28584,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM M09",
-                                "location identifier": "M09",
+                                "sample identifier": "8/22/2023 12:16:57 PM M9",
+                                "location identifier": "M9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -29256,8 +29256,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM N01",
-                                "location identifier": "N01",
+                                "sample identifier": "8/22/2023 12:16:57 PM N1",
+                                "location identifier": "N1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -29298,8 +29298,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM N02",
-                                "location identifier": "N02",
+                                "sample identifier": "8/22/2023 12:16:57 PM N2",
+                                "location identifier": "N2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -29340,8 +29340,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM N03",
-                                "location identifier": "N03",
+                                "sample identifier": "8/22/2023 12:16:57 PM N3",
+                                "location identifier": "N3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -29382,8 +29382,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM N04",
-                                "location identifier": "N04",
+                                "sample identifier": "8/22/2023 12:16:57 PM N4",
+                                "location identifier": "N4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -29424,8 +29424,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM N05",
-                                "location identifier": "N05",
+                                "sample identifier": "8/22/2023 12:16:57 PM N5",
+                                "location identifier": "N5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -29466,8 +29466,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM N06",
-                                "location identifier": "N06",
+                                "sample identifier": "8/22/2023 12:16:57 PM N6",
+                                "location identifier": "N6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -29508,8 +29508,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM N07",
-                                "location identifier": "N07",
+                                "sample identifier": "8/22/2023 12:16:57 PM N7",
+                                "location identifier": "N7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -29550,8 +29550,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM N08",
-                                "location identifier": "N08",
+                                "sample identifier": "8/22/2023 12:16:57 PM N8",
+                                "location identifier": "N8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -29592,8 +29592,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM N09",
-                                "location identifier": "N09",
+                                "sample identifier": "8/22/2023 12:16:57 PM N9",
+                                "location identifier": "N9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -30264,8 +30264,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM O01",
-                                "location identifier": "O01",
+                                "sample identifier": "8/22/2023 12:16:57 PM O1",
+                                "location identifier": "O1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -30306,8 +30306,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM O02",
-                                "location identifier": "O02",
+                                "sample identifier": "8/22/2023 12:16:57 PM O2",
+                                "location identifier": "O2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -30348,8 +30348,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM O03",
-                                "location identifier": "O03",
+                                "sample identifier": "8/22/2023 12:16:57 PM O3",
+                                "location identifier": "O3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -30390,8 +30390,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM O04",
-                                "location identifier": "O04",
+                                "sample identifier": "8/22/2023 12:16:57 PM O4",
+                                "location identifier": "O4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -30432,8 +30432,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM O05",
-                                "location identifier": "O05",
+                                "sample identifier": "8/22/2023 12:16:57 PM O5",
+                                "location identifier": "O5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -30474,8 +30474,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM O06",
-                                "location identifier": "O06",
+                                "sample identifier": "8/22/2023 12:16:57 PM O6",
+                                "location identifier": "O6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -30516,8 +30516,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM O07",
-                                "location identifier": "O07",
+                                "sample identifier": "8/22/2023 12:16:57 PM O7",
+                                "location identifier": "O7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -30558,8 +30558,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM O08",
-                                "location identifier": "O08",
+                                "sample identifier": "8/22/2023 12:16:57 PM O8",
+                                "location identifier": "O8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -30600,8 +30600,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM O09",
-                                "location identifier": "O09",
+                                "sample identifier": "8/22/2023 12:16:57 PM O9",
+                                "location identifier": "O9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -31272,8 +31272,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM P01",
-                                "location identifier": "P01",
+                                "sample identifier": "8/22/2023 12:16:57 PM P1",
+                                "location identifier": "P1",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -31314,8 +31314,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM P02",
-                                "location identifier": "P02",
+                                "sample identifier": "8/22/2023 12:16:57 PM P2",
+                                "location identifier": "P2",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -31356,8 +31356,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM P03",
-                                "location identifier": "P03",
+                                "sample identifier": "8/22/2023 12:16:57 PM P3",
+                                "location identifier": "P3",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -31398,8 +31398,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM P04",
-                                "location identifier": "P04",
+                                "sample identifier": "8/22/2023 12:16:57 PM P4",
+                                "location identifier": "P4",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -31440,8 +31440,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM P05",
-                                "location identifier": "P05",
+                                "sample identifier": "8/22/2023 12:16:57 PM P5",
+                                "location identifier": "P5",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -31482,8 +31482,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM P06",
-                                "location identifier": "P06",
+                                "sample identifier": "8/22/2023 12:16:57 PM P6",
+                                "location identifier": "P6",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -31524,8 +31524,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM P07",
-                                "location identifier": "P07",
+                                "sample identifier": "8/22/2023 12:16:57 PM P7",
+                                "location identifier": "P7",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -31566,8 +31566,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM P08",
-                                "location identifier": "P08",
+                                "sample identifier": "8/22/2023 12:16:57 PM P8",
+                                "location identifier": "P8",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -31608,8 +31608,8 @@
                                 ]
                             },
                             "sample document": {
-                                "sample identifier": "8/22/2023 12:16:57 PM P09",
-                                "location identifier": "P09",
+                                "sample identifier": "8/22/2023 12:16:57 PM P9",
+                                "location identifier": "P9",
                                 "sample role type": "unknown sample role",
                                 "well plate identifier": "8/22/2023 12:16:57 PM"
                             },
@@ -32269,7 +32269,7 @@
             "software name": "EnVision Workstation",
             "software version": "1.14.3049.1193",
             "ASM converter name": "allotropy_perkinelmer_envision",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.54"
         },
         "calculated data aggregate document": {
             "calculated data document": [


### PR DESCRIPTION
This makes well identifiers inconsistent with other plate reader documents and standard practice.

The leading zero was only added to make sorting work in particular place in the code, updated the sorting to work without needing leading zero.