### PR TITLE
fix: ThermoFisher Qubit Flex - add fields that were accidentally removed/renamed in refactor

### DIFF
--- a/src/allotropy/allotrope/schema_mappers/adm/spectrophotometry/benchling/_2023/_12/spectrophotometry.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/spectrophotometry/benchling/_2023/_12/spectrophotometry.py
@@ -209,6 +209,7 @@ class Mapper(SchemaMapper[Data, Model]):
                     ASM_converter_name=self.converter_name,
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                     software_name=data.metadata.software_name,
+                    software_version=data.metadata.software_version,
                 ),
                 spectrophotometry_document=[
                     self._get_technique_document(measurement_group, data.metadata)

--- a/src/allotropy/parsers/thermo_fisher_qubit_flex/thermo_fisher_qubit_flex_structure.py
+++ b/src/allotropy/parsers/thermo_fisher_qubit_flex/thermo_fisher_qubit_flex_structure.py
@@ -54,7 +54,7 @@ def create_measurement_group(data: SeriesData) -> MeasurementGroup:
                 },
                 sample_custom_info={
                     "last read standards": data.get(str, "Test Date"),
-                    "selected standards": data.get(int, "Selected Samples"),
+                    "selected samples": data.get(int, "Selected Samples"),
                     "qubit tube concentration": {
                         "value": data.get(float, "Qubit Tube Conc.", NaN),
                         "unit": data.get(str, "Qubit tube conc. units", UNITLESS),

--- a/src/allotropy/parsers/thermo_fisher_qubit_flex/thermo_fisher_qubit_flex_structure.py
+++ b/src/allotropy/parsers/thermo_fisher_qubit_flex/thermo_fisher_qubit_flex_structure.py
@@ -18,7 +18,7 @@ from allotropy.allotrope.schema_mappers.adm.spectrophotometry.benchling._2023._1
 )
 from allotropy.parsers.constants import NOT_APPLICABLE
 from allotropy.parsers.thermo_fisher_qubit_flex import constants
-from allotropy.parsers.utils.pandas import map_rows, SeriesData
+from allotropy.parsers.utils.pandas import df_to_series_data, map_rows, SeriesData
 from allotropy.parsers.utils.uuids import random_uuid_str
 
 
@@ -99,17 +99,19 @@ def create_measurement_group(data: SeriesData) -> MeasurementGroup:
     )
 
 
-def create_data(data_frame: pd.DataFrame, file_name: str) -> Data:
+def create_data(df: pd.DataFrame, file_name: str) -> Data:
+    header = df_to_series_data(df.head(1))
     return Data(
         metadata=Metadata(
             file_name=file_name,
             device_identifier=NOT_APPLICABLE,
             model_number=constants.MODEL_NUMBER,
             software_name=constants.SOFTWARE_NAME,
+            software_version=header.get(str, "Software Version"),
             product_manufacturer=constants.PRODUCT_MANUFACTURER,
             brand_name=constants.BRAND_NAME,
             device_type=constants.DEVICE_TYPE,
             container_type=ContainerType.tube,
         ),
-        measurement_groups=map_rows(data_frame, create_measurement_group),
+        measurement_groups=map_rows(df, create_measurement_group),
     )

--- a/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_01.json
+++ b/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_01.json
@@ -450,6 +450,7 @@
         "data system document": {
             "file name": "thermo_fisher_qubit_flex_example_01.csv",
             "software name": "Qubit Flex software",
+            "software version": "1.5.0",
             "ASM converter name": "allotropy_thermo_fisher_qubit_flex",
             "ASM converter version": "0.1.57"
         }

--- a/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_01.json
+++ b/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_01.json
@@ -43,7 +43,7 @@
                                 "batch identifier": "131222-164034",
                                 "custom information document": {
                                     "last read standards": "2022-12-13T16:41:09+00:00",
-                                    "selected standards": 6,
+                                    "selected samples": 6,
                                     "qubit tube concentration": {
                                         "value": 2.64,
                                         "unit": "ug/mL"
@@ -116,7 +116,7 @@
                                 "batch identifier": "131222-164034",
                                 "custom information document": {
                                     "last read standards": "2022-12-13T16:41:09+00:00",
-                                    "selected standards": 6,
+                                    "selected samples": 6,
                                     "qubit tube concentration": {
                                         "value": 3.05,
                                         "unit": "ug/mL"
@@ -189,7 +189,7 @@
                                 "batch identifier": "131222-164034",
                                 "custom information document": {
                                     "last read standards": "2022-12-13T16:41:09+00:00",
-                                    "selected standards": 6,
+                                    "selected samples": 6,
                                     "qubit tube concentration": {
                                         "value": 2.67,
                                         "unit": "ug/mL"
@@ -262,7 +262,7 @@
                                 "batch identifier": "131222-164034",
                                 "custom information document": {
                                     "last read standards": "2022-12-13T16:41:09+00:00",
-                                    "selected standards": 6,
+                                    "selected samples": 6,
                                     "qubit tube concentration": {
                                         "value": 1.86,
                                         "unit": "ug/mL"
@@ -335,7 +335,7 @@
                                 "batch identifier": "131222-164034",
                                 "custom information document": {
                                     "last read standards": "2022-12-13T16:41:09+00:00",
-                                    "selected standards": 6,
+                                    "selected samples": 6,
                                     "qubit tube concentration": {
                                         "value": 2.73,
                                         "unit": "ug/mL"
@@ -408,7 +408,7 @@
                                 "batch identifier": "131222-164034",
                                 "custom information document": {
                                     "last read standards": "2022-12-13T16:41:09+00:00",
-                                    "selected standards": 6,
+                                    "selected samples": 6,
                                     "qubit tube concentration": {
                                         "value": 2.43,
                                         "unit": "ug/mL"
@@ -451,7 +451,7 @@
             "file name": "thermo_fisher_qubit_flex_example_01.csv",
             "software name": "Qubit Flex software",
             "ASM converter name": "allotropy_thermo_fisher_qubit_flex",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.57"
         }
     }
 }


### PR DESCRIPTION
Add back software version, rename "selected standards" back to "selected samples", accidentally deleted here: https://github.com/Benchling-Open-Source/allotropy/pull/699/files