### PR TITLE
fix: Update DataSeries to use float parsing utility when reading a float value, in order to better handle edge cases

### DIFF
--- a/src/allotropy/parsers/utils/pandas.py
+++ b/src/allotropy/parsers/utils/pandas.py
@@ -308,7 +308,8 @@ class SeriesData:
             if type_ is float and isinstance(raw_value, str) and "%" in raw_value:
                 raw_value = raw_value.strip("%")
             convert = try_float_or_none if type_ is float else type_
-            value = None if raw_value is None else convert(raw_value)
+            # mypy can't figure out that try_float_or_none will only be used when type_ is float.
+            value = None if raw_value is None else convert(raw_value)  # type: ignore[operator]
         except ValueError:
             value = None
         return default if value is None else value

--- a/src/allotropy/parsers/utils/pandas.py
+++ b/src/allotropy/parsers/utils/pandas.py
@@ -21,7 +21,6 @@ from allotropy.parsers.utils.values import (
     assert_is_type,
     assert_not_none,
     str_to_bool,
-    try_float,
     try_float_or_none,
 )
 from allotropy.types import IOType

--- a/src/allotropy/parsers/utils/pandas.py
+++ b/src/allotropy/parsers/utils/pandas.py
@@ -21,6 +21,8 @@ from allotropy.parsers.utils.values import (
     assert_is_type,
     assert_not_none,
     str_to_bool,
+    try_float,
+    try_float_or_none,
 )
 from allotropy.types import IOType
 
@@ -306,7 +308,8 @@ class SeriesData:
                 )
             if type_ is float and isinstance(raw_value, str) and "%" in raw_value:
                 raw_value = raw_value.strip("%")
-            value = None if raw_value is None else type_(raw_value)
+            convert = try_float_or_none if type_ is float else type_
+            value = None if raw_value is None else convert(raw_value)
         except ValueError:
             value = None
         return default if value is None else value

--- a/tests/parsers/utils/pandas_test.py
+++ b/tests/parsers/utils/pandas_test.py
@@ -96,11 +96,13 @@ def test_get_float() -> None:
         pd.Series(
             {
                 "percent": "10.1%",
+                "comma": "10,0",
             }
         )
     )
 
     assert data.get(float, "percent") == 10.1
+    assert data.get(float, "comma") == 10.0
 
 
 def test_get_not_nan() -> None:


### PR DESCRIPTION
Having `DataSeries.get` use `try_float_or_none` allows it to handle all edge cases handled by `try_float`, e.g. parsing floats with comma decimals.