### PR TITLE
fix: SoftMax Pro - raise error for unsupported Group data format

### DIFF
--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
@@ -203,13 +203,15 @@ class GroupData:
         )
 
         samples = data["Sample"].ffill()
-        return GroupData(
-            name=name,
-            sample_data=[
+        try:
+            sample_data = [
                 GroupSampleData.create(data.iloc[sample_entries.index])
                 for _, sample_entries in samples.groupby(samples)
-            ],
-        )
+            ]
+        except ValueError as e:
+            msg = "Invalid data - unsupported Group data format."
+            raise AllotropeConversionError(msg) from e
+        return GroupData(name=name, sample_data=sample_data)
 
 
 @dataclass(frozen=True)

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_structure.py
@@ -209,7 +209,7 @@ class GroupData:
                 for _, sample_entries in samples.groupby(samples)
             ]
         except ValueError as e:
-            msg = "Invalid data - unsupported Group data format."
+            msg = f"Unable to read Group data format for group {name}."
             raise AllotropeConversionError(msg) from e
         return GroupData(name=name, sample_data=sample_data)
 


### PR DESCRIPTION
This error was reported in a sentry issue with only the traceback indicanting that a `ValueError` was raised.

Since there are no steps to reproduce but just the traceback I was unable to figure out the format in the `Group` data block that could result in this error, so no additional testing was added for this.