### PR TITLE
chore: Update vscode settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
   // Use Black for formatting
   "black-formatter.args": [
     "--config",
-    "${workspaceRoot}/pyproject.toml"
+    "${workspaceFolder}/pyproject.toml"
   ],
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter",
@@ -33,6 +33,9 @@
     "editor.codeActionsOnSave": {
       "source.organizeImports": "explicit"
     }
+  },
+  "[plaintext]": {
+    "files.trimTrailingWhitespace": false
   },
   "search.useIgnoreFiles": true,
   "python.testing.pytestArgs": [


### PR DESCRIPTION
Updated .vscode settins:

- Replace `workspaceRoot` with `workspaceFolder` since the former has been [deprecated](https://code.visualstudio.com/docs/editor/variables-reference#_why-isnt-workspaceroot-documented) in favor of the latter.
- Turn off the trimming of trailing whitespace in plaintext (`.txt`) files. This is to prevent corrupting instrument files when editing them (some instruments like softmaxpro use tab separated tables that might contain empty measurements)