### PR TITLE
feat: include unc path in all existing adapters

### DIFF
--- a/src/allotropy/allotrope/schema_mappers/adm/light_obscuration/benchling/_2023/_12/light_obscuration.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/light_obscuration/benchling/_2023/_12/light_obscuration.py
@@ -95,6 +95,7 @@ class MeasurementGroup:
 @dataclass(frozen=True)
 class Metadata:
     file_name: str
+    unc_path: str
     equipment_serial_number: str
     detector_identifier: str
     detector_model_number: str
@@ -127,6 +128,7 @@ class Mapper(SchemaMapper[Data, Model]):
                 data_system_document=DataSystemDocument(
                     file_name=data.metadata.file_name,
                     software_name=data.metadata.software_name,
+                    UNC_path=data.metadata.unc_path,
                     software_version=data.metadata.software_version,
                     ASM_converter_name=self.converter_name,
                     ASM_converter_version=ASM_CONVERTER_VERSION,

--- a/src/allotropy/allotrope/schema_mappers/adm/multi_analyte_profiling/benchling/_2024/_01/multi_analyte_profiling.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/multi_analyte_profiling/benchling/_2024/_01/multi_analyte_profiling.py
@@ -97,6 +97,7 @@ class Calibration:
 @dataclass(frozen=True)
 class Metadata:
     file_name: str
+    unc_path: str
     device_type: str
     model_number: str | None = None
     software_name: str | None = None
@@ -133,6 +134,7 @@ class Mapper(SchemaMapper[Data, Model]):
                 data_system_document=DataSystemDocument(
                     data_system_instance_identifier=data.metadata.data_system_instance_identifier,
                     file_name=data.metadata.file_name,
+                    UNC_path=data.metadata.unc_path,
                     software_name=data.metadata.software_name,
                     software_version=data.metadata.software_version,
                     ASM_converter_name=self.converter_name,

--- a/src/allotropy/allotrope/schema_mappers/adm/pcr/BENCHLING/_2023/_09/dpcr.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/pcr/BENCHLING/_2023/_09/dpcr.py
@@ -121,6 +121,7 @@ class Mapper(SchemaMapper[Data, Model]):
                 ),
                 data_system_document=DataSystemDocument(
                     file_name=data.metadata.file_name,
+                    UNC_path=data.metadata.unc_path,
                     software_name=data.metadata.software_name,
                     ASM_converter_name=self.converter_name,
                     ASM_converter_version=ASM_CONVERTER_VERSION,

--- a/src/allotropy/allotrope/schema_mappers/adm/spectrophotometry/benchling/_2023/_12/spectrophotometry.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/spectrophotometry/benchling/_2023/_12/spectrophotometry.py
@@ -206,6 +206,7 @@ class Mapper(SchemaMapper[Data, Model]):
                 ),
                 data_system_document=DataSystemDocument(
                     file_name=data.metadata.file_name,
+                    UNC_path=data.metadata.unc_path,
                     ASM_converter_name=self.converter_name,
                     ASM_converter_version=ASM_CONVERTER_VERSION,
                     software_name=data.metadata.software_name,

--- a/src/allotropy/named_file_contents.py
+++ b/src/allotropy/named_file_contents.py
@@ -21,9 +21,9 @@ class NamedFileContents:
     """
 
     contents: IOType
-    original_file_name: str
+    original_file_path: str
     encoding: str | None = None
 
     @cached_property
     def extension(self) -> str:
-        return PureWindowsPath(self.original_file_name).suffix[1:]
+        return PureWindowsPath(self.original_file_path).suffix[1:]

--- a/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
+++ b/src/allotropy/parsers/agilent_gen5/agilent_gen5_parser.py
@@ -40,7 +40,7 @@ class AgilentGen5Parser(VendorParser[Data, Model]):
             raise AllotropeConversionError(DEFAULT_EXPORT_FORMAT_ERROR)
 
         header_data = HeaderData.create(
-            reader.header_data, named_file_contents.original_file_name
+            reader.header_data, named_file_contents.original_file_path
         )
         read_data = ReadData.create(reader.sections["Procedure Details"])
         kinetic_data = KineticData.create(reader.sections["Procedure Details"])

--- a/src/allotropy/parsers/agilent_gen5/agilent_gen5_structure.py
+++ b/src/allotropy/parsers/agilent_gen5/agilent_gen5_structure.py
@@ -78,9 +78,11 @@ class HeaderData:
     equipment_serial_number: str | None
     plate_well_count: float
     file_name: str
+    unc_path: str
 
     @classmethod
-    def create(cls, data: SeriesData, file_name: str) -> HeaderData:
+    def create(cls, data: SeriesData, file_path: str) -> HeaderData:
+        file_name = Path(file_path).name
         matches = re.match(FILENAME_REGEX, file_name)
         plate_identifier = matches.groupdict()["plate_identifier"] if matches else None
         plate_well_count = cls._extract_well_count(data[str, "Plate Type"])
@@ -88,6 +90,7 @@ class HeaderData:
             software_version=data[str, "Software Version"],
             experiment_file_path=data.get(str, "Experiment File Path:"),
             file_name=file_name,
+            unc_path=file_path,
             protocol_file_path=data.get(str, "Protocol File Path:"),
             datetime=f'{data[str, "Date"]} {data[str, "Time"]}',
             well_plate_identifier=plate_identifier or data.get(str, "Plate Number"),
@@ -784,7 +787,7 @@ def create_metadata(header_data: HeaderData) -> Metadata:
         file_name=header_data.file_name,
         asm_file_identifier=asm_file_identifier.name,
         data_system_instance_id=NOT_APPLICABLE,
-        unc_path=NOT_APPLICABLE,
+        unc_path=header_data.unc_path,
     )
 
 

--- a/src/allotropy/parsers/agilent_gen5_image/agilent_gen5_image_parser.py
+++ b/src/allotropy/parsers/agilent_gen5_image/agilent_gen5_image_parser.py
@@ -30,7 +30,7 @@ class AgilentGen5ImageParser(VendorParser[Data, Model]):
         reader = AgilentGen5Reader(named_file_contents)
 
         header_data = HeaderData.create(
-            reader.header_data, named_file_contents.original_file_name
+            reader.header_data, named_file_contents.original_file_path
         )
         read_data = ReadData.create(reader.sections["Procedure Details"])
 

--- a/src/allotropy/parsers/agilent_gen5_image/agilent_gen5_image_structure.py
+++ b/src/allotropy/parsers/agilent_gen5_image/agilent_gen5_image_structure.py
@@ -345,6 +345,7 @@ def create_metadata(header_data: HeaderData) -> Metadata:
         software_name=DEFAULT_SOFTWARE_NAME,
         software_version=header_data.software_version,
         file_name=header_data.file_name,
+        unc_path=header_data.unc_path,
     )
 
 

--- a/src/allotropy/parsers/agilent_tapestation_analysis/agilent_tapestation_analysis_parser.py
+++ b/src/allotropy/parsers/agilent_tapestation_analysis/agilent_tapestation_analysis_parser.py
@@ -34,7 +34,7 @@ class AgilentTapestationAnalysisParser(VendorParser[Data, Model]):
 
         measurement_groups, calculated_data = create_measurement_groups(root_element)
         return Data(
-            create_metadata(root_element, named_file_contents.original_file_name),
+            create_metadata(root_element, named_file_contents.original_file_path),
             measurement_groups,
             # NOTE: in current implementation, calculated data is reported at global level for some reason.
             # TODO(nstender): should we move this inside of measurements?

--- a/src/allotropy/parsers/agilent_tapestation_analysis/agilent_tapestation_analysis_structure.py
+++ b/src/allotropy/parsers/agilent_tapestation_analysis/agilent_tapestation_analysis_structure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from xml.etree import ElementTree as ET  # noqa: N817
 
 from allotropy.allotrope.models.shared.definitions.units import UNITLESS
@@ -62,13 +63,14 @@ def _get_calculated_data(
     return calculated_data
 
 
-def create_metadata(root_element: ET.Element, file_name: str) -> Metadata:
+def create_metadata(root_element: ET.Element, file_path: str) -> Metadata:
     file_information = get_element_from_xml(root_element, "FileInformation")
     environment = get_element_from_xml(
         root_element, "ScreenTapes/ScreenTape/Environment"
     )
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         analyst=get_val_from_xml_or_none(environment, "Experimenter"),
         analytical_method_identifier=get_val_from_xml_or_none(
             file_information, "Assay"

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_parser.py
@@ -32,7 +32,7 @@ class AppbioAbsoluteQParser(VendorParser[Data, Model]):
         return Data(
             create_metadata(
                 wells[0].items[0].instrument_identifier,
-                named_file_contents.original_file_name,
+                named_file_contents.original_file_path,
             ),
             create_measurement_groups(wells),
             calculated_data=create_calculated_data(wells, groups),

--- a/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_structure.py
+++ b/src/allotropy/parsers/appbio_absolute_q/appbio_absolute_q_structure.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -218,7 +219,7 @@ def create_calculated_data(
     ]
 
 
-def create_metadata(device_identifier: str, file_name: str) -> Metadata:
+def create_metadata(device_identifier: str, file_path: str) -> Metadata:
     return Metadata(
         device_identifier=device_identifier,
         brand_name=BRAND_NAME,
@@ -226,5 +227,6 @@ def create_metadata(device_identifier: str, file_name: str) -> Metadata:
         container_type=ContainerType.well_plate,
         software_name=SOFTWARE_NAME,
         product_manufacturer=PRODUCT_MANUFACTURER,
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
     )

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_data_creator.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_data_creator.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from pathlib import Path
 
 from allotropy.allotrope.models.shared.definitions.definitions import (
     FieldComponentDatatype,
@@ -200,7 +201,7 @@ def _create_measurement(
     )
 
 
-def create_metadata(header: Header, file_name: str) -> Metadata:
+def create_metadata(header: Header, file_path: str) -> Metadata:
     return Metadata(
         device_identifier=header.device_identifier,
         device_type=constants.DEVICE_TYPE,
@@ -209,8 +210,8 @@ def create_metadata(header: Header, file_name: str) -> Metadata:
         software_name=constants.SOFTWARE_NAME,
         software_version=constants.SOFTWARE_VERSION,
         data_system_instance_identifier=constants.DATA_SYSTEM_INSTANCE_IDENTIFIER,
-        file_name=file_name,
-        unc_path="",  # unknown
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         measurement_method_identifier=header.measurement_method_identifier,
         experiment_type=header.experiment_type,
         container_type=constants.CONTAINER_TYPE,

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
@@ -53,7 +53,7 @@ class AppBioQuantStudioParser(VendorParser[Data, Model]):
         )
 
         return Data(
-            metadata=create_metadata(header, named_file_contents.original_file_name),
+            metadata=create_metadata(header, named_file_contents.original_file_path),
             measurement_groups=create_measurement_groups(
                 header, wells, amp_data, multi_data, results_data, melt_data
             ),

--- a/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_data_creator.py
+++ b/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_data_creator.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from allotropy.allotrope.models.adm.pcr.benchling._2023._09.qpcr import (
     ExperimentType,
 )
@@ -60,16 +62,16 @@ from allotropy.parsers.appbio_quantstudio_designandanalysis.structure.standard_c
 
 
 def create_metadata(
-    header: Header, file_name: str, experiment_type: ExperimentType
+    header: Header, file_path: str, experiment_type: ExperimentType
 ) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         product_manufacturer=constants.PRODUCT_MANUFACTURER,
         device_identifier=header.device_identifier,
         model_number=header.model_number,
         device_serial_number=header.device_serial_number,
         data_system_instance_identifier=constants.DATA_SYSTEM_INSTANCE_IDENTIFIER,
-        unc_path="",  # unknown
         software_name=header.software_name,
         software_version=header.software_version,
         container_type=constants.CONTAINER_TYPE,

--- a/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio_designandanalysis/appbio_quantstudio_designandanalysis_parser.py
@@ -28,7 +28,7 @@ class AppBioQuantStudioDesignandanalysisParser(VendorParser[Data, Model]):
         return Data(
             create_metadata(
                 data.header,
-                named_file_contents.original_file_name,
+                named_file_contents.original_file_path,
                 data.experiment_type,
             ),
             create_measurement_groups(data.wells.wells, data.header),

--- a/src/allotropy/parsers/beckman_pharmspec/beckman_pharmspec_parser.py
+++ b/src/allotropy/parsers/beckman_pharmspec/beckman_pharmspec_parser.py
@@ -32,7 +32,7 @@ class PharmSpecParser(VendorParser[Data, Model]):
         header = Header.create(reader.header)
 
         return Data(
-            create_metadata(header, named_file_contents.original_file_name),
+            create_metadata(header, named_file_contents.original_file_path),
             create_measurement_groups(header, distributions),
             create_calculated_data(distributions),
         )

--- a/src/allotropy/parsers/beckman_pharmspec/beckman_pharmspec_structure.py
+++ b/src/allotropy/parsers/beckman_pharmspec/beckman_pharmspec_structure.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
+from pathlib import Path
 import re
 
 import pandas as pd
@@ -102,9 +103,10 @@ class Header:
         )
 
 
-def create_metadata(header: Header, file_name: str) -> Metadata:
+def create_metadata(header: Header, file_path: str) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         software_name=PHARMSPEC_SOFTWARE_NAME,
         software_version=header.software_version,
         detector_identifier=header.detector_identifier,

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
@@ -26,7 +26,7 @@ class ViCellBluParser(VendorParser[Data, Model]):
 
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
         return Data(
-            create_metadata(named_file_contents.original_file_name),
+            create_metadata(named_file_contents.original_file_path),
             map_rows(
                 ViCellBluReader.read(named_file_contents), create_measurement_group
             ),

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_structure.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_structure.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
     Measurement,
     MeasurementGroup,
@@ -55,11 +57,12 @@ def create_measurement_group(data: SeriesData) -> MeasurementGroup:
     )
 
 
-def create_metadata(file_name: str) -> Metadata:
+def create_metadata(file_path: str) -> Metadata:
     return Metadata(
         device_type=DEVICE_TYPE,
         detection_type=DETECTION_TYPE,
         model_number=DEFAULT_MODEL_NUMBER,
         software_name=VICELL_BLU_SOFTWARE_NAME,
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
     )

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_parser.py
@@ -31,6 +31,6 @@ class ViCellXRParser(VendorParser[Data, Model]):
             raise AllotropeConversionError(msg)
 
         return Data(
-            create_metadata(reader_data, named_file_contents.original_file_name),
+            create_metadata(reader_data, named_file_contents.original_file_path),
             [create_measurement_group(row) for row in reader_data.data],
         )

--- a/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_structure.py
+++ b/src/allotropy/parsers/beckman_vi_cell_xr/vi_cell_xr_structure.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
     Measurement,
     MeasurementGroup,
@@ -48,7 +50,7 @@ def create_measurement_group(data: SeriesData) -> MeasurementGroup:
     )
 
 
-def create_metadata(reader_data: ViCellData, file_name: str) -> Metadata:
+def create_metadata(reader_data: ViCellData, file_path: str) -> Metadata:
     return Metadata(
         device_type=DEVICE_TYPE,
         detection_type=DETECTION_TYPE,
@@ -56,5 +58,6 @@ def create_metadata(reader_data: ViCellData, file_name: str) -> Metadata:
         equipment_serial_number=reader_data.serial_number,
         software_name=SOFTWARE_NAME,
         software_version=reader_data.version.value,
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
     )

--- a/src/allotropy/parsers/biorad_bioplex_manager/biorad_bioplex_manager_parser.py
+++ b/src/allotropy/parsers/biorad_bioplex_manager/biorad_bioplex_manager_parser.py
@@ -37,7 +37,7 @@ class BioradBioplexParser(VendorParser[Data, Model]):
 
         return Data(
             create_metadata(
-                reader.root, system_metadata, named_file_contents.original_file_name
+                reader.root, system_metadata, named_file_contents.original_file_path
             ),
             [
                 create_measurement_group(

--- a/src/allotropy/parsers/biorad_bioplex_manager/biorad_bioplex_manager_structure.py
+++ b/src/allotropy/parsers/biorad_bioplex_manager/biorad_bioplex_manager_structure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 import xml.etree.ElementTree as Et
 
 from allotropy.allotrope.models.shared.components.plate_reader import SampleRoleType
@@ -210,10 +211,11 @@ def get_well_name(well_attrib: dict[str, str]) -> str:
 
 
 def create_metadata(
-    root_xml: Et.Element, system_metadata: SystemMetadata, file_name: str
+    root_xml: Et.Element, system_metadata: SystemMetadata, file_path: str
 ) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         software_name=constants.SOFTWARE_NAME,
         software_version=root_xml.attrib["BioPlexManagerVersion"],
         equipment_serial_number=system_metadata.serial_number,

--- a/src/allotropy/parsers/bmg_mars/bmg_mars_parser.py
+++ b/src/allotropy/parsers/bmg_mars/bmg_mars_parser.py
@@ -28,6 +28,6 @@ class BmgMarsParser(VendorParser[Data, Model]):
         reader = BmgMarsReader(named_file_contents)
         header = Header.create(reader.header, reader.header_content)
         return Data(
-            create_metadata(header, named_file_contents.original_file_name),
+            create_metadata(header, named_file_contents.original_file_path),
             create_measurement_groups(reader.data, header),
         )

--- a/src/allotropy/parsers/bmg_mars/bmg_mars_structure.py
+++ b/src/allotropy/parsers/bmg_mars/bmg_mars_structure.py
@@ -98,7 +98,7 @@ class Header:
 
 
 def create_metadata(header: Header, file_path: str) -> Metadata:
-    asm_file_identifier = Path(file_path).with_suffix(".json").name
+    asm_file_identifier = Path(file_path).with_suffix(".json")
     return Metadata(
         file_name=Path(file_path).name,
         asm_file_identifier=asm_file_identifier.name,

--- a/src/allotropy/parsers/bmg_mars/bmg_mars_structure.py
+++ b/src/allotropy/parsers/bmg_mars/bmg_mars_structure.py
@@ -97,12 +97,12 @@ class Header:
         )
 
 
-def create_metadata(header: Header, file_name: str) -> Metadata:
-    asm_file_identifier = Path(file_name).with_suffix(".json")
+def create_metadata(header: Header, file_path: str) -> Metadata:
+    asm_file_identifier = Path(file_path).with_suffix(".json").name
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
         asm_file_identifier=asm_file_identifier.name,
-        unc_path=header.path,
+        unc_path=header.path or file_path,
         device_identifier=NOT_APPLICABLE,
         model_number=NOT_APPLICABLE,
         data_system_instance_id=NOT_APPLICABLE,

--- a/src/allotropy/parsers/chemometec_nc_view/chemometec_nc_view_parser.py
+++ b/src/allotropy/parsers/chemometec_nc_view/chemometec_nc_view_parser.py
@@ -28,6 +28,6 @@ class ChemometecNcViewParser(VendorParser[Data, Model]):
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
         reader = ChemometecNcViewReader(named_file_contents)
         return Data(
-            create_metadata(reader.header, named_file_contents.original_file_name),
+            create_metadata(reader.header, named_file_contents.original_file_path),
             map_rows(reader.data, create_measurement_groups),
         )

--- a/src/allotropy/parsers/chemometec_nc_view/chemometec_nc_view_structure.py
+++ b/src/allotropy/parsers/chemometec_nc_view/chemometec_nc_view_structure.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from pathlib import Path
 
 from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
     Measurement,
@@ -12,16 +13,16 @@ from allotropy.parsers.utils.uuids import random_uuid_str
 from allotropy.parsers.utils.values import try_float_or_none
 
 
-def create_metadata(data: SeriesData, file_name: str) -> Metadata:
+def create_metadata(data: SeriesData, file_path: str) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         software_name=constants.SOFTWARE_NAME,
         device_type=constants.DEVICE_TYPE,
         equipment_serial_number=data[str, "INSTRUMENT"].split(":")[-1].strip(),
         product_manufacturer=constants.PRODUCT_MANUFACTURER,
         detection_type=constants.DETECTION_TYPE,
         model_number=NOT_APPLICABLE,
-        unc_path=NOT_APPLICABLE,
     )
 
 

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
@@ -26,7 +26,7 @@ class ChemometecNucleoviewParser(VendorParser[Data, Model]):
         df = NucleoviewReader.read(named_file_contents.contents)
         return Data(
             create_metadata(
-                df_to_series_data(df.head(1)), named_file_contents.original_file_name
+                df_to_series_data(df.head(1)), named_file_contents.original_file_path
             ),
             map_rows(df, create_measurement_groups),
         )

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_structure.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_structure.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
 
 from allotropy.allotrope.models.shared.definitions.definitions import (
@@ -22,9 +24,10 @@ from allotropy.parsers.utils.pandas import SeriesData
 from allotropy.parsers.utils.uuids import random_uuid_str
 
 
-def create_metadata(data: SeriesData, file_name: str) -> Metadata:
+def create_metadata(data: SeriesData, file_path: str) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         model_number=data.get(str, "Instrument type", DEFAULT_MODEL_NUMBER),
         equipment_serial_number=data.get(str, "Instrument s/n"),
         software_name=NUCLEOCOUNTER_SOFTWARE_NAME,

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_parser.py
@@ -38,6 +38,6 @@ class ExampleWeylandYutaniParser(VendorParser[Data, Model]):
             raise AllotropeConversionError(msg)
 
         return Data(
-            create_metadata(instrument, named_file_contents.original_file_name),
+            create_metadata(instrument, named_file_contents.original_file_path),
             [create_measurement_group(plate, basic_assay_info) for plate in plates],
         )

--- a/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_structure.py
+++ b/src/allotropy/parsers/example_weyland_yutani/example_weyland_yutani_structure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
 import pandas as pd
 
@@ -86,9 +87,10 @@ class Plate:
         ]
 
 
-def create_metadata(instrument: Instrument, file_name: str) -> Metadata:
+def create_metadata(instrument: Instrument, file_path: str) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         model_number=instrument.serial_number,
         device_identifier=instrument.nickname,
     )

--- a/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
+++ b/src/allotropy/parsers/luminex_xponent/luminex_xponent_parser.py
@@ -29,7 +29,7 @@ class LuminexXponentParser(VendorParser[MapperData, Model]):
         data = Data.create(reader)
         return MapperData(
             create_metadata(
-                data.header, data.calibrations, named_file_contents.original_file_name
+                data.header, data.calibrations, named_file_contents.original_file_path
             ),
             create_measurement_groups(data.measurement_list.measurements, data.header),
         )

--- a/src/allotropy/parsers/luminex_xponent/luminex_xponent_structure.py
+++ b/src/allotropy/parsers/luminex_xponent/luminex_xponent_structure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 import re
 
 import pandas as pd
@@ -259,10 +260,11 @@ class Data:
 
 
 def create_metadata(
-    header: Header, calibrations: list[Calibration], file_name: str
+    header: Header, calibrations: list[Calibration], file_path: str
 ) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         equipment_serial_number=header.equipment_serial_number,
         model_number=header.model_number,
         calibrations=calibrations,

--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_parser.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_parser.py
@@ -42,7 +42,7 @@ class MabtechApexParser(VendorParser[Data, Model]):
             for measurements in measurements_per_well.values()
         ]
         data = Data(
-            create_metadata(reader.plate_info, named_file_contents.original_file_name),
+            create_metadata(reader.plate_info, named_file_contents.original_file_path),
             data_measurement,
         )
         return data

--- a/src/allotropy/parsers/mabtech_apex/mabtech_apex_structure.py
+++ b/src/allotropy/parsers/mabtech_apex/mabtech_apex_structure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 import re
 
 from allotropy.allotrope.models.shared.definitions.units import UNITLESS
@@ -20,7 +21,7 @@ from allotropy.parsers.utils.uuids import random_uuid_str
 from allotropy.parsers.utils.values import assert_not_none
 
 
-def create_metadata(plate_info: SeriesData, file_name: str) -> Metadata:
+def create_metadata(plate_info: SeriesData, file_path: str) -> Metadata:
     machine_id = assert_not_none(
         re.match(
             "([A-Z]+[a-z]*) ([0-9]+)",
@@ -32,11 +33,11 @@ def create_metadata(plate_info: SeriesData, file_name: str) -> Metadata:
     return Metadata(
         device_identifier=NOT_APPLICABLE,
         software_name=constants.SOFTWARE_NAME,
-        unc_path=plate_info.get(str, "Path:"),
         software_version=plate_info.get(str, "Software Version:"),
         model_number=machine_id.group(1),
         equipment_serial_number=machine_id.group(2),
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=plate_info.get(str, "Path:", file_path),
     )
 
 

--- a/src/allotropy/parsers/methodical_mind/methodical_mind_parser.py
+++ b/src/allotropy/parsers/methodical_mind/methodical_mind_parser.py
@@ -32,7 +32,7 @@ class MethodicalMindParser(VendorParser[Data, Model]):
         return Data(
             create_metadata(
                 Header.create(reader.plate_headers[0]),
-                named_file_contents.original_file_name,
+                named_file_contents.original_file_path,
             ),
             create_measurement_groups(
                 [PlateData.create(header, data) for header, data in reader]

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_data_creator.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_data_creator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from itertools import chain
+from pathlib import Path
 
 from allotropy.allotrope.models.shared.definitions.definitions import (
     FieldComponentDatatype,
@@ -29,15 +30,15 @@ from allotropy.parsers.moldev_softmax_pro.softmax_pro_structure import (
 from allotropy.parsers.utils.uuids import random_uuid_str
 
 
-def create_metadata(file_name: str) -> Metadata:
+def create_metadata(file_path: str) -> Metadata:
     return Metadata(
         asm_file_identifier=NOT_APPLICABLE,
         device_identifier=NOT_APPLICABLE,
         model_number=NOT_APPLICABLE,
         data_system_instance_id=NOT_APPLICABLE,
-        unc_path=NOT_APPLICABLE,
         software_name="SoftMax Pro",
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
     )
 
 

--- a/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
+++ b/src/allotropy/parsers/moldev_softmax_pro/softmax_pro_parser.py
@@ -29,7 +29,7 @@ class SoftmaxproParser(VendorParser[Data, Model]):
         data = StructureData.create(reader)
 
         return Data(
-            create_metadata(named_file_contents.original_file_name),
+            create_metadata(named_file_contents.original_file_path),
             create_measurement_groups(data),
             create_calculated_data(data),
         )

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_parser.py
@@ -30,9 +30,9 @@ class NovaBioFlexParser(VendorParser[Data, Model]):
         data = read_csv(
             named_file_contents.contents, parse_dates=["Date & Time"]
         ).replace(np.nan, None)
-        title = Title.create(named_file_contents.original_file_name)
+        title = Title.create(named_file_contents.original_file_path)
         sample_list = SampleList.create(data)
         return Data(
-            create_metadata(title, named_file_contents.original_file_name),
+            create_metadata(title, named_file_contents.original_file_path),
             create_measurement_groups(title, sample_list),
         )

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_structure.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_structure.py
@@ -35,7 +35,8 @@ class Title:
     device_identifier: str | None
 
     @staticmethod
-    def create(filename: str) -> Title:
+    def create(file_path: str) -> Title:
+        filename = Path(file_path).name
         matches = re.match(FILENAME_REGEX, filename, flags=re.IGNORECASE)
 
         if not matches:

--- a/src/allotropy/parsers/novabio_flex2/novabio_flex2_structure.py
+++ b/src/allotropy/parsers/novabio_flex2/novabio_flex2_structure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 import re
 from typing import Any
 
@@ -177,9 +178,10 @@ def _get_measurements(sample: Sample) -> list[Measurement]:
     return measurements
 
 
-def create_metadata(title: Title, file_name: str) -> Metadata:
+def create_metadata(title: Title, file_path: str) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         device_type=DEVICE_TYPE,
         model_number=MODEL_NUMBER,
         product_manufacturer=PRODUCT_MANUFACTURER,

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_parser.py
@@ -30,7 +30,7 @@ class PerkinElmerEnvisionParser(VendorParser[Data, Model]):
 
         return Data(
             create_metadata(
-                data.software, data.instrument, named_file_contents.original_file_name
+                data.software, data.instrument, named_file_contents.original_file_path
             ),
             create_measurement_groups(data),
             create_calculated_data(data.plate_list, data.labels.get_read_type()),

--- a/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
+++ b/src/allotropy/parsers/perkin_elmer_envision/perkin_elmer_envision_structure.py
@@ -692,13 +692,13 @@ class Data:
 
 
 def create_metadata(
-    software: Software, instrument: Instrument, file_name: str
+    software: Software, instrument: Instrument, file_path: str
 ) -> Metadata:
-    asm_file_identifier = Path(file_name).with_suffix(".json")
+    path = Path(file_path)
     return Metadata(
-        file_name=file_name,
-        asm_file_identifier=asm_file_identifier.name,
-        unc_path=NOT_APPLICABLE,
+        file_name=path.name,
+        unc_path=file_path,
+        asm_file_identifier=path.with_suffix(".json").name,
         software_name=software.software_name,
         software_version=software.software_version,
         model_number=constants.MODEL_NUMBER,

--- a/src/allotropy/parsers/qiacuity_dpcr/qiacuity_dpcr_parser.py
+++ b/src/allotropy/parsers/qiacuity_dpcr/qiacuity_dpcr_parser.py
@@ -26,7 +26,7 @@ class QiacuitydPCRParser(VendorParser[Data, Model]):
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
         reader = QiacuitydPCRReader(named_file_contents.contents)
         return Data(
-            create_metadata(named_file_contents.original_file_name),
+            create_metadata(named_file_contents.original_file_path),
             measurement_groups=[
                 MeasurementGroup(
                     measurements=map_rows(reader.well_data, create_measurements),

--- a/src/allotropy/parsers/qiacuity_dpcr/qiacuity_dpcr_structure.py
+++ b/src/allotropy/parsers/qiacuity_dpcr/qiacuity_dpcr_structure.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from allotropy.allotrope.schema_mappers.adm.pcr.BENCHLING._2023._09.dpcr import (
     Measurement,
     Metadata,
@@ -43,12 +45,13 @@ def create_measurements(data: SeriesData) -> Measurement:
     )
 
 
-def create_metadata(file_name: str) -> Metadata:
+def create_metadata(file_path: str) -> Metadata:
     return Metadata(
         device_identifier=DEVICE_IDENTIFIER,
         brand_name=BRAND_NAME,
         device_type=DEVICE_TYPE,
         software_name=SOFTWARE_NAME,
         product_manufacturer=PRODUCT_MANUFACTURER,
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
     )

--- a/src/allotropy/parsers/revvity_kaleido/kaleido_parser.py
+++ b/src/allotropy/parsers/revvity_kaleido/kaleido_parser.py
@@ -25,6 +25,6 @@ class KaleidoParser(VendorParser[Data, Model]):
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
         data = create_data(CsvReader(read_to_lines(named_file_contents)))
         return Data(
-            create_metadata(data, named_file_contents.original_file_name),
+            create_metadata(data, named_file_contents.original_file_path),
             create_measurement_groups(data),
         )

--- a/src/allotropy/parsers/revvity_kaleido/kaleido_structure.py
+++ b/src/allotropy/parsers/revvity_kaleido/kaleido_structure.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import Enum
 import logging
+from pathlib import Path
 import re
 
 import pandas as pd
@@ -456,9 +457,10 @@ class Data:
         )
 
 
-def create_metadata(data: Data, file_name: str) -> Metadata:
+def create_metadata(data: Data, file_path: str) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         software_name=constants.SOFTWARE_NAME,
         software_version=data.version,
         device_identifier=constants.DEVICE_IDENTIFIER,

--- a/src/allotropy/parsers/revvity_matrix/revvity_matrix_parser.py
+++ b/src/allotropy/parsers/revvity_matrix/revvity_matrix_parser.py
@@ -28,6 +28,6 @@ class RevvityMatrixParser(VendorParser[Data, Model]):
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
         reader = RevvityMatrixReader(named_file_contents)
         return Data(
-            create_metadata(named_file_contents.original_file_name),
+            create_metadata(named_file_contents.original_file_path),
             map_rows(reader.data, create_measurement_group),
         )

--- a/src/allotropy/parsers/revvity_matrix/revvity_matrix_structure.py
+++ b/src/allotropy/parsers/revvity_matrix/revvity_matrix_structure.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from pathlib import Path
 
 from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
     Error,
@@ -11,9 +12,10 @@ from allotropy.parsers.utils.pandas import SeriesData
 from allotropy.parsers.utils.uuids import random_uuid_str
 
 
-def create_metadata(file_name: str) -> Metadata:
+def create_metadata(file_path: str) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         device_type=constants.DEVICE_TYPE,
     )
 

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_parser.py
@@ -32,6 +32,6 @@ class RocheCedexBiohtParser(VendorParser[Data, Model]):
         samples = Sample.create_samples(reader.samples_data)
 
         return Data(
-            create_metadata(title, named_file_contents.original_file_name),
+            create_metadata(title, named_file_contents.original_file_path),
             measurement_groups=create_measurement_groups(samples, title),
         )

--- a/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_structure.py
+++ b/src/allotropy/parsers/roche_cedex_bioht/roche_cedex_bioht_structure.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
+from pathlib import Path
 
 from dateutil import parser
 import pandas as pd
@@ -202,14 +203,14 @@ def create_measurement_groups(
     return groups
 
 
-def create_metadata(title: Title, file_name: str) -> Metadata:
+def create_metadata(title: Title, file_path: str) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         device_type=SOLUTION_ANALYZER,
         model_number=title.model_number,
         equipment_serial_number=title.device_serial_number,
         device_identifier=NOT_APPLICABLE,
-        unc_path="",
         software_name=title.model_number,
         software_version=title.software_version,
     )

--- a/src/allotropy/parsers/roche_cedex_hires/roche_cedex_hires_parser.py
+++ b/src/allotropy/parsers/roche_cedex_hires/roche_cedex_hires_parser.py
@@ -28,6 +28,6 @@ class RocheCedexHiResParser(VendorParser[Data, Model]):
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
         reader = RocheCedexHiResReader(named_file_contents)
         return Data(
-            create_metadata(reader.header, named_file_contents.original_file_name),
+            create_metadata(reader.header, named_file_contents.original_file_path),
             map_rows(reader.data, create_measurement_groups),
         )

--- a/src/allotropy/parsers/roche_cedex_hires/roche_cedex_hires_structure.py
+++ b/src/allotropy/parsers/roche_cedex_hires/roche_cedex_hires_structure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from pathlib import Path
 
 from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
     Measurement,
@@ -12,9 +13,10 @@ from allotropy.parsers.utils.pandas import SeriesData
 from allotropy.parsers.utils.uuids import random_uuid_str
 
 
-def create_metadata(data: SeriesData, file_name: str) -> Metadata:
+def create_metadata(data: SeriesData, file_path: str) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         device_type=constants.DEVICE_TYPE,
         detection_type=constants.DETECTION_TYPE,
         model_number=constants.MODEL_NUMBER,

--- a/src/allotropy/parsers/thermo_fisher_genesys30/thermo_fisher_genesys30_parser.py
+++ b/src/allotropy/parsers/thermo_fisher_genesys30/thermo_fisher_genesys30_parser.py
@@ -27,6 +27,6 @@ class ThermoFisherGenesys30Parser(VendorParser[Data, Model]):
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
         reader = ThermoFisherGenesys30Reader(named_file_contents)
         return Data(
-            create_metadata(reader.header, named_file_contents.original_file_name),
+            create_metadata(reader.header, named_file_contents.original_file_path),
             create_measurement_groups(reader.header, reader.data),
         )

--- a/src/allotropy/parsers/thermo_fisher_genesys30/thermo_fisher_genesys30_structure.py
+++ b/src/allotropy/parsers/thermo_fisher_genesys30/thermo_fisher_genesys30_structure.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from pathlib import Path
 
 import pandas as pd
 
@@ -26,9 +27,10 @@ from allotropy.parsers.utils.pandas import SeriesData
 from allotropy.parsers.utils.uuids import random_uuid_str
 
 
-def create_metadata(header: SeriesData, file_name: str) -> Metadata:
+def create_metadata(header: SeriesData, file_path: str) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         device_type=constants.DEVICE_TYPE,
         device_identifier=NOT_APPLICABLE,
         model_number=constants.MODEL_NUMBER,

--- a/src/allotropy/parsers/thermo_fisher_nanodrop_8000/nanodrop_8000_parser.py
+++ b/src/allotropy/parsers/thermo_fisher_nanodrop_8000/nanodrop_8000_parser.py
@@ -29,7 +29,7 @@ class Nanodrop8000Parser(VendorParser[Data, Model]):
         rows = SpectroscopyRow.create_rows(data)
 
         return Data(
-            create_metadata(named_file_contents.original_file_name),
+            create_metadata(named_file_contents.original_file_path),
             measurement_groups=[create_measurement_group(row) for row in rows],
             # NOTE: in current implementation, calculated data is reported at global level for some reason.
             # TODO(nstender): should we move this inside of measurements?

--- a/src/allotropy/parsers/thermo_fisher_nanodrop_8000/nanodrop_8000_structure.py
+++ b/src/allotropy/parsers/thermo_fisher_nanodrop_8000/nanodrop_8000_structure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
 import pandas as pd
 
@@ -196,12 +197,13 @@ class SpectroscopyRow:
         return map_rows(data, SpectroscopyRow.create)
 
 
-def create_metadata(file_name: str) -> Metadata:
+def create_metadata(file_path: str) -> Metadata:
     return Metadata(
         device_identifier=constants.DEVICE_IDENTIFIER,
         device_type=constants.DEVICE_TYPE,
         model_number=constants.MODEL_NUBMER,
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
     )
 
 

--- a/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
+++ b/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_parser.py
@@ -28,7 +28,7 @@ class NanodropEightParser(VendorParser[Data, Model]):
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
         data = NanodropEightReader.read(named_file_contents)
         rows = SpectroscopyRow.create_rows(data)
-        metadata = create_metadata(named_file_contents.original_file_name, data)
+        metadata = create_metadata(named_file_contents.original_file_path, data)
 
         return Data(
             metadata=metadata,

--- a/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_structure.py
+++ b/src/allotropy/parsers/thermo_fisher_nanodrop_eight/nanodrop_eight_structure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
 import pandas as pd
 
@@ -131,13 +132,14 @@ class SpectroscopyRow:
         return map_rows(data, SpectroscopyRow.create)
 
 
-def create_metadata(file_name: str, data: pd.DataFrame) -> Metadata:
+def create_metadata(file_path: str, data: pd.DataFrame) -> Metadata:
     return Metadata(
         device_identifier=constants.DEVICE_IDENTIFIER,
         device_type=constants.DEVICE_TYPE,
         model_number=constants.MODEL_NUBMER,
         equipment_serial_number=data.iloc[0]["serial number"],
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
     )
 
 

--- a/src/allotropy/parsers/thermo_fisher_nanodrop_one/thermo_fisher_nanodrop_one_parser.py
+++ b/src/allotropy/parsers/thermo_fisher_nanodrop_one/thermo_fisher_nanodrop_one_parser.py
@@ -40,11 +40,11 @@ class ThermoFisherNanodropOneParser(VendorParser[Data, Model]):
             named_file_contents.contents,
             encoding=DEFAULT_ENCODING,
         )
-        experiment_type, *_ = named_file_contents.original_file_name.split(maxsplit=1)
+        experiment_type, *_ = named_file_contents.original_file_path.split(maxsplit=1)
         return csv_data, experiment_type
 
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
         data, experiment_type = self.read_data(named_file_contents)
         return DataNanodrop.create(
-            data, experiment_type, named_file_contents.original_file_name
+            data, experiment_type, named_file_contents.original_file_path
         )

--- a/src/allotropy/parsers/thermo_fisher_nanodrop_one/thermo_fisher_nanodrop_one_structure.py
+++ b/src/allotropy/parsers/thermo_fisher_nanodrop_one/thermo_fisher_nanodrop_one_structure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 import re
 
 import pandas as pd
@@ -221,7 +222,7 @@ class RowElements:
 @dataclass(frozen=True)
 class DataNanodrop(Data):
     @staticmethod
-    def create(data: pd.DataFrame, experiment_type: str, file_name: str) -> Data:
+    def create(data: pd.DataFrame, experiment_type: str, file_path: str) -> Data:
         row_elements = RowElements.create(data, experiment_type)
 
         return Data(
@@ -231,7 +232,8 @@ class DataNanodrop(Data):
                 model_number="NanoDrop One",
                 brand_name="NanoDrop",
                 product_manufacturer="ThermoFisher Scientific",
-                file_name=file_name,
+                file_name=Path(file_path).name,
+                unc_path=file_path,
                 software_name="NanoDrop One software",
             ),
             measurement_groups=list(row_elements.measurement_groups),

--- a/src/allotropy/parsers/thermo_fisher_qubit4/thermo_fisher_qubit4_parser.py
+++ b/src/allotropy/parsers/thermo_fisher_qubit4/thermo_fisher_qubit4_parser.py
@@ -26,7 +26,7 @@ class ThermoFisherQubit4Parser(VendorParser[Data, Model]):
 
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
         return Data(
-            create_metadata(named_file_contents.original_file_name),
+            create_metadata(named_file_contents.original_file_path),
             measurement_groups=map_rows(
                 ThermoFisherQubit4Reader.read(named_file_contents),
                 create_measurement_group,

--- a/src/allotropy/parsers/thermo_fisher_qubit4/thermo_fisher_qubit4_structure.py
+++ b/src/allotropy/parsers/thermo_fisher_qubit4/thermo_fisher_qubit4_structure.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from allotropy.allotrope.models.adm.spectrophotometry.benchling._2023._12.spectrophotometry import (
     ContainerType,
 )
@@ -84,9 +86,10 @@ def create_measurement_group(data: SeriesData) -> MeasurementGroup:
     )
 
 
-def create_metadata(file_name: str) -> Metadata:
+def create_metadata(file_path: str) -> Metadata:
     return Metadata(
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
         device_identifier=NOT_APPLICABLE,
         model_number=constants.MODEL_NUMBER,
         software_name=constants.QUBIT_SOFTWARE,

--- a/src/allotropy/parsers/thermo_fisher_qubit_flex/thermo_fisher_qubit_flex_parser.py
+++ b/src/allotropy/parsers/thermo_fisher_qubit_flex/thermo_fisher_qubit_flex_parser.py
@@ -28,4 +28,4 @@ class ThermoFisherQubitFlexParser(VendorParser[Data, Model]):
 
     def create_data(self, named_file_contents: NamedFileContents) -> Data:
         df = ThermoFisherQubitFlexReader.read(named_file_contents)
-        return create_data(df, named_file_contents.original_file_name)
+        return create_data(df, named_file_contents.original_file_path)

--- a/src/allotropy/parsers/thermo_fisher_qubit_flex/thermo_fisher_qubit_flex_structure.py
+++ b/src/allotropy/parsers/thermo_fisher_qubit_flex/thermo_fisher_qubit_flex_structure.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
 
 from allotropy.allotrope.models.adm.spectrophotometry.benchling._2023._12.spectrophotometry import (
@@ -99,11 +101,12 @@ def create_measurement_group(data: SeriesData) -> MeasurementGroup:
     )
 
 
-def create_data(df: pd.DataFrame, file_name: str) -> Data:
+def create_data(df: pd.DataFrame, file_path: str) -> Data:
     header = df_to_series_data(df.head(1))
     return Data(
         metadata=Metadata(
-            file_name=file_name,
+            file_name=Path(file_path).name,
+            unc_path=file_path,
             device_identifier=NOT_APPLICABLE,
             model_number=constants.MODEL_NUMBER,
             software_name=constants.SOFTWARE_NAME,

--- a/src/allotropy/parsers/thermo_skanit/thermo_skanit_parser.py
+++ b/src/allotropy/parsers/thermo_skanit/thermo_skanit_parser.py
@@ -23,5 +23,5 @@ class ThermoSkanItParser(VendorParser[Data, Model]):
             named_file_contents.contents, engine="calamine"
         )
         return DataThermoSkanIt.create(
-            sheet_data=contents, file_name=named_file_contents.original_file_name
+            sheet_data=contents, file_name=named_file_contents.original_file_path
         )

--- a/src/allotropy/parsers/thermo_skanit/thermo_skanit_parser.py
+++ b/src/allotropy/parsers/thermo_skanit/thermo_skanit_parser.py
@@ -23,5 +23,5 @@ class ThermoSkanItParser(VendorParser[Data, Model]):
             named_file_contents.contents, engine="calamine"
         )
         return DataThermoSkanIt.create(
-            sheet_data=contents, file_name=named_file_contents.original_file_path
+            sheet_data=contents, file_path=named_file_contents.original_file_path
         )

--- a/src/allotropy/parsers/thermo_skanit/thermo_skanit_structure.py
+++ b/src/allotropy/parsers/thermo_skanit/thermo_skanit_structure.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 import re
 
 import numpy as np
@@ -24,7 +25,7 @@ from allotropy.parsers.utils.uuids import random_uuid_str
 class ThermoSkanItMetadata:
     @staticmethod
     def create_metadata(
-        instrument_info_df: pd.DataFrame, general_info_df: pd.DataFrame, file_name: str
+        instrument_info_df: pd.DataFrame, general_info_df: pd.DataFrame, file_path: str
     ) -> Metadata:
 
         # Replace empty with "" so we can add label columns together.
@@ -57,8 +58,8 @@ class ThermoSkanItMetadata:
             model_number=instrument_info_data[str, "Name"],
             software_name=software_name,
             software_version=version_number,
-            unc_path="",
-            file_name=file_name,
+            file_name=Path(file_path).name,
+            unc_path=file_path,
             equipment_serial_number=instrument_info_data.get(str, "Serial number"),
         )
 

--- a/src/allotropy/parsers/thermo_skanit/thermo_skanit_structure.py
+++ b/src/allotropy/parsers/thermo_skanit/thermo_skanit_structure.py
@@ -231,7 +231,7 @@ class DataThermoSkanIt(Data):
         return df
 
     @staticmethod
-    def create(sheet_data: dict[str, pd.DataFrame], file_name: str) -> Data:
+    def create(sheet_data: dict[str, pd.DataFrame], file_path: str) -> Data:
         for sheet_name, df in sheet_data.items():
             clean_df = DataThermoSkanIt._clean_dataframe(df)
             # NOTE: This assumes a single absorbance plate on a single tab
@@ -249,7 +249,7 @@ class DataThermoSkanIt(Data):
         metadata = ThermoSkanItMetadata.create_metadata(
             instrument_info_df=inst_info_df,
             general_info_df=general_df,
-            file_name=file_name,
+            file_path=file_path,
         )
         measurement_groups = ThermoSkanItMeasurementGroups.create(
             absorbance_sheet_df=abs_df,

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_parser.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_parser.py
@@ -31,7 +31,7 @@ class UnchainedLabsLunaticParser(VendorParser[Data, Model]):
             reader.header, reader.data
         )
         return Data(
-            create_metadata(reader.header, named_file_contents.original_file_name),
+            create_metadata(reader.header, named_file_contents.original_file_path),
             measurement_groups=measurement_groups,
             calculated_data=calculated_data,
         )

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
 
 from allotropy.allotrope.models.shared.definitions.definitions import NaN
@@ -119,7 +121,7 @@ def _create_measurement_group(
     )
 
 
-def create_metadata(header: SeriesData, file_name: str) -> Metadata:
+def create_metadata(header: SeriesData, file_path: str) -> Metadata:
     device_identifier = header.get(str, "Instrument ID") or header.get(
         str, "Instrument"
     )
@@ -131,7 +133,8 @@ def create_metadata(header: SeriesData, file_name: str) -> Metadata:
         ),
         software_name=SOFTWARE_NAME,
         software_version=header.get(str, "Software version"),
-        file_name=file_name,
+        file_name=Path(file_path).name,
+        unc_path=file_path,
     )
 
 

--- a/src/allotropy/to_allotrope.py
+++ b/src/allotropy/to_allotrope.py
@@ -1,5 +1,4 @@
 from datetime import tzinfo
-from pathlib import Path
 from typing import Any
 
 from allotropy.allotrope.allotrope import serialize_and_validate_allotrope
@@ -13,20 +12,20 @@ VendorType = Vendor | str
 
 def allotrope_from_io(
     contents: IOType,
-    filename: str,
+    filepath: str,
     vendor_type: VendorType,
     default_timezone: tzinfo | None = None,
     encoding: str | None = None,
 ) -> dict[str, Any]:
     model = allotrope_model_from_io(
-        contents, filename, vendor_type, default_timezone, encoding
+        contents, filepath, vendor_type, default_timezone, encoding
     )
     return serialize_and_validate_allotrope(model)
 
 
 def allotrope_model_from_io(
     contents: IOType,
-    filename: str,
+    filepath: str,
     vendor_type: VendorType,
     default_timezone: tzinfo | None = None,
     encoding: str | None = None,
@@ -36,7 +35,7 @@ def allotrope_model_from_io(
     except ValueError as e:
         msg = f"Failed to create parser, unregistered vendor: {vendor_type}."
         raise AllotropeConversionError(msg) from e
-    named_file_contents = NamedFileContents(contents, filename, encoding)
+    named_file_contents = NamedFileContents(contents, filepath, encoding)
     if named_file_contents.extension not in vendor.supported_extensions:
         msg = f"Unsupported file extension '{named_file_contents.extension}' for parser '{vendor.display_name}', expected one of '{vendor.supported_extensions}'."
         raise AllotropeConversionError(msg)
@@ -64,7 +63,7 @@ def allotrope_model_from_file(
         with open(filepath, "rb") as f:
             return allotrope_model_from_io(
                 f,
-                Path(filepath).name,
+                filepath,
                 vendor_type,
                 default_timezone=default_timezone,
                 encoding=encoding,

--- a/tests/parsers/agilent_gen5/agilent_gen5_structure_test.py
+++ b/tests/parsers/agilent_gen5/agilent_gen5_structure_test.py
@@ -28,7 +28,7 @@ def test_create_header_data_no_well_plate_id_in_filename() -> None:
         )
     )
 
-    header_data = HeaderData.create(data, "dummy_filename.txt")
+    header_data = HeaderData.create(data, "users/files/dummy_filename.txt")
 
     assert header_data == HeaderData(
         software_version="3.12.08",
@@ -39,6 +39,7 @@ def test_create_header_data_no_well_plate_id_in_filename() -> None:
         model_number="Synergy H1",
         equipment_serial_number="Serial01",
         file_name="dummy_filename.txt",
+        unc_path="users/files/dummy_filename.txt",
         plate_well_count=96,
     )
 

--- a/tests/parsers/agilent_gen5/testdata/absorbance/010307_114129_BNCH654563_stdcurve_singleplate01.json
+++ b/tests/parsers/agilent_gen5/testdata/absorbance/010307_114129_BNCH654563_stdcurve_singleplate01.json
@@ -7211,9 +7211,9 @@
             "ASM file identifier": "010307_114129_BNCH654563_stdcurve_singleplate01.json",
             "data system instance identifier": "N/A",
             "file name": "010307_114129_BNCH654563_stdcurve_singleplate01.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/absorbance/010307_114129_BNCH654563_stdcurve_singleplate01.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/absorbance/240411_172731_BNCH2345883_abs450_96well_non_numeric_values.json
+++ b/tests/parsers/agilent_gen5/testdata/absorbance/240411_172731_BNCH2345883_abs450_96well_non_numeric_values.json
@@ -4239,9 +4239,9 @@
             "ASM file identifier": "240411_172731_BNCH2345883_abs450_96well_non_numeric_values.json",
             "data system instance identifier": "N/A",
             "file name": "240411_172731_BNCH2345883_abs450_96well_non_numeric_values.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/absorbance/240411_172731_BNCH2345883_abs450_96well_non_numeric_values.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/absorbance/Kinetic_Analysis_Mean_Slope_and_Standard_Curve_tab.json
+++ b/tests/parsers/agilent_gen5/testdata/absorbance/Kinetic_Analysis_Mean_Slope_and_Standard_Curve_tab.json
@@ -21723,9 +21723,9 @@
             "ASM file identifier": "Kinetic_Analysis_Mean_Slope_and_Standard_Curve_tab.json",
             "data system instance identifier": "N/A",
             "file name": "Kinetic_Analysis_Mean_Slope_and_Standard_Curve_tab.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/absorbance/Kinetic_Analysis_Mean_Slope_and_Standard_Curve_tab.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/absorbance/endpoint_pathlength_correct_singleplate.json
+++ b/tests/parsers/agilent_gen5/testdata/absorbance/endpoint_pathlength_correct_singleplate.json
@@ -37547,9 +37547,9 @@
             "ASM file identifier": "endpoint_pathlength_correct_singleplate.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_pathlength_correct_singleplate.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/absorbance/endpoint_pathlength_correct_singleplate.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/absorbance/endpoint_pathlength_correct_singleplate_no_pm_in_time.json
+++ b/tests/parsers/agilent_gen5/testdata/absorbance/endpoint_pathlength_correct_singleplate_no_pm_in_time.json
@@ -37547,9 +37547,9 @@
             "ASM file identifier": "endpoint_pathlength_correct_singleplate_no_pm_in_time.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_pathlength_correct_singleplate_no_pm_in_time.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/absorbance/exclude/endpoint_pathlength_correct_singleplate_no_pm_in_time.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/absorbance/endpoint_stdcurve_singleplate.json
+++ b/tests/parsers/agilent_gen5/testdata/absorbance/endpoint_stdcurve_singleplate.json
@@ -7211,9 +7211,9 @@
             "ASM file identifier": "endpoint_stdcurve_singleplate.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_stdcurve_singleplate.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/absorbance/endpoint_stdcurve_singleplate.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/absorbance/endpoint_stdcurve_singleplate_2.json
+++ b/tests/parsers/agilent_gen5/testdata/absorbance/endpoint_stdcurve_singleplate_2.json
@@ -7211,9 +7211,9 @@
             "ASM file identifier": "endpoint_stdcurve_singleplate_2.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_stdcurve_singleplate_2.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/absorbance/endpoint_stdcurve_singleplate_2.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/absorbance/kinetic_helper_gene_growth_curve.json
+++ b/tests/parsers/agilent_gen5/testdata/absorbance/kinetic_helper_gene_growth_curve.json
@@ -36683,9 +36683,9 @@
             "ASM file identifier": "kinetic_helper_gene_growth_curve.json",
             "data system instance identifier": "N/A",
             "file name": "kinetic_helper_gene_growth_curve.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/absorbance/kinetic_helper_gene_growth_curve.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.0.1"
         },

--- a/tests/parsers/agilent_gen5/testdata/fluorescence/alphalisa_endpoint_singleplate.json
+++ b/tests/parsers/agilent_gen5/testdata/fluorescence/alphalisa_endpoint_singleplate.json
@@ -7163,9 +7163,9 @@
             "ASM file identifier": "alphalisa_endpoint_singleplate.json",
             "data system instance identifier": "N/A",
             "file name": "alphalisa_endpoint_singleplate.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/fluorescence/alphalisa_endpoint_singleplate.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.13.15"
         },

--- a/tests/parsers/agilent_gen5/testdata/fluorescence/alphalisa_test_2.json
+++ b/tests/parsers/agilent_gen5/testdata/fluorescence/alphalisa_test_2.json
@@ -2827,9 +2827,9 @@
             "ASM file identifier": "alphalisa_test_2.json",
             "data system instance identifier": "N/A",
             "file name": "alphalisa_test_2.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/fluorescence/alphalisa_test_2.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_single_plate_example.json
+++ b/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_single_plate_example.json
@@ -553,9 +553,9 @@
             "ASM file identifier": "endpoint_single_plate_example.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_single_plate_example.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_single_plate_example.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.15.15"
         },

--- a/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate.json
+++ b/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate.json
@@ -18827,9 +18827,9 @@
             "ASM file identifier": "endpoint_singleplate.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_singleplate.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter.json
+++ b/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter.json
@@ -36115,9 +36115,9 @@
             "ASM file identifier": "endpoint_singleplate_filter.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_singleplate_filter.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.15.15"
         },

--- a/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter_withStepLabel.json
+++ b/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter_withStepLabel.json
@@ -11143,9 +11143,9 @@
             "ASM file identifier": "endpoint_singleplate_filter_withStepLabel.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_singleplate_filter_withStepLabel.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter_withStepLabel.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter_withStepLabel_withCalculatedValues.json
+++ b/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter_withStepLabel_withCalculatedValues.json
@@ -19971,9 +19971,9 @@
             "ASM file identifier": "endpoint_singleplate_filter_withStepLabel_withCalculatedValues.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_singleplate_filter_withStepLabel_withCalculatedValues.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter_withStepLabel_withCalculatedValues.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter_withoutStepLabel.json
+++ b/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter_withoutStepLabel.json
@@ -11143,9 +11143,9 @@
             "ASM file identifier": "endpoint_singleplate_filter_withoutStepLabel.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_singleplate_filter_withoutStepLabel.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter_withoutStepLabel.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter_withoutStepLabel_withCalculatedValues.json
+++ b/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter_withoutStepLabel_withCalculatedValues.json
@@ -18051,9 +18051,9 @@
             "ASM file identifier": "endpoint_singleplate_filter_withoutStepLabel_withCalculatedValues.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_singleplate_filter_withoutStepLabel_withCalculatedValues.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_filter_withoutStepLabel_withCalculatedValues.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_monochromator_withoutStepLabel.json
+++ b/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_monochromator_withoutStepLabel.json
@@ -8839,9 +8839,9 @@
             "ASM file identifier": "endpoint_singleplate_monochromator_withoutStepLabel.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_singleplate_monochromator_withoutStepLabel.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/fluorescence/endpoint_singleplate_monochromator_withoutStepLabel.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate.json
+++ b/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate.json
@@ -5483,9 +5483,9 @@
             "ASM file identifier": "endpoint_singleplate.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_singleplate.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate_withFilter_withStepLabel.json
+++ b/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate_withFilter_withStepLabel.json
@@ -4615,9 +4615,9 @@
             "ASM file identifier": "endpoint_singleplate_withFilter_withStepLabel.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_singleplate_withFilter_withStepLabel.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate_withFilter_withStepLabel.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate_withFilter_withoutStepLabel.json
+++ b/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate_withFilter_withoutStepLabel.json
@@ -4615,9 +4615,9 @@
             "ASM file identifier": "endpoint_singleplate_withFilter_withoutStepLabel.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_singleplate_withFilter_withoutStepLabel.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate_withFilter_withoutStepLabel.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate_withoutStepLabel.json
+++ b/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate_withoutStepLabel.json
@@ -3943,9 +3943,9 @@
             "ASM file identifier": "endpoint_singleplate_withoutStepLabel.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_singleplate_withoutStepLabel.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate_withoutStepLabel.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate_without_bandwidth.json
+++ b/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate_without_bandwidth.json
@@ -547,9 +547,9 @@
             "ASM file identifier": "endpoint_singleplate_without_bandwidth.json",
             "data system instance identifier": "N/A",
             "file name": "endpoint_singleplate_without_bandwidth.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/luminescence/endpoint_singleplate_without_bandwidth.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.12.08"
         },

--- a/tests/parsers/agilent_gen5/testdata/multi_read_modes/multiple_read_modes.json
+++ b/tests/parsers/agilent_gen5/testdata/multi_read_modes/multiple_read_modes.json
@@ -12775,9 +12775,9 @@
             "ASM file identifier": "multiple_read_modes.json",
             "data system instance identifier": "N/A",
             "file name": "multiple_read_modes.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/multi_read_modes/multiple_read_modes.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.15.15"
         },

--- a/tests/parsers/agilent_gen5/testdata/multi_read_modes/two_same_read_modes.json
+++ b/tests/parsers/agilent_gen5/testdata/multi_read_modes/two_same_read_modes.json
@@ -7687,9 +7687,9 @@
             "ASM file identifier": "two_same_read_modes.json",
             "data system instance identifier": "N/A",
             "file name": "two_same_read_modes.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5/testdata/multi_read_modes/two_same_read_modes.txt",
             "ASM converter name": "allotropy_agilent_gen5",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "Gen5",
             "software version": "3.15.15"
         },

--- a/tests/parsers/agilent_gen5_image/testdata/96-Well Trevigen CometAssayCometChip Imaging and Analysis Sample File 23Nov15.json
+++ b/tests/parsers/agilent_gen5_image/testdata/96-Well Trevigen CometAssayCometChip Imaging and Analysis Sample File 23Nov15.json
@@ -22570,10 +22570,11 @@
         },
         "data system document": {
             "file name": "96-Well Trevigen CometAssayCometChip Imaging and Analysis Sample File 23Nov15.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5_image/testdata/96-Well Trevigen CometAssayCometChip Imaging and Analysis Sample File 23Nov15.txt",
             "software name": "Gen5 Image",
             "software version": "3.12.08",
             "ASM converter name": "allotropy_agilent_gen5_image",
-            "ASM converter version": "0.1.30"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/agilent_gen5_image/testdata/Cell_Count_DAPI_GFP.json
+++ b/tests/parsers/agilent_gen5_image/testdata/Cell_Count_DAPI_GFP.json
@@ -16810,10 +16810,11 @@
         },
         "data system document": {
             "file name": "Cell_Count_DAPI_GFP.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5_image/testdata/Cell_Count_DAPI_GFP.txt",
             "software name": "Gen5 Image",
             "software version": "3.12.08",
             "ASM converter name": "allotropy_agilent_gen5_image",
-            "ASM converter version": "0.1.30"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/agilent_gen5_image/testdata/HeLa 96well Colony 11pt Doxorubicin UprBF_TAB.json
+++ b/tests/parsers/agilent_gen5_image/testdata/HeLa 96well Colony 11pt Doxorubicin UprBF_TAB.json
@@ -12202,10 +12202,11 @@
         },
         "data system document": {
             "file name": "HeLa 96well Colony 11pt Doxorubicin UprBF_TAB.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5_image/testdata/HeLa 96well Colony 11pt Doxorubicin UprBF_TAB.txt",
             "software name": "Gen5 Image",
             "software version": "3.12.08",
             "ASM converter name": "allotropy_agilent_gen5_image",
-            "ASM converter version": "0.1.30"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/agilent_gen5_image/testdata/image_montage_no_results_table.json
+++ b/tests/parsers/agilent_gen5_image/testdata/image_montage_no_results_table.json
@@ -54,10 +54,11 @@
         },
         "data system document": {
             "file name": "image_montage_no_results_table.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5_image/testdata/image_montage_no_results_table.txt",
             "software name": "Gen5 Image",
             "software version": "3.12.08",
             "ASM converter name": "allotropy_agilent_gen5_image",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/agilent_gen5_image/testdata/no_results_agilent_gen5_img_example.json
+++ b/tests/parsers/agilent_gen5_image/testdata/no_results_agilent_gen5_img_example.json
@@ -151,10 +151,11 @@
         },
         "data system document": {
             "file name": "no_results_agilent_gen5_img_example.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/agilent_gen5_image/testdata/no_results_agilent_gen5_img_example.txt",
             "software name": "Gen5 Image",
             "software version": "1.11.11",
             "ASM converter name": "allotropy_agilent_gen5_image",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/agilent_tapestation_analysis/agilent_tapestation_analysis_structure_test.py
+++ b/tests/parsers/agilent_tapestation_analysis/agilent_tapestation_analysis_structure_test.py
@@ -35,9 +35,10 @@ from tests.parsers.agilent_tapestation_analysis.agilent_tapestation_test_data im
 
 
 def test_create_metadata() -> None:
-    metadata = create_metadata(get_metadata_xml(), "file.txt")
+    metadata = create_metadata(get_metadata_xml(), "users/files/file.txt")
     assert metadata == Metadata(
         file_name="file.txt",
+        unc_path="users/files/file.txt",
         analyst="TapeStation User",
         analytical_method_identifier="cfDNA",
         data_system_instance_identifier="TAPESTATIONPC",

--- a/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example01.json
+++ b/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example01.json
@@ -794,9 +794,10 @@
         ],
         "data system document": {
             "file name": "Appbio_AbsoluteQ_example01.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example01.csv",
             "software name": "QuantStudio Absolute Q Digital PCR Software",
             "ASM converter name": "allotropy_appbio_absoluteq",
-            "ASM converter version": "0.1.42"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example02.json
+++ b/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example02.json
@@ -794,9 +794,10 @@
         ],
         "data system document": {
             "file name": "Appbio_AbsoluteQ_example02.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example02.csv",
             "software name": "QuantStudio Absolute Q Digital PCR Software",
             "ASM converter name": "allotropy_appbio_absoluteq",
-            "ASM converter version": "0.1.42"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example03.json
+++ b/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example03.json
@@ -794,9 +794,10 @@
         ],
         "data system document": {
             "file name": "Appbio_AbsoluteQ_example03.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example03.csv",
             "software name": "QuantStudio Absolute Q Digital PCR Software",
             "ASM converter name": "allotropy_appbio_absoluteq",
-            "ASM converter version": "0.1.42"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example04.json
+++ b/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example04.json
@@ -794,9 +794,10 @@
         ],
         "data system document": {
             "file name": "Appbio_AbsoluteQ_example04.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example04.csv",
             "software name": "QuantStudio Absolute Q Digital PCR Software",
             "ASM converter name": "allotropy_appbio_absoluteq",
-            "ASM converter version": "0.1.42"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example05.json
+++ b/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example05.json
@@ -1386,9 +1386,10 @@
         ],
         "data system document": {
             "file name": "Appbio_AbsoluteQ_example05.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_absolute_q/testdata/Appbio_AbsoluteQ_example05.csv",
             "software name": "QuantStudio Absolute Q Digital PCR Software",
             "ASM converter name": "allotropy_appbio_absoluteq",
-            "ASM converter version": "0.1.42"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example03.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example03.json
@@ -55211,11 +55211,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_example03.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example03.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example04.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example04.json
@@ -27923,11 +27923,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_example04.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example04.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example05.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example05.json
@@ -33599,11 +33599,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_example05.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example05.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example06.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example06.json
@@ -1226,11 +1226,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_example06.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example06.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example07.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example07.json
@@ -48935,11 +48935,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_example07.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example07.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_broken_path_calc_doc.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_broken_path_calc_doc.json
@@ -146,11 +146,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_minimal_broken_path_calc_doc.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_broken_path_calc_doc.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_missing_results.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_missing_results.json
@@ -282,11 +282,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_minimal_missing_results.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_missing_results.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test01.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test01.json
@@ -414,11 +414,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_minimal_test01.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test01.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test02.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test02.json
@@ -246,11 +246,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_minimal_test02.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test02.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test03.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test03.json
@@ -282,11 +282,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_minimal_test03.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test03.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test04.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test04.json
@@ -281,11 +281,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_minimal_test04.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test04.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test07.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test07.json
@@ -1226,11 +1226,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_minimal_test07.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test07.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_multiple_cal_doc_wells.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_multiple_cal_doc_wells.json
@@ -525,11 +525,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_multiple_cal_doc_wells.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_multiple_cal_doc_wells.txt",
             "software name": "Thermo QuantStudio",
             "software version": "1.0",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS1_Standard_Curve_example01.json
+++ b/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS1_Standard_Curve_example01.json
@@ -48012,11 +48012,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_designandanalysis_QS1_Standard_Curve_example01.xlsx",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS1_Standard_Curve_example01.xlsx",
             "software name": "Design & Analysis Software",
             "software version": "2.7.0",
             "ASM converter name": "allotropy_appbio_quantstudio_design_&_analysis",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS7Pro_Primary_Analysis_example18.json
+++ b/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS7Pro_Primary_Analysis_example18.json
@@ -5484,11 +5484,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_designandanalysis_QS7Pro_Primary_Analysis_example18.xlsx",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS7Pro_Primary_Analysis_example18.xlsx",
             "software name": "Design & Analysis Software",
             "software version": "2.6.0",
             "ASM converter name": "allotropy_appbio_quantstudio_design_&_analysis",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS7Pro_Relative_Quantification_example11.json
+++ b/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS7Pro_Relative_Quantification_example11.json
@@ -36012,11 +36012,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_designandanalysis_QS7Pro_Relative_Quantification_example11.xlsx",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS7Pro_Relative_Quantification_example11.xlsx",
             "software name": "Design & Analysis Software",
             "software version": "2.7.0",
             "ASM converter name": "allotropy_appbio_quantstudio_design_&_analysis",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS7Pro_Standard_Curve_example14.json
+++ b/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS7Pro_Standard_Curve_example14.json
@@ -48012,11 +48012,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_designandanalysis_QS7Pro_Standard_Curve_example14.xlsx",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS7Pro_Standard_Curve_example14.xlsx",
             "software name": "Design & Analysis Software",
             "software version": "2.7.0",
             "ASM converter name": "allotropy_appbio_quantstudio_design_&_analysis",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS7_Standard_Curve_example06.json
+++ b/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS7_Standard_Curve_example06.json
@@ -48012,11 +48012,11 @@
         "data system document": {
             "data system instance identifier": "localhost",
             "file name": "appbio_quantstudio_designandanalysis_QS7_Standard_Curve_example06.xlsx",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/appbio_quantstudio_designandanalysis/testdata/appbio_quantstudio_designandanalysis_QS7_Standard_Curve_example06.xlsx",
             "software name": "Design & Analysis Software",
             "software version": "2.7.0",
             "ASM converter name": "allotropy_appbio_quantstudio_design_&_analysis",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/beckman_pharmspec/testdata/hiac_example_1.json
+++ b/tests/parsers/beckman_pharmspec/testdata/hiac_example_1.json
@@ -254,10 +254,11 @@
         ],
         "data system document": {
             "file name": "hiac_example_1.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_pharmspec/testdata/hiac_example_1.xlsx",
             "software name": "PharmSpec",
             "software version": "3.0",
             "ASM converter name": "allotropy_beckman_pharmspec",
-            "ASM converter version": "0.1.47"
+            "ASM converter version": "0.1.58"
         },
         "device system document": {
             "equipment serial number": "1808303021",

--- a/tests/parsers/beckman_pharmspec/testdata/hiac_example_2.json
+++ b/tests/parsers/beckman_pharmspec/testdata/hiac_example_2.json
@@ -375,10 +375,11 @@
         ],
         "data system document": {
             "file name": "hiac_example_2.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_pharmspec/testdata/hiac_example_2.xlsx",
             "software name": "PharmSpec",
             "software version": "3.0",
             "ASM converter name": "allotropy_beckman_pharmspec",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "device system document": {
             "equipment serial number": "1808303021",

--- a/tests/parsers/beckman_pharmspec/testdata/hiac_example_3.json
+++ b/tests/parsers/beckman_pharmspec/testdata/hiac_example_3.json
@@ -133,10 +133,11 @@
         ],
         "data system document": {
             "file name": "hiac_example_3.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_pharmspec/testdata/hiac_example_3.xlsx",
             "software name": "PharmSpec",
             "software version": "3.0",
             "ASM converter name": "allotropy_beckman_pharmspec",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "device system document": {
             "equipment serial number": "1808303021",

--- a/tests/parsers/beckman_pharmspec/testdata/hiac_example_4.json
+++ b/tests/parsers/beckman_pharmspec/testdata/hiac_example_4.json
@@ -133,10 +133,11 @@
         ],
         "data system document": {
             "file name": "hiac_example_4.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_pharmspec/testdata/hiac_example_4.xlsx",
             "software name": "PharmSpec",
             "software version": "3.0",
             "ASM converter name": "allotropy_beckman_pharmspec",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "device system document": {
             "equipment serial number": "1808303021",

--- a/tests/parsers/beckman_pharmspec/testdata/hiac_example_5.json
+++ b/tests/parsers/beckman_pharmspec/testdata/hiac_example_5.json
@@ -375,10 +375,11 @@
         ],
         "data system document": {
             "file name": "hiac_example_5.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_pharmspec/testdata/hiac_example_5.xlsx",
             "software name": "PharmSpec",
             "software version": "3.0",
             "ASM converter name": "allotropy_beckman_pharmspec",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "device system document": {
             "equipment serial number": "1808303021",

--- a/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_different_mu_character.json
+++ b/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_different_mu_character.json
@@ -87,9 +87,10 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-BLU_different_mu_character.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_different_mu_character.csv",
             "software name": "Vi-Cell BLU",
             "ASM converter name": "allotropy_beckman_vi_cell_blu",
-            "ASM converter version": "0.1.43"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01.json
+++ b/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01.json
@@ -790,9 +790,10 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-BLU_example01.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01.csv",
             "software name": "Vi-Cell BLU",
             "ASM converter name": "allotropy_beckman_vi_cell_blu",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01_utf16.json
+++ b/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01_utf16.json
@@ -798,9 +798,10 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-BLU_example01_utf16.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01_utf16.csv",
             "software name": "Vi-Cell BLU",
             "ASM converter name": "allotropy_beckman_vi_cell_blu",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example02.json
+++ b/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example02.json
@@ -403,9 +403,10 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-BLU_example02.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example02.csv",
             "software name": "Vi-Cell BLU",
             "ASM converter name": "allotropy_beckman_vi_cell_blu",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.04/Beckman_Vi-Cell-XR_example03_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.04/Beckman_Vi-Cell-XR_example03_instrumentOutput.json
@@ -2150,10 +2150,11 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-XR_example03_instrumentOutput.xls",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_xr/testdata/v2.04/Beckman_Vi-Cell-XR_example03_instrumentOutput.xls",
             "software name": "Vi-Cell XR",
             "software version": "2.04",
             "ASM converter name": "allotropy_beckman_vi_cell_xr",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example01_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example01_instrumentOutput.json
@@ -11790,10 +11790,11 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-XR_example01_instrumentOutput.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example01_instrumentOutput.xlsx",
             "software name": "Vi-Cell XR",
             "software version": "2.06",
             "ASM converter name": "allotropy_beckman_vi_cell_xr",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example04_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example04_instrumentOutput.json
@@ -1017,10 +1017,11 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-XR_example04_instrumentOutput.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example04_instrumentOutput.xlsx",
             "software name": "Vi-Cell XR",
             "software version": "2.06",
             "ASM converter name": "allotropy_beckman_vi_cell_xr",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example05_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example05_instrumentOutput.json
@@ -261,10 +261,11 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-XR_example05_instrumentOutput.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example05_instrumentOutput.xlsx",
             "software name": "Vi-Cell XR",
             "software version": "2.06",
             "ASM converter name": "allotropy_beckman_vi_cell_xr",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example06_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example06_instrumentOutput.json
@@ -198,10 +198,11 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-XR_example06_instrumentOutput.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example06_instrumentOutput.xlsx",
             "software name": "Vi-Cell XR",
             "software version": "2.06",
             "ASM converter name": "allotropy_beckman_vi_cell_xr",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example07_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example07_instrumentOutput.json
@@ -72,10 +72,11 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-XR_example07_instrumentOutput.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example07_instrumentOutput.txt",
             "software name": "Vi-Cell XR",
             "software version": "2.06",
             "ASM converter name": "allotropy_beckman_vi_cell_xr",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example08_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example08_instrumentOutput.json
@@ -72,10 +72,11 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-XR_example08_instrumentOutput.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example08_instrumentOutput.txt",
             "software name": "Vi-Cell XR",
             "software version": "2.06",
             "ASM converter name": "allotropy_beckman_vi_cell_xr",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_hiddenRow.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_hiddenRow.json
@@ -1521,10 +1521,11 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-XR_hiddenRow.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_hiddenRow.xlsx",
             "software name": "Vi-Cell XR",
             "software version": "2.06",
             "ASM converter name": "allotropy_beckman_vi_cell_xr",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_no_total_cells.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_no_total_cells.json
@@ -1425,10 +1425,11 @@
         },
         "data system document": {
             "file name": "Beckman_Vi-Cell-XR_no_total_cells.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_no_total_cells.xlsx",
             "software name": "Vi-Cell XR",
             "software version": "2.06",
             "ASM converter name": "allotropy_beckman_vi_cell_xr",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/style_fill_incorrect.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/style_fill_incorrect.json
@@ -72,10 +72,11 @@
         },
         "data system document": {
             "file name": "style_fill_incorrect.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/style_fill_incorrect.xlsx",
             "software name": "Vi-Cell XR",
             "software version": "2.06",
             "ASM converter name": "allotropy_beckman_vi_cell_xr",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/biorad_bioplex_manager/testdata/bio-rad_bio-plex_manager_example_01.json
+++ b/tests/parsers/biorad_bioplex_manager/testdata/bio-rad_bio-plex_manager_example_01.json
@@ -25178,10 +25178,11 @@
         ],
         "data system document": {
             "file name": "bio-rad_bio-plex_manager_example_01.xml",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/biorad_bioplex_manager/testdata/bio-rad_bio-plex_manager_example_01.xml",
             "software name": "“Bio-Plex Manager",
             "software version": "6.2.0.175",
             "ASM converter name": "allotropy_bio_rad_bio_plex_manager",
-            "ASM converter version": "0.1.49"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/chemometec_nc_view/chemometec_nc_view_structure_test.py
+++ b/tests/parsers/chemometec_nc_view/chemometec_nc_view_structure_test.py
@@ -14,16 +14,16 @@ def test_create_metadata() -> None:
         "INSTRUMENT": "S/N: 9002029999999999",
     }
     df_data = pd.DataFrame(data, index=[0])
-    file_name = "chemometec_nc_view_example.csv"
-    metadata = create_metadata(df_to_series_data(df_data), file_name)
-    assert metadata.file_name == file_name
+    file_path = "chemometec_nc_view_example.csv"
+    metadata = create_metadata(df_to_series_data(df_data), file_path)
+    assert metadata.file_name == file_path
     assert metadata.software_name == constants.SOFTWARE_NAME
     assert metadata.device_type == constants.DEVICE_TYPE
     assert metadata.equipment_serial_number == "9002029999999999"
     assert metadata.product_manufacturer == constants.PRODUCT_MANUFACTURER
     assert metadata.detection_type == constants.DETECTION_TYPE
     assert metadata.model_number == NOT_APPLICABLE
-    assert metadata.unc_path == NOT_APPLICABLE
+    assert metadata.unc_path == file_path
 
 
 def test_create_measurement_groups() -> None:

--- a/tests/parsers/chemometec_nc_view/testdata/chememotec_nc_view_example.json
+++ b/tests/parsers/chemometec_nc_view/testdata/chememotec_nc_view_example.json
@@ -2090,10 +2090,10 @@
         },
         "data system document": {
             "file name": "chememotec_nc_view_example.csv",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/chemometec_nc_view/testdata/chememotec_nc_view_example.csv",
             "software name": "NC-View",
             "ASM converter name": "allotropy_chemometec_nc_view",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example01.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example01.json
@@ -63,10 +63,11 @@
         },
         "data system document": {
             "file name": "chemometec_nucleoview_example01.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example01.csv",
             "software name": "NucleoView",
             "software version": "1.4.2.0",
             "ASM converter name": "allotropy_chemometec_nucleoview",
-            "ASM converter version": "0.1.27"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example02.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example02.json
@@ -63,10 +63,11 @@
         },
         "data system document": {
             "file name": "chemometec_nucleoview_example02.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example02.csv",
             "software name": "NucleoView",
             "software version": "1.4.0.0",
             "ASM converter name": "allotropy_chemometec_nucleoview",
-            "ASM converter version": "0.1.27"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example03.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example03.json
@@ -62,9 +62,10 @@
         },
         "data system document": {
             "file name": "chemometec_nucleoview_example03.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example03.csv",
             "software name": "NucleoView",
             "ASM converter name": "allotropy_chemometec_nucleoview",
-            "ASM converter version": "0.1.17"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example04.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example04.json
@@ -63,10 +63,11 @@
         },
         "data system document": {
             "file name": "chemometec_nucleoview_example04.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example04.csv",
             "software name": "NucleoView",
             "software version": "1.4.2.0",
             "ASM converter name": "allotropy_chemometec_nucleoview",
-            "ASM converter version": "0.1.27"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example05.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example05.json
@@ -63,10 +63,11 @@
         },
         "data system document": {
             "file name": "chemometec_nucleoview_example05.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example05.csv",
             "software name": "NucleoView",
             "software version": "1.4.2.0",
             "ASM converter name": "allotropy_chemometec_nucleoview",
-            "ASM converter version": "0.1.27"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example06.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example06.json
@@ -63,10 +63,11 @@
         },
         "data system document": {
             "file name": "chemometec_nucleoview_example06.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example06.csv",
             "software name": "NucleoView",
             "software version": "1.4.0.0",
             "ASM converter name": "allotropy_chemometec_nucleoview",
-            "ASM converter version": "0.1.27"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_checksum_correct.json
+++ b/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_checksum_correct.json
@@ -327,8 +327,9 @@
         },
         "data system document": {
             "file name": "Weyland_Yutani_checksum_correct.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_checksum_correct.csv",
             "ASM converter name": "allotropy_example_weyland_yutani",
-            "ASM converter version": "0.1.49"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_simple_correct.json
+++ b/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_simple_correct.json
@@ -327,8 +327,9 @@
         },
         "data system document": {
             "file name": "Weyland_Yutani_simple_correct.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/example_weyland_yutani/testdata/Weyland_Yutani_simple_correct.csv",
             "ASM converter name": "allotropy_example_weyland_yutani",
-            "ASM converter version": "0.1.49"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example02.json
+++ b/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example02.json
@@ -33224,10 +33224,11 @@
         "data system document": {
             "data system instance identifier": "USWPMRLWN003504",
             "file name": "luminex_xPONENT_example02.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example02.csv",
             "software name": "xPONENT",
             "software version": "4.3.229.0",
             "ASM converter name": "allotropy_luminex_xponent",
-            "ASM converter version": "0.1.29"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example02_saved.json
+++ b/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example02_saved.json
@@ -33224,10 +33224,11 @@
         "data system document": {
             "data system instance identifier": "USWPMRLWN003504",
             "file name": "luminex_xPONENT_example02_saved.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example02_saved.csv",
             "software name": "xPONENT",
             "software version": "4.3.229.0",
             "ASM converter name": "allotropy_luminex_xponent",
-            "ASM converter version": "0.1.34"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example03.json
+++ b/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example03.json
@@ -33414,10 +33414,11 @@
         "data system document": {
             "data system instance identifier": "ABCDEFG123456",
             "file name": "luminex_xPONENT_example03.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/luminex_xponent/testdata/luminex_xPONENT_example03.csv",
             "software name": "xPONENT",
             "software version": "4.3.229.0",
             "ASM converter name": "allotropy_luminex_xponent",
-            "ASM converter version": "0.1.29"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_example01.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_example01.json
@@ -19760,9 +19760,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_absorbance_endpoint_example01.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_example01.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_example02.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_example02.json
@@ -19760,9 +19760,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_absorbance_endpoint_example02.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_example02.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_example04.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_example04.json
@@ -43879,9 +43879,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_absorbance_endpoint_example04.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_example04.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_example05.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_example05.json
@@ -43879,9 +43879,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_absorbance_endpoint_example05.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_example05.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example01.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example01.json
@@ -16781,9 +16781,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_absorbance_endpoint_partial_plate_example01.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example01.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example02.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example02.json
@@ -16781,9 +16781,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_absorbance_endpoint_partial_plate_example02.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example02.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example03.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example03.json
@@ -2891,9 +2891,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_absorbance_endpoint_partial_plate_example03.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example03.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example04.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example04.json
@@ -4267,9 +4267,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_absorbance_endpoint_partial_plate_example04.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example04.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example05.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example05.json
@@ -3499,9 +3499,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_absorbance_endpoint_partial_plate_example05.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_absorbance_endpoint_partial_plate_example05.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_fluorescence_endpoint_example06.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_fluorescence_endpoint_example06.json
@@ -58037,9 +58037,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_fluorescence_endpoint_example06.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_fluorescence_endpoint_example06.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_fluorescence_endpoint_example07.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_fluorescence_endpoint_example07.json
@@ -58037,9 +58037,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_fluorescence_endpoint_example07.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_fluorescence_endpoint_example07.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_fluorescence_endpoint_partial_plate_example01.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_fluorescence_endpoint_partial_plate_example01.json
@@ -5131,9 +5131,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_fluorescence_endpoint_partial_plate_example01.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_fluorescence_endpoint_partial_plate_example01.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_fluorescence_endpoint_partial_plate_example02.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_fluorescence_endpoint_partial_plate_example02.json
@@ -4363,9 +4363,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_fluorescence_endpoint_partial_plate_example02.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_fluorescence_endpoint_partial_plate_example02.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_example03.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_example03.json
@@ -5771,9 +5771,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_luminescence_endpoint_example03.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_example03.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_example08.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_example08.json
@@ -53717,9 +53717,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_luminescence_endpoint_example08.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_example08.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_example09.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_example09.json
@@ -53717,9 +53717,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_luminescence_endpoint_example09.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_example09.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_partial_plate_example01.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_partial_plate_example01.json
@@ -4651,9 +4651,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_luminescence_endpoint_partial_plate_example01.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_partial_plate_example01.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_partial_plate_example02.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_partial_plate_example02.json
@@ -3883,9 +3883,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "MD_SMP_luminescence_endpoint_partial_plate_example02.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/MD_SMP_luminescence_endpoint_partial_plate_example02.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/abs_endpoint_plates.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/abs_endpoint_plates.json
@@ -11499,9 +11499,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "abs_endpoint_plates.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/abs_endpoint_plates.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/fl_kinetic_plates.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/fl_kinetic_plates.json
@@ -1235,9 +1235,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "fl_kinetic_plates.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/fl_kinetic_plates.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.54",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/group_cols_with_int_sample_names.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/group_cols_with_int_sample_names.json
@@ -11946,9 +11946,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "group_cols_with_int_sample_names.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/group_cols_with_int_sample_names.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/moldev_softmax_pro/testdata/softmaxpro_no_calc_docs.json
+++ b/tests/parsers/moldev_softmax_pro/testdata/softmaxpro_no_calc_docs.json
@@ -13543,9 +13543,9 @@
             "ASM file identifier": "N/A",
             "data system instance identifier": "N/A",
             "file name": "softmaxpro_no_calc_docs.txt",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/moldev_softmax_pro/testdata/softmaxpro_no_calc_docs.txt",
             "ASM converter name": "allotropy_molecular_devices_softmax_pro",
-            "ASM converter version": "0.1.51",
+            "ASM converter version": "0.1.58",
             "software name": "SoftMax Pro"
         },
         "device system document": {

--- a/tests/parsers/novabio_flex2/testdata/SampleResults2022-06-28_142558.json
+++ b/tests/parsers/novabio_flex2/testdata/SampleResults2022-06-28_142558.json
@@ -159,9 +159,10 @@
         },
         "data system document": {
             "file name": "SampleResults2022-06-28_142558.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/novabio_flex2/testdata/SampleResults2022-06-28_142558.csv",
             "software name": "NovaBio Flex",
             "ASM converter name": "allotropy_novabio_flex2",
-            "ASM converter version": "0.1.47"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/novabio_flex2/testdata/SampleResultsDEVICE1232021-02-18_104838.json
+++ b/tests/parsers/novabio_flex2/testdata/SampleResultsDEVICE1232021-02-18_104838.json
@@ -1028,9 +1028,10 @@
         },
         "data system document": {
             "file name": "SampleResultsDEVICE1232021-02-18_104838.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/novabio_flex2/testdata/SampleResultsDEVICE1232021-02-18_104838.csv",
             "software name": "NovaBio Flex",
             "ASM converter name": "allotropy_novabio_flex2",
-            "ASM converter version": "0.1.47"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_absorbance_example01.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_absorbance_example01.json
@@ -42635,9 +42635,9 @@
             "ASM file identifier": "PE_Envision_absorbance_example01.json",
             "data system instance identifier": "N/A",
             "file name": "PE_Envision_absorbance_example01.csv",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_absorbance_example01.csv",
             "ASM converter name": "allotropy_perkinelmer_envision",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "EnVision Workstation",
             "software version": "1.14.3049.1193"
         },

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example01.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example01.json
@@ -6491,9 +6491,9 @@
             "ASM file identifier": "PE_Envision_fluorescence_example01.json",
             "data system instance identifier": "N/A",
             "file name": "PE_Envision_fluorescence_example01.csv",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example01.csv",
             "ASM converter name": "allotropy_perkinelmer_envision",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "EnVision Workstation",
             "software version": "1.14.3049.1193"
         },

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example02.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example02.json
@@ -24551,9 +24551,9 @@
             "ASM file identifier": "PE_Envision_fluorescence_example02.json",
             "data system instance identifier": "N/A",
             "file name": "PE_Envision_fluorescence_example02.csv",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example02.csv",
             "ASM converter name": "allotropy_perkinelmer_envision",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "EnVision Workstation",
             "software version": "1.13.3009.1409"
         },

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example03.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example03.json
@@ -16519,9 +16519,9 @@
             "ASM file identifier": "PE_Envision_fluorescence_example03.json",
             "data system instance identifier": "N/A",
             "file name": "PE_Envision_fluorescence_example03.csv",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example03.csv",
             "ASM converter name": "allotropy_perkinelmer_envision",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "EnVision Workstation",
             "software version": "1.14.3049.1193"
         },

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example04.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example04.json
@@ -46091,9 +46091,9 @@
             "ASM file identifier": "PE_Envision_fluorescence_example04.json",
             "data system instance identifier": "N/A",
             "file name": "PE_Envision_fluorescence_example04.csv",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_fluorescence_example04.csv",
             "ASM converter name": "allotropy_perkinelmer_envision",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "EnVision Workstation",
             "software version": "1.14.3049.1193"
         },

--- a/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_luminescence_example01.json
+++ b/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_luminescence_example01.json
@@ -45323,9 +45323,9 @@
             "ASM file identifier": "PE_Envision_luminescence_example01.json",
             "data system instance identifier": "N/A",
             "file name": "PE_Envision_luminescence_example01.csv",
-            "UNC path": "N/A",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/perkin_elmer_envision/testdata/PE_Envision_luminescence_example01.csv",
             "ASM converter name": "allotropy_perkinelmer_envision",
-            "ASM converter version": "0.1.56",
+            "ASM converter version": "0.1.58",
             "software name": "EnVision Workstation",
             "software version": "1.14.3049.1193"
         },

--- a/tests/parsers/qiacuity_dpcr/testdata/qiacuity_dpcr_example01.json
+++ b/tests/parsers/qiacuity_dpcr/testdata/qiacuity_dpcr_example01.json
@@ -290,9 +290,10 @@
         ],
         "data system document": {
             "file name": "qiacuity_dpcr_example01.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/qiacuity_dpcr/testdata/qiacuity_dpcr_example01.csv",
             "software name": "Qiacuity Software Suite",
             "ASM converter name": "allotropy_qiacuity_dpcr",
-            "ASM converter version": "0.1.42"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/qiacuity_dpcr/testdata/qiacuity_dpcr_example02.json
+++ b/tests/parsers/qiacuity_dpcr/testdata/qiacuity_dpcr_example02.json
@@ -302,9 +302,10 @@
         ],
         "data system document": {
             "file name": "qiacuity_dpcr_example02.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/qiacuity_dpcr/testdata/qiacuity_dpcr_example02.csv",
             "software name": "Qiacuity Software Suite",
             "ASM converter name": "allotropy_qiacuity_dpcr",
-            "ASM converter version": "0.1.42"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/revvity_kaleido/testdata/absorbance/absorbance_endpoint_single_plate_example_01.json
+++ b/tests/parsers/revvity_kaleido/testdata/absorbance/absorbance_endpoint_single_plate_example_01.json
@@ -4139,10 +4139,11 @@
         },
         "data system document": {
             "file name": "absorbance_endpoint_single_plate_example_01.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/revvity_kaleido/testdata/absorbance/absorbance_endpoint_single_plate_example_01.csv",
             "software name": "Kaleido",
             "software version": "2.0.3058.126",
             "ASM converter name": "allotropy_revvity_kaleido",
-            "ASM converter version": "0.1.33"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/revvity_kaleido/testdata/fluorescence/fluorescence_endpoint_single_plate_example_01.json
+++ b/tests/parsers/revvity_kaleido/testdata/fluorescence/fluorescence_endpoint_single_plate_example_01.json
@@ -18443,10 +18443,11 @@
         },
         "data system document": {
             "file name": "fluorescence_endpoint_single_plate_example_01.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/revvity_kaleido/testdata/fluorescence/fluorescence_endpoint_single_plate_example_01.csv",
             "software name": "Kaleido",
             "software version": "3.0.3067.117",
             "ASM converter name": "allotropy_revvity_kaleido",
-            "ASM converter version": "0.1.23"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/revvity_kaleido/testdata/luminescence/luminescence_endpoint_single_plate_example_01.json
+++ b/tests/parsers/revvity_kaleido/testdata/luminescence/luminescence_endpoint_single_plate_example_01.json
@@ -3755,10 +3755,11 @@
         },
         "data system document": {
             "file name": "luminescence_endpoint_single_plate_example_01.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/revvity_kaleido/testdata/luminescence/luminescence_endpoint_single_plate_example_01.csv",
             "software name": "Kaleido",
             "software version": "3.0.3067.117",
             "ASM converter name": "allotropy_revvity_kaleido",
-            "ASM converter version": "0.1.23"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/revvity_kaleido/testdata/optical_imaging/optical_imaging_endpoint_single_plate_example_03.json
+++ b/tests/parsers/revvity_kaleido/testdata/optical_imaging/optical_imaging_endpoint_single_plate_example_03.json
@@ -46859,10 +46859,11 @@
         },
         "data system document": {
             "file name": "optical_imaging_endpoint_single_plate_example_03.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/revvity_kaleido/testdata/optical_imaging/optical_imaging_endpoint_single_plate_example_03.csv",
             "software name": "Kaleido",
             "software version": "2.0.3058.126",
             "ASM converter name": "allotropy_revvity_kaleido",
-            "ASM converter version": "0.1.33"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_csv.json
+++ b/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_csv.json
@@ -1360,8 +1360,9 @@
         "device system document": {},
         "data system document": {
             "file name": "revvity_matrix_1_csv.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_csv.csv",
             "ASM converter name": "allotropy_revvity_matrix",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_xlsx.json
+++ b/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_xlsx.json
@@ -1360,8 +1360,9 @@
         "device system document": {},
         "data system document": {
             "file name": "revvity_matrix_1_xlsx.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_xlsx.xlsx",
             "ASM converter name": "allotropy_revvity_matrix",
-            "ASM converter version": "0.1.54"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example01.json
+++ b/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example01.json
@@ -273,11 +273,11 @@
         },
         "data system document": {
             "file name": "roche_cedex_bioht_example01.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example01.txt",
             "software name": "CEDEX BIO HT",
             "software version": "6.0.0.1905 (1905)",
             "ASM converter name": "allotropy_roche_cedex_bioht",
-            "ASM converter version": "0.1.47"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example02.json
+++ b/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example02.json
@@ -247,11 +247,11 @@
         },
         "data system document": {
             "file name": "roche_cedex_bioht_example02.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example02.txt",
             "software name": "CEDEX BIO HT",
             "software version": "6.0.0.1905 (1905)",
             "ASM converter name": "allotropy_roche_cedex_bioht",
-            "ASM converter version": "0.1.47"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example03.json
+++ b/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example03.json
@@ -10848,11 +10848,11 @@
         },
         "data system document": {
             "file name": "roche_cedex_bioht_example03.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example03.txt",
             "software name": "CEDEX BIO HT",
             "software version": "6.0.0.1905 (1905)",
             "ASM converter name": "allotropy_roche_cedex_bioht",
-            "ASM converter version": "0.1.47"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example04.json
+++ b/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example04.json
@@ -190,11 +190,11 @@
         },
         "data system document": {
             "file name": "roche_cedex_bioht_example04.txt",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/roche_cedex_bioht/testdata/roche_cedex_bioht_example04.txt",
             "software name": "CEDEX BIO HT",
             "software version": "6.0.0.1905 (1905)",
             "ASM converter name": "allotropy_roche_cedex_bioht",
-            "ASM converter version": "0.1.47"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_1.json
+++ b/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_1.json
@@ -861,9 +861,10 @@
         },
         "data system document": {
             "file name": "roche_cedex_hires_example_1.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_1.csv",
             "software name": "Cedex software",
             "ASM converter name": "allotropy_roche_cedex_hires",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_2.json
+++ b/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_2.json
@@ -861,9 +861,10 @@
         },
         "data system document": {
             "file name": "roche_cedex_hires_example_2.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_2.xlsx",
             "software name": "Cedex software",
             "ASM converter name": "allotropy_roche_cedex_hires",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_3.json
+++ b/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_3.json
@@ -10295,9 +10295,10 @@
         },
         "data system document": {
             "file name": "roche_cedex_hires_example_3.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_3.csv",
             "software name": "Cedex software",
             "ASM converter name": "allotropy_roche_cedex_hires",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_4.json
+++ b/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_4.json
@@ -10295,9 +10295,10 @@
         },
         "data system document": {
             "file name": "roche_cedex_hires_example_4.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_4.xlsx",
             "software name": "Cedex software",
             "ASM converter name": "allotropy_roche_cedex_hires",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/thermo_fisher_genesys30/testdata/thermo_fisher_genesys30_example_01.json
+++ b/tests/parsers/thermo_fisher_genesys30/testdata/thermo_fisher_genesys30_example_01.json
@@ -385,9 +385,10 @@
         },
         "data system document": {
             "file name": "thermo_fisher_genesys30_example_01.tsv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_genesys30/testdata/thermo_fisher_genesys30_example_01.tsv",
             "software name": "Genesys 30 instrument software",
             "ASM converter name": "allotropy_thermo_fisher_genesys30",
-            "ASM converter version": "0.1.45"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/thermo_fisher_genesys30/testdata/thermo_fisher_genesys30_example_02.json
+++ b/tests/parsers/thermo_fisher_genesys30/testdata/thermo_fisher_genesys30_example_02.json
@@ -385,9 +385,10 @@
         },
         "data system document": {
             "file name": "thermo_fisher_genesys30_example_02.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_genesys30/testdata/thermo_fisher_genesys30_example_02.csv",
             "software name": "Genesys 30 instrument software",
             "ASM converter name": "allotropy_thermo_fisher_genesys30",
-            "ASM converter version": "0.1.45"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_8000_example01.json
+++ b/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_8000_example01.json
@@ -296,8 +296,9 @@
         },
         "data system document": {
             "file name": "Thermo_NanoDrop_8000_example01.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_8000_example01.txt",
             "ASM converter name": "allotropy_thermo_fisher_nanodrop_8000",
-            "ASM converter version": "0.1.52"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_8000_example02.json
+++ b/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_8000_example02.json
@@ -1569,8 +1569,9 @@
         },
         "data system document": {
             "file name": "Thermo_NanoDrop_8000_example02.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_8000_example02.txt",
             "ASM converter name": "allotropy_thermo_fisher_nanodrop_8000",
-            "ASM converter version": "0.1.52"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_8000_example03.json
+++ b/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_8000_example03.json
@@ -387,8 +387,9 @@
         },
         "data system document": {
             "file name": "Thermo_NanoDrop_8000_example03.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_8000_example03.txt",
             "ASM converter name": "allotropy_thermo_fisher_nanodrop_8000",
-            "ASM converter version": "0.1.52"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_8000_example04.json
+++ b/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_8000_example04.json
@@ -576,8 +576,9 @@
         },
         "data system document": {
             "file name": "Thermo_NanoDrop_8000_example04.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_8000_example04.txt",
             "ASM converter name": "allotropy_thermo_fisher_nanodrop_8000",
-            "ASM converter version": "0.1.52"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_mRNA.json
+++ b/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_mRNA.json
@@ -247,8 +247,9 @@
         },
         "data system document": {
             "file name": "Thermo_NanoDrop_mRNA.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_8000/testdata/Thermo_NanoDrop_mRNA.txt",
             "ASM converter name": "allotropy_thermo_fisher_nanodrop_8000",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/thermo_fisher_nanodrop_eight/testdata/thermo_nanodrop_eight_example01.json
+++ b/tests/parsers/thermo_fisher_nanodrop_eight/testdata/thermo_nanodrop_eight_example01.json
@@ -3100,8 +3100,9 @@
         },
         "data system document": {
             "file name": "thermo_nanodrop_eight_example01.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_eight/testdata/thermo_nanodrop_eight_example01.txt",
             "ASM converter name": "allotropy_thermo_fisher_nanodrop_eight",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/thermo_fisher_nanodrop_eight/testdata/thermo_nanodrop_eight_example02.json
+++ b/tests/parsers/thermo_fisher_nanodrop_eight/testdata/thermo_nanodrop_eight_example02.json
@@ -3100,8 +3100,9 @@
         },
         "data system document": {
             "file name": "thermo_nanodrop_eight_example02.txt",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_eight/testdata/thermo_nanodrop_eight_example02.txt",
             "ASM converter name": "allotropy_thermo_fisher_nanodrop_eight",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/thermo_fisher_nanodrop_one/testdata/dsDNA 7_19_2023 3_27_29 PM.json
+++ b/tests/parsers/thermo_fisher_nanodrop_one/testdata/dsDNA 7_19_2023 3_27_29 PM.json
@@ -101,7 +101,7 @@
                             }
                         }
                     ],
-                    "experiment type": "dsDNA"
+                    "experiment type": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_one/testdata/dsDNA"
                 }
             },
             {
@@ -203,7 +203,7 @@
                             }
                         }
                     ],
-                    "experiment type": "dsDNA"
+                    "experiment type": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_one/testdata/dsDNA"
                 }
             },
             {
@@ -273,7 +273,7 @@
                             }
                         }
                     ],
-                    "experiment type": "dsDNA"
+                    "experiment type": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_one/testdata/dsDNA"
                 }
             },
             {
@@ -343,7 +343,7 @@
                             }
                         }
                     ],
-                    "experiment type": "dsDNA"
+                    "experiment type": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_one/testdata/dsDNA"
                 }
             },
             {
@@ -445,7 +445,7 @@
                             }
                         }
                     ],
-                    "experiment type": "dsDNA"
+                    "experiment type": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_one/testdata/dsDNA"
                 }
             },
             {
@@ -547,7 +547,7 @@
                             }
                         }
                     ],
-                    "experiment type": "dsDNA"
+                    "experiment type": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_one/testdata/dsDNA"
                 }
             }
         ],
@@ -559,9 +559,10 @@
         },
         "data system document": {
             "file name": "dsDNA 7_19_2023 3_27_29 PM.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_one/testdata/dsDNA 7_19_2023 3_27_29 PM.csv",
             "software name": "NanoDrop One software",
             "ASM converter name": "allotropy_thermo_fisher_nanodrop_one",
-            "ASM converter version": "0.1.52"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/thermo_fisher_nanodrop_one/testdata/example1.json
+++ b/tests/parsers/thermo_fisher_nanodrop_one/testdata/example1.json
@@ -559,9 +559,10 @@
         },
         "data system document": {
             "file name": "example1.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_nanodrop_one/testdata/example1.xlsx",
             "software name": "NanoDrop One software",
             "ASM converter name": "allotropy_thermo_fisher_nanodrop_one",
-            "ASM converter version": "0.1.49"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/thermo_fisher_qubit4/testdata/thermo_fisher_qubit4_example_1.json
+++ b/tests/parsers/thermo_fisher_qubit4/testdata/thermo_fisher_qubit4_example_1.json
@@ -31,10 +31,6 @@
                                 "sample identifier": "Sample_#231212-064054",
                                 "batch identifier": "2023-12-12",
                                 "custom information document": {
-                                    "original sample concentration": {
-                                        "value": 6.08,
-                                        "unit": "ng/µL"
-                                    },
                                     "qubit tube concentration": {
                                         "value": 30.4,
                                         "unit": "ng/mL"
@@ -46,6 +42,10 @@
                                     "standard 2 concentration": {
                                         "value": 21133.11,
                                         "unit": "RFU"
+                                    },
+                                    "original sample concentration": {
+                                        "value": 6.08,
+                                        "unit": "ng/µL"
                                     }
                                 }
                             },
@@ -88,10 +88,6 @@
                                 "sample identifier": "Sample_#231212-020958",
                                 "batch identifier": "2023-12-12",
                                 "custom information document": {
-                                    "original sample concentration": {
-                                        "value": 112.0,
-                                        "unit": "ng/µL"
-                                    },
                                     "qubit tube concentration": {
                                         "value": 560.0,
                                         "unit": "ng/mL"
@@ -103,6 +99,10 @@
                                     "standard 2 concentration": {
                                         "value": 21133.11,
                                         "unit": "RFU"
+                                    },
+                                    "original sample concentration": {
+                                        "value": 112.0,
+                                        "unit": "ng/µL"
                                     }
                                 }
                             },
@@ -125,9 +125,10 @@
         },
         "data system document": {
             "file name": "thermo_fisher_qubit4_example_1.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_qubit4/testdata/thermo_fisher_qubit4_example_1.csv",
             "software name": "Qubit 4 software",
             "ASM converter name": "allotropy_thermo_fisher_qubit_4",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/thermo_fisher_qubit4/testdata/thermo_fisher_qubit4_example_2.json
+++ b/tests/parsers/thermo_fisher_qubit4/testdata/thermo_fisher_qubit4_example_2.json
@@ -31,10 +31,6 @@
                                 "sample identifier": "Sample_#231212-064054",
                                 "batch identifier": "2023-12-12 00:00:00",
                                 "custom information document": {
-                                    "original sample concentration": {
-                                        "value": 6.08,
-                                        "unit": "ng/µL"
-                                    },
                                     "qubit tube concentration": {
                                         "value": 30.4,
                                         "unit": "ng/mL"
@@ -46,6 +42,10 @@
                                     "standard 2 concentration": {
                                         "value": 21133.11,
                                         "unit": "RFU"
+                                    },
+                                    "original sample concentration": {
+                                        "value": 6.08,
+                                        "unit": "ng/µL"
                                     }
                                 }
                             },
@@ -88,10 +88,6 @@
                                 "sample identifier": "Sample_#231212-020958",
                                 "batch identifier": "2023-12-12 00:00:00",
                                 "custom information document": {
-                                    "original sample concentration": {
-                                        "value": 112.0,
-                                        "unit": "ng/µL"
-                                    },
                                     "qubit tube concentration": {
                                         "value": 560.0,
                                         "unit": "ng/mL"
@@ -103,6 +99,10 @@
                                     "standard 2 concentration": {
                                         "value": 21133.11,
                                         "unit": "RFU"
+                                    },
+                                    "original sample concentration": {
+                                        "value": 112.0,
+                                        "unit": "ng/µL"
                                     }
                                 }
                             },
@@ -125,9 +125,10 @@
         },
         "data system document": {
             "file name": "thermo_fisher_qubit4_example_2.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_qubit4/testdata/thermo_fisher_qubit4_example_2.xlsx",
             "software name": "Qubit 4 software",
             "ASM converter name": "allotropy_thermo_fisher_qubit_4",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/thermo_fisher_qubit4/testdata/thermo_fisher_qubit4_example_3.json
+++ b/tests/parsers/thermo_fisher_qubit4/testdata/thermo_fisher_qubit4_example_3.json
@@ -410,9 +410,10 @@
         },
         "data system document": {
             "file name": "thermo_fisher_qubit4_example_3.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_qubit4/testdata/thermo_fisher_qubit4_example_3.csv",
             "software name": "Qubit 4 software",
             "ASM converter name": "allotropy_thermo_fisher_qubit_4",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/thermo_fisher_qubit4/testdata/thermo_fisher_qubit4_example_4.json
+++ b/tests/parsers/thermo_fisher_qubit4/testdata/thermo_fisher_qubit4_example_4.json
@@ -410,9 +410,10 @@
         },
         "data system document": {
             "file name": "thermo_fisher_qubit4_example_4.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_qubit4/testdata/thermo_fisher_qubit4_example_4.xlsx",
             "software name": "Qubit 4 software",
             "ASM converter name": "allotropy_thermo_fisher_qubit_4",
-            "ASM converter version": "0.1.38"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_01.json
+++ b/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_01.json
@@ -449,10 +449,11 @@
         },
         "data system document": {
             "file name": "thermo_fisher_qubit_flex_example_01.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_01.csv",
             "software name": "Qubit Flex software",
             "software version": "1.5.0",
             "ASM converter name": "allotropy_thermo_fisher_qubit_flex",
-            "ASM converter version": "0.1.57"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_02.json
+++ b/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_02.json
@@ -3323,9 +3323,10 @@
         },
         "data system document": {
             "file name": "thermo_fisher_qubit_flex_example_02.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_02.xlsx",
             "software name": "Qubit Flex software",
             "ASM converter name": "allotropy_thermo_fisher_qubit_flex",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_03.json
+++ b/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_03.json
@@ -770,9 +770,10 @@
         },
         "data system document": {
             "file name": "thermo_fisher_qubit_flex_example_03.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_fisher_qubit_flex/testdata/thermo_fisher_qubit_flex_example_03.xlsx",
             "software name": "Qubit Flex software",
             "ASM converter name": "allotropy_thermo_fisher_qubit_flex",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/thermo_skanit/testdata/skanit_data.json
+++ b/tests/parsers/thermo_skanit/testdata/skanit_data.json
@@ -3466,11 +3466,11 @@
         },
         "data system document": {
             "file name": "skanit_data.xlsx",
-            "UNC path": "",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/thermo_skanit/testdata/skanit_data.xlsx",
             "software name": "SkanIt Software 7.0 RE for Microplate Readers RE",
             "software version": "7.0.0.50",
             "ASM converter name": "allotropy_thermo_skanit",
-            "ASM converter version": "0.1.52"
+            "ASM converter version": "0.1.58"
         }
     }
 }

--- a/tests/parsers/thermo_skanit/thermo_skanit_structure_test.py
+++ b/tests/parsers/thermo_skanit/thermo_skanit_structure_test.py
@@ -136,7 +136,7 @@ def test_create_metadata() -> None:
     skanit_metadata = ThermoSkanItMetadata.create_metadata(
         instrument_info_df=instrument_info_df,
         general_info_df=general_info_df,
-        file_name="test file",
+        file_path="test_file",
     )
 
     assert skanit_metadata.device_identifier == "Varioskan LUX"
@@ -213,6 +213,6 @@ def test_create_skanit_data() -> None:
         ),
         "Layout definitions": pd.read_excel(file_path, sheet_name="Layout definitions"),
     }
-    skanit_data = DataThermoSkanIt.create(sheet_data=sheet_data, file_name="abc")
+    skanit_data = DataThermoSkanIt.create(sheet_data=sheet_data, file_path="abc")
     assert len(skanit_data.measurement_groups) == 96
     assert skanit_data.metadata.equipment_serial_number == "3020-81776"

--- a/tests/parsers/unchained_labs_lunatic/testdata/2024-07-12_CW288_Plate1.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/2024-07-12_CW288_Plate1.json
@@ -2746,10 +2746,11 @@
         },
         "data system document": {
             "file name": "2024-07-12_CW288_Plate1.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/unchained_labs_lunatic/testdata/2024-07-12_CW288_Plate1.xlsx",
             "software name": "Lunatic and Stunner Analysis",
             "software version": "6.0.0.99",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/unchained_labs_lunatic/testdata/2024-07-16_CW288_Plate2.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/2024-07-16_CW288_Plate2.json
@@ -3658,10 +3658,11 @@
         },
         "data system document": {
             "file name": "2024-07-16_CW288_Plate2.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/unchained_labs_lunatic/testdata/2024-07-16_CW288_Plate2.xlsx",
             "software name": "Lunatic and Stunner Analysis",
             "software version": "6.0.0.99",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/unchained_labs_lunatic/testdata/Demo_A260_dsDNA_Data.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Demo_A260_dsDNA_Data.json
@@ -1194,9 +1194,10 @@
         },
         "data system document": {
             "file name": "Demo_A260_dsDNA_Data.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/unchained_labs_lunatic/testdata/Demo_A260_dsDNA_Data.csv",
             "software name": "Lunatic and Stunner Analysis",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.49"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/unchained_labs_lunatic/testdata/Demo_A280_Protein.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Demo_A280_Protein.json
@@ -1194,9 +1194,10 @@
         },
         "data system document": {
             "file name": "Demo_A280_Protein.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/unchained_labs_lunatic/testdata/Demo_A280_Protein.csv",
             "software name": "Lunatic and Stunner Analysis",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.49"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_no_header.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_no_header.json
@@ -84,9 +84,10 @@
         },
         "data system document": {
             "file name": "Example_Lunatic_Plate_Reader_csv_no_header.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_no_header.csv",
             "software name": "Lunatic and Stunner Analysis",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.49"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_with_header.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_with_header.json
@@ -50,10 +50,11 @@
         },
         "data system document": {
             "file name": "Example_Lunatic_Plate_Reader_csv_with_header.csv",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_with_header.csv",
             "software name": "Lunatic and Stunner Analysis",
             "software version": "8.2.0.259",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_no_header.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_no_header.json
@@ -84,9 +84,10 @@
         },
         "data system document": {
             "file name": "Example_Lunatic_Plate_Reader_xlsx_no_header.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_no_header.xlsx",
             "software name": "Lunatic and Stunner Analysis",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.49"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [

--- a/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_with_header.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_with_header.json
@@ -90,10 +90,11 @@
         },
         "data system document": {
             "file name": "Example_Lunatic_Plate_Reader_xlsx_with_header.xlsx",
+            "UNC path": "/Users/sebastian.cardona/workspace/allotropy/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_with_header.xlsx",
             "software name": "Lunatic and Stunner Analysis",
             "software version": "8.2.0.259",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.56"
+            "ASM converter version": "0.1.58"
         },
         "calculated data aggregate document": {
             "calculated data document": [


### PR DESCRIPTION
Include the real file path and map it to the `data system document` `UNC_path` in all existing adapters.

- The `NamedFileContents` class will now get the full `file_path` instead of just the `file_name` of the instrument file being converted.
- This file path is now used for both the `file name` and `UNC path` properties of the `data system document` when they are not extracted from the instrument files.

TODO:
- Currently the tests are getting the absolute path from where they are stored, this will obviously make the tests fail when running in different systems. We need a way to mock the path to make the tests consistent. Probably the best place to do it will be when instantiating `NamedFileContets`