### PR TITLE
fix: Global - update schemas to align the use of `μ` characters with allotrope

### DIFF
--- a/src/allotropy/allotrope/models/shared/definitions/units.py
+++ b/src/allotropy/allotrope/models/shared/definitions/units.py
@@ -86,12 +86,12 @@ class Microliter(HasUnit):
 
 @dataclass(frozen=True, kw_only=True)
 class MicroliterPerMinute(HasUnit):
-    unit: str = "μL/min"
+    unit: str = "µL/min"
 
 
 @dataclass(frozen=True, kw_only=True)
 class Micrometer(HasUnit):
-    unit: str = "μm"
+    unit: str = "µm"
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/allotropy/allotrope/schemas/adm/liquid-chromatography/BENCHLING/2023/09/liquid-chromatography.schema.json
+++ b/src/allotropy/allotrope/schemas/adm/liquid-chromatography/BENCHLING/2023/09/liquid-chromatography.schema.json
@@ -7754,11 +7754,11 @@
             "unit"
           ]
         },
-        "keV/μm": {
+        "keV/µm": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "keV/μm",
+              "const": "keV/µm",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#KiloElectronVoltPerMicrometer"
             }
           },
@@ -11678,11 +11678,11 @@
             "unit"
           ]
         },
-        "μG": {
+        "µG": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μG",
+              "const": "µG",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#Microgravity"
             }
           },
@@ -11690,11 +11690,11 @@
             "unit"
           ]
         },
-        "μH": {
+        "µH": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μH",
+              "const": "µH",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroHenry"
             }
           },
@@ -11702,11 +11702,11 @@
             "unit"
           ]
         },
-        "μL/min": {
+        "µL/min": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μL/min",
+              "const": "µL/min",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroliterPerMinute"
             }
           },
@@ -11714,11 +11714,11 @@
             "unit"
           ]
         },
-        "μL/s": {
+        "µL/s": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μL/s",
+              "const": "µL/s",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroliterPerSecond"
             }
           },
@@ -11726,11 +11726,11 @@
             "unit"
           ]
         },
-        "μV": {
+        "µV": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μV",
+              "const": "µV",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#Microvolt"
             }
           },
@@ -11738,11 +11738,11 @@
             "unit"
           ]
         },
-        "μW": {
+        "µW": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μW",
+              "const": "µW",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroWatt"
             }
           },
@@ -11750,11 +11750,11 @@
             "unit"
           ]
         },
-        "μW/g": {
+        "µW/g": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μW/g",
+              "const": "µW/g",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroWattPerGram"
             }
           },
@@ -11762,11 +11762,11 @@
             "unit"
           ]
         },
-        "μcal/°C": {
+        "µcal/°C": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μcal/°C",
+              "const": "µcal/°C",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroCaloriePerDegreeCelsius"
             }
           },
@@ -11774,11 +11774,11 @@
             "unit"
           ]
         },
-        "μin": {
+        "µin": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μin",
+              "const": "µin",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroInch"
             }
           },
@@ -11798,11 +11798,11 @@
             "unit"
           ]
         },
-        "μs": {
+        "µs": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μs",
+              "const": "µs",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroSecond"
             }
           },
@@ -11810,11 +11810,11 @@
             "unit"
           ]
         },
-        "μtorr": {
+        "µtorr": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μtorr",
+              "const": "µtorr",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroTorr"
             }
           },

--- a/src/allotropy/allotrope/schemas/adm/liquid-chromatography/BENCHLING/2023/09/liquid-chromatography.schema.json
+++ b/src/allotropy/allotrope/schemas/adm/liquid-chromatography/BENCHLING/2023/09/liquid-chromatography.schema.json
@@ -108,7 +108,7 @@
                                                   "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2023/09/core.schema#/$defs/tQuantityValue"
                                                 },
                                                 {
-                                                  "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2023/09/units.schema#/$defs/μm"
+                                                  "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2023/09/units.schema#/$defs/µm"
                                                 }
                                               ]
                                             },
@@ -11786,11 +11786,11 @@
             "unit"
           ]
         },
-        "μm": {
+        "µm": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μm",
+              "const": "µm",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#Micrometer"
             }
           },

--- a/src/allotropy/allotrope/schemas/adm/liquid-chromatography/REC/2023/09/liquid-chromatography.schema.json
+++ b/src/allotropy/allotrope/schemas/adm/liquid-chromatography/REC/2023/09/liquid-chromatography.schema.json
@@ -108,7 +108,7 @@
                                                   "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2023/09/core.schema#/$defs/tQuantityValue"
                                                 },
                                                 {
-                                                  "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2023/09/units.schema#/$defs/μm"
+                                                  "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2023/09/units.schema#/$defs/µm"
                                                 }
                                               ]
                                             },
@@ -11710,11 +11710,11 @@
             "unit"
           ]
         },
-        "μm": {
+        "µm": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μm",
+              "const": "µm",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#Micrometer"
             }
           },

--- a/src/allotropy/allotrope/schemas/adm/liquid-chromatography/REC/2023/09/liquid-chromatography.schema.json
+++ b/src/allotropy/allotrope/schemas/adm/liquid-chromatography/REC/2023/09/liquid-chromatography.schema.json
@@ -7678,11 +7678,11 @@
             "unit"
           ]
         },
-        "keV/μm": {
+        "keV/µm": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "keV/μm",
+              "const": "keV/µm",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#KiloElectronVoltPerMicrometer"
             }
           },
@@ -11602,11 +11602,11 @@
             "unit"
           ]
         },
-        "μG": {
+        "µG": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μG",
+              "const": "µG",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#Microgravity"
             }
           },
@@ -11614,11 +11614,11 @@
             "unit"
           ]
         },
-        "μH": {
+        "µH": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μH",
+              "const": "µH",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroHenry"
             }
           },
@@ -11626,11 +11626,11 @@
             "unit"
           ]
         },
-        "μL/min": {
+        "µL/min": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μL/min",
+              "const": "µL/min",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroliterPerMinute"
             }
           },
@@ -11638,11 +11638,11 @@
             "unit"
           ]
         },
-        "μL/s": {
+        "µL/s": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μL/s",
+              "const": "µL/s",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroliterPerSecond"
             }
           },
@@ -11650,11 +11650,11 @@
             "unit"
           ]
         },
-        "μV": {
+        "µV": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μV",
+              "const": "µV",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#Microvolt"
             }
           },
@@ -11662,11 +11662,11 @@
             "unit"
           ]
         },
-        "μW": {
+        "µW": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μW",
+              "const": "µW",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroWatt"
             }
           },
@@ -11674,11 +11674,11 @@
             "unit"
           ]
         },
-        "μW/g": {
+        "µW/g": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μW/g",
+              "const": "µW/g",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroWattPerGram"
             }
           },
@@ -11686,11 +11686,11 @@
             "unit"
           ]
         },
-        "μcal/°C": {
+        "µcal/°C": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μcal/°C",
+              "const": "µcal/°C",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroCaloriePerDegreeCelsius"
             }
           },
@@ -11698,11 +11698,11 @@
             "unit"
           ]
         },
-        "μin": {
+        "µin": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μin",
+              "const": "µin",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroInch"
             }
           },
@@ -11722,11 +11722,11 @@
             "unit"
           ]
         },
-        "μs": {
+        "µs": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μs",
+              "const": "µs",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroSecond"
             }
           },
@@ -11734,11 +11734,11 @@
             "unit"
           ]
         },
-        "μtorr": {
+        "µtorr": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μtorr",
+              "const": "µtorr",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroTorr"
             }
           },

--- a/src/allotropy/allotrope/schemas/adm/multi-analyte-profiling/REC/2024/09/multi-analyte-profiling.schema.json
+++ b/src/allotropy/allotrope/schemas/adm/multi-analyte-profiling/REC/2024/09/multi-analyte-profiling.schema.json
@@ -11810,7 +11810,7 @@
             "unit"
           ]
         },
-        "μm": {
+        "µm": {
           "properties": {
             "unit": {
               "type": "string",

--- a/src/allotropy/allotrope/schemas/adm/multi-analyte-profiling/REC/2024/09/multi-analyte-profiling.schema.json
+++ b/src/allotropy/allotrope/schemas/adm/multi-analyte-profiling/REC/2024/09/multi-analyte-profiling.schema.json
@@ -7730,11 +7730,11 @@
             "unit"
           ]
         },
-        "keV/μm": {
+        "keV/µm": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "keV/μm",
+              "const": "keV/µm",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#KiloElectronVoltPerMicrometer"
             }
           },
@@ -11702,11 +11702,11 @@
             "unit"
           ]
         },
-        "μG": {
+        "µG": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μG",
+              "const": "µG",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#Microgravity"
             }
           },
@@ -11714,11 +11714,11 @@
             "unit"
           ]
         },
-        "μH": {
+        "µH": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μH",
+              "const": "µH",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroHenry"
             }
           },
@@ -11726,11 +11726,11 @@
             "unit"
           ]
         },
-        "μL/min": {
+        "µL/min": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μL/min",
+              "const": "µL/min",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroliterPerMinute"
             }
           },
@@ -11738,11 +11738,11 @@
             "unit"
           ]
         },
-        "μL/s": {
+        "µL/s": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μL/s",
+              "const": "µL/s",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroliterPerSecond"
             }
           },
@@ -11750,11 +11750,11 @@
             "unit"
           ]
         },
-        "μV": {
+        "µV": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μV",
+              "const": "µV",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#Microvolt"
             }
           },
@@ -11762,11 +11762,11 @@
             "unit"
           ]
         },
-        "μW": {
+        "µW": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μW",
+              "const": "µW",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroWatt"
             }
           },
@@ -11774,11 +11774,11 @@
             "unit"
           ]
         },
-        "μW/g": {
+        "µW/g": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μW/g",
+              "const": "µW/g",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroWattPerGram"
             }
           },
@@ -11786,11 +11786,11 @@
             "unit"
           ]
         },
-        "μcal/°C": {
+        "µcal/°C": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μcal/°C",
+              "const": "µcal/°C",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroCaloriePerDegreeCelsius"
             }
           },
@@ -11798,11 +11798,11 @@
             "unit"
           ]
         },
-        "μin": {
+        "µin": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μin",
+              "const": "µin",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroInch"
             }
           },
@@ -11822,11 +11822,11 @@
             "unit"
           ]
         },
-        "μs": {
+        "µs": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μs",
+              "const": "µs",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroSecond"
             }
           },
@@ -11834,11 +11834,11 @@
             "unit"
           ]
         },
-        "μtorr": {
+        "µtorr": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μtorr",
+              "const": "µtorr",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroTorr"
             }
           },

--- a/src/allotropy/allotrope/schemas/adm/solution-analyzer/REC/2024/03/solution-analyzer.schema.json
+++ b/src/allotropy/allotrope/schemas/adm/solution-analyzer/REC/2024/03/solution-analyzer.schema.json
@@ -11064,11 +11064,11 @@
             "unit"
           ]
         },
-        "μm": {
+        "µm": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μm",
+              "const": "µm",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#Micrometer"
             }
           },
@@ -11709,7 +11709,7 @@
                                 "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2024/03/core.schema#/$defs/tQuantityValue"
                               },
                               {
-                                "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/03/units.schema#/$defs/μm"
+                                "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/µm"
                               }
                             ]
                           },
@@ -11721,7 +11721,7 @@
                                 "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2024/03/core.schema#/$defs/tQuantityValue"
                               },
                               {
-                                "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/03/units.schema#/$defs/μm"
+                                "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/µm"
                               }
                             ]
                           }
@@ -11783,7 +11783,7 @@
                             "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2024/03/core.schema#/$defs/tQuantityValue"
                           },
                           {
-                            "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/03/units.schema#/$defs/μm"
+                            "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/µm"
                           }
                         ]
                       },
@@ -11795,7 +11795,7 @@
                             "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2024/03/core.schema#/$defs/tQuantityValue"
                           },
                           {
-                            "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/03/units.schema#/$defs/μm"
+                            "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/µm"
                           }
                         ]
                       },
@@ -11807,7 +11807,7 @@
                             "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2024/03/core.schema#/$defs/tQuantityValue"
                           },
                           {
-                            "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/03/units.schema#/$defs/μm"
+                            "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/µm"
                           }
                         ]
                       },

--- a/src/allotropy/allotrope/schemas/adm/solution-analyzer/REC/2024/03/solution-analyzer.schema.json
+++ b/src/allotropy/allotrope/schemas/adm/solution-analyzer/REC/2024/03/solution-analyzer.schema.json
@@ -7020,11 +7020,11 @@
             "unit"
           ]
         },
-        "keV/μm": {
+        "keV/µm": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "keV/μm",
+              "const": "keV/µm",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#KiloElectronVoltPerMicrometer"
             }
           },
@@ -10956,11 +10956,11 @@
             "unit"
           ]
         },
-        "μG": {
+        "µG": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μG",
+              "const": "µG",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#Microgravity"
             }
           },
@@ -10968,11 +10968,11 @@
             "unit"
           ]
         },
-        "μH": {
+        "µH": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μH",
+              "const": "µH",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroHenry"
             }
           },
@@ -10980,11 +10980,11 @@
             "unit"
           ]
         },
-        "μL/min": {
+        "µL/min": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μL/min",
+              "const": "µL/min",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroliterPerMinute"
             }
           },
@@ -10992,11 +10992,11 @@
             "unit"
           ]
         },
-        "μL/s": {
+        "µL/s": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μL/s",
+              "const": "µL/s",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroliterPerSecond"
             }
           },
@@ -11004,11 +11004,11 @@
             "unit"
           ]
         },
-        "μV": {
+        "µV": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μV",
+              "const": "µV",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#Microvolt"
             }
           },
@@ -11016,11 +11016,11 @@
             "unit"
           ]
         },
-        "μW": {
+        "µW": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μW",
+              "const": "µW",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroWatt"
             }
           },
@@ -11028,11 +11028,11 @@
             "unit"
           ]
         },
-        "μW/g": {
+        "µW/g": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μW/g",
+              "const": "µW/g",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroWattPerGram"
             }
           },
@@ -11040,11 +11040,11 @@
             "unit"
           ]
         },
-        "μcal/°C": {
+        "µcal/°C": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μcal/°C",
+              "const": "µcal/°C",
               "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroCaloriePerDegreeCelsius"
             }
           },
@@ -11052,11 +11052,11 @@
             "unit"
           ]
         },
-        "μin": {
+        "µin": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μin",
+              "const": "µin",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroInch"
             }
           },
@@ -11076,11 +11076,11 @@
             "unit"
           ]
         },
-        "μs": {
+        "µs": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μs",
+              "const": "µs",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroSecond"
             }
           },
@@ -11088,11 +11088,11 @@
             "unit"
           ]
         },
-        "μtorr": {
+        "µtorr": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μtorr",
+              "const": "µtorr",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#MicroTorr"
             }
           },

--- a/src/allotropy/allotrope/schemas/adm/solution-analyzer/REC/2024/09/solution-analyzer.schema.json
+++ b/src/allotropy/allotrope/schemas/adm/solution-analyzer/REC/2024/09/solution-analyzer.schema.json
@@ -11629,11 +11629,11 @@
             "unit"
           ]
         },
-        "μm": {
+        "µm": {
           "properties": {
             "unit": {
               "type": "string",
-              "const": "μm",
+              "const": "µm",
               "$asm.unit-iri": "http://qudt.org/vocab/unit#Micrometer"
             }
           },
@@ -12246,7 +12246,7 @@
                                 "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2024/09/core.schema#/$defs/tQuantityValue"
                               },
                               {
-                                "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/μm"
+                                "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/µm"
                               }
                             ]
                           },
@@ -12258,7 +12258,7 @@
                                 "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2024/09/core.schema#/$defs/tQuantityValue"
                               },
                               {
-                                "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/μm"
+                                "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/µm"
                               }
                             ]
                           }
@@ -12320,7 +12320,7 @@
                             "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2024/09/core.schema#/$defs/tQuantityValue"
                           },
                           {
-                            "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/μm"
+                            "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/µm"
                           }
                         ]
                       },
@@ -12332,7 +12332,7 @@
                             "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2024/09/core.schema#/$defs/tQuantityValue"
                           },
                           {
-                            "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/μm"
+                            "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/µm"
                           }
                         ]
                       },
@@ -12344,7 +12344,7 @@
                             "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2024/09/core.schema#/$defs/tQuantityValue"
                           },
                           {
-                            "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/μm"
+                            "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/µm"
                           }
                         ]
                       },
@@ -12715,7 +12715,7 @@
                                           "$ref": "http://purl.allotrope.org/json-schemas/adm/core/REC/2024/09/core.schema#/$defs/tQuantityValue"
                                         },
                                         {
-                                          "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/μm"
+                                          "$ref": "http://purl.allotrope.org/json-schemas/qudt/REC/2024/09/units.schema#/$defs/µm"
                                         }
                                       ]
                                     },

--- a/src/allotropy/allotrope/schemas/shared/definitions/units.json
+++ b/src/allotropy/allotrope/schemas/shared/definitions/units.json
@@ -183,7 +183,7 @@
     "properties": {
       "unit": {
         "type": "string",
-        "const": "μL/min",
+        "const": "µL/min",
         "$asm.unit-iri": "http://purl.allotrope.org/ontology/qudt-ext/unit#MicroliterPerMinute"
       }
     },
@@ -195,7 +195,7 @@
     "properties": {
       "unit": {
         "type": "string",
-        "const": "μm",
+        "const": "µm",
         "$asm.unit-iri": "http://qudt.org/vocab/unit#Micrometer"
       }
     },

--- a/src/allotropy/parsers/beckman_pharmspec/constants.py
+++ b/src/allotropy/parsers/beckman_pharmspec/constants.py
@@ -3,7 +3,7 @@ DEVICE_TYPE = "solution-analyzer"
 
 # This map is used to map the column names to units, for calculated data items.
 UNIT_LOOKUP = {
-    "particle_size": "μm",
+    "particle_size": "µm",
     "cumulative_count": "(unitless)",
     "cumulative_particle_density": "Counts/mL",
     "differential_particle_density": "Counts/mL",

--- a/tests/parsers/beckman_pharmspec/testdata/hiac_example_1.json
+++ b/tests/parsers/beckman_pharmspec/testdata/hiac_example_1.json
@@ -89,7 +89,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 2.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 48.0,
@@ -112,7 +112,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 5.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 1.0,
@@ -135,7 +135,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 10.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -158,7 +158,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 25.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -181,7 +181,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 50.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -291,7 +291,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 2.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 24.0,
@@ -314,7 +314,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 5.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 9.0,
@@ -337,7 +337,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 10.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 4.0,
@@ -360,7 +360,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 25.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -383,7 +383,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 50.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -421,7 +421,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 2.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_15",
                     "data source aggregate document": {
@@ -481,7 +481,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 5.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_18",
                     "data source aggregate document": {
@@ -541,7 +541,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 10.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_21",
                     "data source aggregate document": {
@@ -601,7 +601,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 25.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_24",
                     "data source aggregate document": {
@@ -661,7 +661,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 50.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_27",
                     "data source aggregate document": {

--- a/tests/parsers/beckman_pharmspec/testdata/hiac_example_2.json
+++ b/tests/parsers/beckman_pharmspec/testdata/hiac_example_2.json
@@ -89,7 +89,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 2.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 48.0,
@@ -112,7 +112,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 5.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 1.0,
@@ -135,7 +135,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 10.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -158,7 +158,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 25.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -181,7 +181,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 50.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -291,7 +291,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 2.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 24.0,
@@ -314,7 +314,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 5.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 9.0,
@@ -337,7 +337,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 10.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 4.0,
@@ -360,7 +360,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 25.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -383,7 +383,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 50.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -493,7 +493,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 2.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 24.0,
@@ -516,7 +516,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 5.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 9.0,
@@ -539,7 +539,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 10.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 4.0,
@@ -562,7 +562,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 25.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -585,7 +585,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 50.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -623,7 +623,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 2.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_20",
                     "data source aggregate document": {
@@ -695,7 +695,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 5.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_23",
                     "data source aggregate document": {
@@ -767,7 +767,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 10.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_26",
                     "data source aggregate document": {
@@ -839,7 +839,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 25.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_29",
                     "data source aggregate document": {
@@ -911,7 +911,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 50.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_32",
                     "data source aggregate document": {

--- a/tests/parsers/beckman_pharmspec/testdata/hiac_example_3.json
+++ b/tests/parsers/beckman_pharmspec/testdata/hiac_example_3.json
@@ -89,7 +89,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 2.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 48.0,
@@ -112,7 +112,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 5.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 1.0,
@@ -135,7 +135,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 10.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -158,7 +158,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 25.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -181,7 +181,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 50.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -219,7 +219,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 2.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_10",
                     "data source aggregate document": {
@@ -267,7 +267,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 5.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_13",
                     "data source aggregate document": {
@@ -315,7 +315,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 10.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_16",
                     "data source aggregate document": {
@@ -363,7 +363,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 25.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_19",
                     "data source aggregate document": {
@@ -411,7 +411,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 50.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_22",
                     "data source aggregate document": {

--- a/tests/parsers/beckman_pharmspec/testdata/hiac_example_4.json
+++ b/tests/parsers/beckman_pharmspec/testdata/hiac_example_4.json
@@ -89,7 +89,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 2.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 48.0,
@@ -112,7 +112,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 5.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 1.0,
@@ -135,7 +135,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 10.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -158,7 +158,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 25.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -181,7 +181,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 50.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,

--- a/tests/parsers/beckman_pharmspec/testdata/hiac_example_5.json
+++ b/tests/parsers/beckman_pharmspec/testdata/hiac_example_5.json
@@ -89,7 +89,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 2.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 24.0,
@@ -112,7 +112,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 5.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 9.0,
@@ -135,7 +135,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 10.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 4.0,
@@ -158,7 +158,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 25.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -181,7 +181,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 50.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -291,7 +291,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 2.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 48.0,
@@ -314,7 +314,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 5.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 1.0,
@@ -337,7 +337,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 10.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -360,7 +360,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 25.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -383,7 +383,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 50.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -493,7 +493,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 2.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 24.0,
@@ -516,7 +516,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 5.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 9.0,
@@ -539,7 +539,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 10.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 4.0,
@@ -562,7 +562,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 25.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -585,7 +585,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 50.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,

--- a/tests/parsers/beckman_pharmspec/testdata/pharmspec_example_01.json
+++ b/tests/parsers/beckman_pharmspec/testdata/pharmspec_example_01.json
@@ -89,7 +89,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 2.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 48.0,
@@ -112,7 +112,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 5.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 1.0,
@@ -135,7 +135,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 10.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -158,7 +158,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 25.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -181,7 +181,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 50.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -291,7 +291,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 2.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 24.0,
@@ -314,7 +314,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 5.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 9.0,
@@ -337,7 +337,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 10.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 4.0,
@@ -360,7 +360,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 25.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -383,7 +383,7 @@
                                                 {
                                                     "particle size": {
                                                         "value": 50.0,
-                                                        "unit": "μm"
+                                                        "unit": "µm"
                                                     },
                                                     "cumulative count": {
                                                         "value": 0.0,
@@ -421,7 +421,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 2.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_15",
                     "data source aggregate document": {
@@ -481,7 +481,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 5.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_18",
                     "data source aggregate document": {
@@ -541,7 +541,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 10.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_21",
                     "data source aggregate document": {
@@ -601,7 +601,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 25.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_24",
                     "data source aggregate document": {
@@ -661,7 +661,7 @@
                     "calculated data name": "average_particle_size",
                     "calculated result": {
                         "value": 50.0,
-                        "unit": "μm"
+                        "unit": "µm"
                     },
                     "calculated data identifier": "BECKMAN_PHARMSPEC_TEST_ID_27",
                     "data source aggregate document": {

--- a/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_different_mu_character.json
+++ b/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_different_mu_character.json
@@ -38,11 +38,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -51,11 +51,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 18.51,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 18.72,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2191,

--- a/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01.json
+++ b/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01.json
@@ -38,11 +38,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -51,11 +51,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 18.51,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 18.72,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2191,
@@ -117,11 +117,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -130,11 +130,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 19.24,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 19.48,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 7670,
@@ -196,11 +196,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -209,11 +209,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.22,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 17.34,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1519,
@@ -275,11 +275,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -288,11 +288,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 19.85,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 20.03,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3195,
@@ -354,11 +354,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -367,11 +367,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.95,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 18.27,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2493,
@@ -433,11 +433,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -446,11 +446,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 18.85,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 19.1,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2920,
@@ -512,11 +512,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -525,11 +525,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 19.29,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 19.42,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average total cell circularity": {
                                             "value": 0.87,
@@ -583,11 +583,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -596,11 +596,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 19.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 19.62,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5284,
@@ -662,11 +662,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -675,11 +675,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.46,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 18.17,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 11360,
@@ -741,11 +741,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -754,11 +754,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.52,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 18.67,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 9799,

--- a/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01_utf16.json
+++ b/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01_utf16.json
@@ -38,11 +38,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -51,11 +51,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 18.51,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 18.72,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2191,
@@ -117,11 +117,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -130,11 +130,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 19.24,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 19.48,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 7670,
@@ -196,11 +196,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -209,11 +209,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.22,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 17.34,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1519,
@@ -275,11 +275,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -288,11 +288,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 19.85,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 20.03,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3195,
@@ -354,11 +354,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -367,11 +367,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.95,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 18.27,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2493,
@@ -433,11 +433,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -446,11 +446,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 18.85,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 19.1,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2920,
@@ -512,11 +512,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -525,11 +525,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 19.29,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 19.42,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 7001,
@@ -591,11 +591,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -604,11 +604,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 19.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 19.62,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5284,
@@ -670,11 +670,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -683,11 +683,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.46,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 18.17,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 11360,
@@ -749,11 +749,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 6.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 30.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -762,11 +762,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.52,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 18.67,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 9799,

--- a/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example02.json
+++ b/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example02.json
@@ -38,11 +38,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 7.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 50.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -51,11 +51,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 16.32,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1204,
@@ -117,11 +117,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 7.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 50.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -130,11 +130,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.1,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 15.51,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 501,
@@ -196,11 +196,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 7.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 50.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -209,11 +209,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 16.03,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1722,
@@ -275,11 +275,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 7.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 50.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -288,11 +288,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.96,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 16.26,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1778,
@@ -354,11 +354,11 @@
                                             },
                                             "minimum cell diameter setting": {
                                                 "value": 7.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "maximum cell diameter setting": {
                                                 "value": 50.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             }
                                         },
                                         "total cell density (cell counter)": {
@@ -367,11 +367,11 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.53,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 15.93,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 829,

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.04/Beckman_Vi-Cell-XR_example03_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.04/Beckman_Vi-Cell-XR_example03_instrumentOutput.json
@@ -43,7 +43,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.61550412902832,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1752,
@@ -106,7 +106,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.795691354370117,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4728,
@@ -169,7 +169,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.810836656188965,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4540,
@@ -232,7 +232,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.494943482971191,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4358,
@@ -295,7 +295,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.467296464538574,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4057,
@@ -358,7 +358,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.091128213500976,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4101,
@@ -421,7 +421,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.763769967651367,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4911,
@@ -484,7 +484,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.59937749633789,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4553,
@@ -547,7 +547,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.13992105255127,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3160,
@@ -610,7 +610,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.105061395263672,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2901,
@@ -673,7 +673,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.578362329101562,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2980,
@@ -736,7 +736,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.081515176391601,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2759,
@@ -799,7 +799,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.616611344909668,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 767,
@@ -862,7 +862,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.16023240814209,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1046,
@@ -925,7 +925,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.599280221557617,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 961,
@@ -988,7 +988,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.33806215057373,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 901,
@@ -1051,7 +1051,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 9.678506715393066,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1045,
@@ -1114,7 +1114,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.195168359375,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1102,
@@ -1177,7 +1177,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.08920846710205,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1285,
@@ -1240,7 +1240,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.811142785644531,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1410,
@@ -1303,7 +1303,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.8708275390625,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1161,
@@ -1366,7 +1366,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.407616479492187,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1479,
@@ -1429,7 +1429,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.807673318481445,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1263,
@@ -1492,7 +1492,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.604998452758789,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2242,
@@ -1555,7 +1555,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.512700898742676,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3136,
@@ -1618,7 +1618,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.350641114807129,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2221,
@@ -1681,7 +1681,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.533931596374511,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2102,
@@ -1744,7 +1744,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 9.848688943481445,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1031,
@@ -1807,7 +1807,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.07056890258789,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4096,
@@ -1870,7 +1870,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.025838716125488,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4641,
@@ -1933,7 +1933,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.43000779876709,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1753,
@@ -1996,7 +1996,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.350288255310058,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1791,
@@ -2059,7 +2059,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.920673234558105,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2306,
@@ -2122,7 +2122,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.895398957824707,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1246,

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example01_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example01_instrumentOutput.json
@@ -43,7 +43,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.12,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 135,
@@ -106,7 +106,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 4.89,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 985,
@@ -169,7 +169,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.16,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 636,
@@ -232,7 +232,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.26,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 949,
@@ -295,7 +295,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.18,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 936,
@@ -358,7 +358,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 891,
@@ -421,7 +421,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.52,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 835,
@@ -484,7 +484,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.34,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1038,
@@ -547,7 +547,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.29,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 736,
@@ -610,7 +610,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 732,
@@ -673,7 +673,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 4.97,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1095,
@@ -736,7 +736,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.51,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 838,
@@ -799,7 +799,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.41,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1080,
@@ -862,7 +862,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.46,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 629,
@@ -925,7 +925,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.51,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 750,
@@ -988,7 +988,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 692,
@@ -1051,7 +1051,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1013,
@@ -1114,7 +1114,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.41,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1124,
@@ -1177,7 +1177,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.25,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1077,
@@ -1240,7 +1240,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.48,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1163,
@@ -1303,7 +1303,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.26,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1541,
@@ -1366,7 +1366,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.94,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1386,
@@ -1429,7 +1429,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.81,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1569,
@@ -1492,7 +1492,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1187,
@@ -1555,7 +1555,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.75,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 942,
@@ -1618,7 +1618,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.85,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3206,
@@ -1681,7 +1681,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.33,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 790,
@@ -1744,7 +1744,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.38,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1412,
@@ -1807,7 +1807,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.62,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1276,
@@ -1870,7 +1870,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1096,
@@ -1933,7 +1933,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.98,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1125,
@@ -1996,7 +1996,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.51,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1213,
@@ -2059,7 +2059,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.05,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 265,
@@ -2122,7 +2122,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1653,
@@ -2185,7 +2185,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.02,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3103,
@@ -2248,7 +2248,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.52,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1587,
@@ -2311,7 +2311,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.24,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1714,
@@ -2374,7 +2374,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.87,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1533,
@@ -2437,7 +2437,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.84,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1248,
@@ -2500,7 +2500,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.92,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1662,
@@ -2563,7 +2563,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.85,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1401,
@@ -2626,7 +2626,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.04,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1161,
@@ -2689,7 +2689,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.17,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3333,
@@ -2752,7 +2752,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.94,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1138,
@@ -2815,7 +2815,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.64,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1356,
@@ -2878,7 +2878,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.75,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1266,
@@ -2941,7 +2941,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.87,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1180,
@@ -3004,7 +3004,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.97,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1227,
@@ -3067,7 +3067,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.88,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1793,
@@ -3130,7 +3130,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.37,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2177,
@@ -3193,7 +3193,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.34,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5185,
@@ -3256,7 +3256,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.31,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1671,
@@ -3319,7 +3319,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.93,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2129,
@@ -3382,7 +3382,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2218,
@@ -3445,7 +3445,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.17,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2002,
@@ -3508,7 +3508,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.03,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1819,
@@ -3571,7 +3571,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.36,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2090,
@@ -3634,7 +3634,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.35,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4876,
@@ -3697,7 +3697,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.36,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1849,
@@ -3760,7 +3760,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.03,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1771,
@@ -3823,7 +3823,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2066,
@@ -3886,7 +3886,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.43,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1876,
@@ -3949,7 +3949,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.51,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2176,
@@ -4012,7 +4012,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.27,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2694,
@@ -4075,7 +4075,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.05,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2429,
@@ -4138,7 +4138,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.43,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4919,
@@ -4201,7 +4201,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.19,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1966,
@@ -4264,7 +4264,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2416,
@@ -4327,7 +4327,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.27,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1804,
@@ -4390,7 +4390,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.17,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2142,
@@ -4453,7 +4453,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.29,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2051,
@@ -4516,7 +4516,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.56,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3971,
@@ -4579,7 +4579,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.35,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 7456,
@@ -4642,7 +4642,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.62,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2735,
@@ -4705,7 +4705,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3239,
@@ -4768,7 +4768,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.52,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3642,
@@ -4831,7 +4831,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.55,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3473,
@@ -4894,7 +4894,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.63,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3389,
@@ -4957,7 +4957,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.62,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3134,
@@ -5020,7 +5020,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.56,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3727,
@@ -5083,7 +5083,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.44,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 7863,
@@ -5146,7 +5146,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.52,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3396,
@@ -5209,7 +5209,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.39,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3276,
@@ -5272,7 +5272,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.53,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3539,
@@ -5335,7 +5335,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.57,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3085,
@@ -5398,7 +5398,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3614,
@@ -5461,7 +5461,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.41,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4487,
@@ -5524,7 +5524,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.27,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4135,
@@ -5587,7 +5587,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 7442,
@@ -5650,7 +5650,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.28,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3292,
@@ -5713,7 +5713,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.03,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3827,
@@ -5776,7 +5776,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.48,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3973,
@@ -5839,7 +5839,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.45,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3284,
@@ -5902,7 +5902,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.18,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3813,
@@ -5965,7 +5965,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.44,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3540,
@@ -6028,7 +6028,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.99,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1578,
@@ -6091,7 +6091,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.91,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2987,
@@ -6154,7 +6154,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.16,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1317,
@@ -6217,7 +6217,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.19,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1314,
@@ -6280,7 +6280,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.01,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1484,
@@ -6343,7 +6343,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1264,
@@ -6406,7 +6406,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.09,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1496,
@@ -6469,7 +6469,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.01,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1631,
@@ -6532,7 +6532,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.02,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1462,
@@ -6595,7 +6595,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.97,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3650,
@@ -6658,7 +6658,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.13,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1609,
@@ -6721,7 +6721,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1516,
@@ -6784,7 +6784,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.14,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1338,
@@ -6847,7 +6847,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.12,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1354,
@@ -6910,7 +6910,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.18,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1589,
@@ -6973,7 +6973,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.14,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1886,
@@ -7036,7 +7036,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.12,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1610,
@@ -7099,7 +7099,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.86,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2649,
@@ -7162,7 +7162,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.02,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1525,
@@ -7225,7 +7225,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.98,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1381,
@@ -7288,7 +7288,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.82,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1408,
@@ -7351,7 +7351,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.85,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3640,
@@ -7414,7 +7414,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.82,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1677,
@@ -7477,7 +7477,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.74,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1512,
@@ -7540,7 +7540,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.72,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1366,
@@ -7603,7 +7603,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.22,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1515,
@@ -7666,7 +7666,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1971,
@@ -7729,7 +7729,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.94,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1758,
@@ -7792,7 +7792,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.85,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1589,
@@ -7855,7 +7855,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.95,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4616,
@@ -7918,7 +7918,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.08,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1722,
@@ -7981,7 +7981,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1797,
@@ -8044,7 +8044,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1375,
@@ -8107,7 +8107,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.84,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1255,
@@ -8170,7 +8170,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.07,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1834,
@@ -8233,7 +8233,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.16,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2023,
@@ -8296,7 +8296,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.07,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1920,
@@ -8359,7 +8359,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.92,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3279,
@@ -8422,7 +8422,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.05,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1725,
@@ -8485,7 +8485,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.78,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1376,
@@ -8548,7 +8548,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.81,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1415,
@@ -8611,7 +8611,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.39,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1082,
@@ -8674,7 +8674,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.81,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1908,
@@ -8737,7 +8737,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.14,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2049,
@@ -8800,7 +8800,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.96,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2022,
@@ -8863,7 +8863,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.92,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3883,
@@ -8926,7 +8926,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.13,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1975,
@@ -8989,7 +8989,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.05,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1595,
@@ -9052,7 +9052,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.75,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1508,
@@ -9115,7 +9115,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.73,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1288,
@@ -9178,7 +9178,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.18,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1996,
@@ -9241,7 +9241,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.16,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2256,
@@ -9304,7 +9304,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.91,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1396,
@@ -9367,7 +9367,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.92,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4978,
@@ -9430,7 +9430,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.12,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1963,
@@ -9493,7 +9493,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.05,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1835,
@@ -9556,7 +9556,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.91,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1287,
@@ -9619,7 +9619,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.72,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1198,
@@ -9682,7 +9682,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.01,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2002,
@@ -9745,7 +9745,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.93,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1971,
@@ -9808,7 +9808,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1359,
@@ -9871,7 +9871,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.81,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3953,
@@ -9934,7 +9934,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.12,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2121,
@@ -9997,7 +9997,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.88,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1391,
@@ -10060,7 +10060,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.79,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1398,
@@ -10123,7 +10123,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.38,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1291,
@@ -10186,7 +10186,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.93,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2155,
@@ -10249,7 +10249,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 6.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2133,
@@ -10312,7 +10312,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.73,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1396,
@@ -10375,7 +10375,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.88,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4911,
@@ -10438,7 +10438,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.62,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2432,
@@ -10501,7 +10501,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.68,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1897,
@@ -10564,7 +10564,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.86,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1246,
@@ -10627,7 +10627,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.77,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1215,
@@ -10690,7 +10690,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.56,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2171,
@@ -10753,7 +10753,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.81,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2714,
@@ -10816,7 +10816,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.19,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1361,
@@ -10879,7 +10879,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4312,
@@ -10942,7 +10942,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2260,
@@ -11005,7 +11005,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.45,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1347,
@@ -11068,7 +11068,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.53,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1283,
@@ -11131,7 +11131,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.14,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1144,
@@ -11194,7 +11194,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.29,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1976,
@@ -11257,7 +11257,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.61,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2245,
@@ -11320,7 +11320,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.46,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2339,
@@ -11383,7 +11383,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.45,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4109,
@@ -11446,7 +11446,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.65,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2271,
@@ -11509,7 +11509,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.67,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1421,
@@ -11572,7 +11572,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.63,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1405,
@@ -11635,7 +11635,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1202,
@@ -11698,7 +11698,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.49,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2141,
@@ -11761,7 +11761,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.69,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2566,

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example04_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example04_instrumentOutput.json
@@ -43,7 +43,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 943,
@@ -106,7 +106,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 933,
@@ -169,7 +169,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1304,
@@ -232,7 +232,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 971,
@@ -295,7 +295,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1468,
@@ -358,7 +358,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1513,
@@ -421,7 +421,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1323,
@@ -484,7 +484,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 966,
@@ -547,7 +547,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1073,
@@ -610,7 +610,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1088,
@@ -673,7 +673,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1317,
@@ -736,7 +736,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 942,
@@ -799,7 +799,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 995,
@@ -862,7 +862,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 664,
@@ -925,7 +925,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 512,
@@ -988,7 +988,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 670,

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example05_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example05_instrumentOutput.json
@@ -43,7 +43,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1027,
@@ -106,7 +106,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2123,
@@ -169,7 +169,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3082,
@@ -232,7 +232,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1519,

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example06_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example06_instrumentOutput.json
@@ -43,7 +43,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.12,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 135,
@@ -106,7 +106,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 4.89,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 985,
@@ -169,7 +169,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 5.16,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 636,

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example07_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example07_instrumentOutput.json
@@ -43,7 +43,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4263,

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example08_instrumentOutput.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_example08_instrumentOutput.json
@@ -43,7 +43,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1960,

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_hiddenRow.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_hiddenRow.json
@@ -43,7 +43,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6622,
@@ -106,7 +106,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.1,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6165,
@@ -169,7 +169,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6133,
@@ -232,7 +232,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5721,
@@ -295,7 +295,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6049,
@@ -358,7 +358,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5920,
@@ -421,7 +421,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5845,
@@ -484,7 +484,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5950,
@@ -547,7 +547,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5730,
@@ -610,7 +610,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5889,
@@ -673,7 +673,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5822,
@@ -736,7 +736,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5830,
@@ -799,7 +799,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6006,
@@ -862,7 +862,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5428,
@@ -925,7 +925,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.1,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5748,
@@ -988,7 +988,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6191,
@@ -1051,7 +1051,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5854,
@@ -1114,7 +1114,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6085,
@@ -1177,7 +1177,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6399,
@@ -1240,7 +1240,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5675,
@@ -1303,7 +1303,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5502,
@@ -1366,7 +1366,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.1,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5863,
@@ -1429,7 +1429,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6071,
@@ -1492,7 +1492,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6570,

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_no_total_cells.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/Beckman_Vi-Cell-XR_no_total_cells.json
@@ -39,7 +39,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6622,
@@ -98,7 +98,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.1,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6165,
@@ -157,7 +157,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6133,
@@ -216,7 +216,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5721,
@@ -275,7 +275,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6049,
@@ -334,7 +334,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5920,
@@ -393,7 +393,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5845,
@@ -452,7 +452,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5950,
@@ -511,7 +511,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5730,
@@ -570,7 +570,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5889,
@@ -629,7 +629,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5822,
@@ -688,7 +688,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5830,
@@ -747,7 +747,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6006,
@@ -806,7 +806,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5428,
@@ -865,7 +865,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.1,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5748,
@@ -924,7 +924,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6191,
@@ -983,7 +983,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5854,
@@ -1042,7 +1042,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6085,
@@ -1101,7 +1101,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6399,
@@ -1160,7 +1160,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5675,
@@ -1219,7 +1219,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5502,
@@ -1278,7 +1278,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.1,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5863,
@@ -1337,7 +1337,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6071,
@@ -1396,7 +1396,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6570,

--- a/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/style_fill_incorrect.json
+++ b/tests/parsers/beckman_vi_cell_xr/testdata/v2.06/style_fill_incorrect.json
@@ -43,7 +43,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4469,

--- a/tests/parsers/chemometec_nc_view/testdata/chememotec_nc_view_example.json
+++ b/tests/parsers/chemometec_nc_view/testdata/chememotec_nc_view_example.json
@@ -47,7 +47,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -112,7 +112,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -177,7 +177,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -242,7 +242,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -307,7 +307,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -372,7 +372,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -437,7 +437,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -502,7 +502,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -567,7 +567,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 16.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -632,7 +632,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -697,7 +697,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -762,7 +762,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -827,7 +827,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -892,7 +892,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -957,7 +957,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1022,7 +1022,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1087,7 +1087,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1152,7 +1152,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1217,7 +1217,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1282,7 +1282,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1347,7 +1347,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1412,7 +1412,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.9,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1477,7 +1477,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 14.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1542,7 +1542,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.8,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1607,7 +1607,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.3,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1672,7 +1672,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1737,7 +1737,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1802,7 +1802,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 18.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1867,7 +1867,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 18.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1932,7 +1932,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 17.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -1997,7 +1997,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 18.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {
@@ -2062,7 +2062,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 18.6,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "custom information document": {
                                             "cell aggregation percentage": {

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example01.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example01.json
@@ -46,7 +46,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 9.1,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         }
                                     }
                                 ]

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example02.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example02.json
@@ -46,7 +46,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         }
                                     }
                                 ]

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example03.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example03.json
@@ -46,7 +46,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.2,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         }
                                     }
                                 ]

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example04.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example04.json
@@ -46,7 +46,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": "NaN",
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         }
                                     }
                                 ]

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example05.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example05.json
@@ -46,7 +46,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": "NaN",
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         }
                                     }
                                 ]

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example06.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example06.json
@@ -46,7 +46,7 @@
                                         },
                                         "average total cell diameter": {
                                             "value": "NaN",
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         }
                                     }
                                 ]

--- a/tests/parsers/cytiva_unicorn/testdata/unicorn_1.json
+++ b/tests/parsers/cytiva_unicorn/testdata/unicorn_1.json
@@ -26,7 +26,7 @@
                                 "chromatography column chemistry type": "AnionExchange",
                                 "chromatography column particle size": {
                                     "value": 100.0,
-                                    "unit": "μm"
+                                    "unit": "µm"
                                 }
                             },
                             "measurement identifier": "CYTIVA_UNICORN_TEST_ID_1",
@@ -95,7 +95,7 @@
                                 "chromatography column chemistry type": "AnionExchange",
                                 "chromatography column particle size": {
                                     "value": 100.0,
-                                    "unit": "μm"
+                                    "unit": "µm"
                                 }
                             },
                             "measurement identifier": "CYTIVA_UNICORN_TEST_ID_2",
@@ -164,7 +164,7 @@
                                 "chromatography column chemistry type": "AnionExchange",
                                 "chromatography column particle size": {
                                     "value": 100.0,
-                                    "unit": "μm"
+                                    "unit": "µm"
                                 }
                             },
                             "measurement identifier": "CYTIVA_UNICORN_TEST_ID_3",
@@ -233,7 +233,7 @@
                                 "chromatography column chemistry type": "AnionExchange",
                                 "chromatography column particle size": {
                                     "value": 100.0,
-                                    "unit": "μm"
+                                    "unit": "µm"
                                 }
                             },
                             "measurement identifier": "CYTIVA_UNICORN_TEST_ID_4",
@@ -343,7 +343,7 @@
                                 "chromatography column chemistry type": "AnionExchange",
                                 "chromatography column particle size": {
                                     "value": 100.0,
-                                    "unit": "μm"
+                                    "unit": "µm"
                                 }
                             },
                             "measurement identifier": "CYTIVA_UNICORN_TEST_ID_5",
@@ -447,7 +447,7 @@
                                 "chromatography column chemistry type": "AnionExchange",
                                 "chromatography column particle size": {
                                     "value": 100.0,
-                                    "unit": "μm"
+                                    "unit": "µm"
                                 }
                             },
                             "measurement identifier": "CYTIVA_UNICORN_TEST_ID_6",
@@ -621,7 +621,7 @@
                                 "chromatography column chemistry type": "AnionExchange",
                                 "chromatography column particle size": {
                                     "value": 100.0,
-                                    "unit": "μm"
+                                    "unit": "µm"
                                 }
                             },
                             "measurement identifier": "CYTIVA_UNICORN_TEST_ID_7",
@@ -877,7 +877,7 @@
                                 "chromatography column chemistry type": "AnionExchange",
                                 "chromatography column particle size": {
                                     "value": 100.0,
-                                    "unit": "μm"
+                                    "unit": "µm"
                                 }
                             },
                             "measurement identifier": "CYTIVA_UNICORN_TEST_ID_8",
@@ -946,7 +946,7 @@
                                 "chromatography column chemistry type": "AnionExchange",
                                 "chromatography column particle size": {
                                     "value": 100.0,
-                                    "unit": "μm"
+                                    "unit": "µm"
                                 }
                             },
                             "measurement identifier": "CYTIVA_UNICORN_TEST_ID_9",

--- a/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_csv.json
+++ b/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_csv.json
@@ -39,15 +39,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 8.88,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 9.53,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 4.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1342.0,
@@ -105,15 +105,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.25,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.94,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 5.66,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1310.0,
@@ -171,15 +171,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.86,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.59,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 6.69,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1304.0,
@@ -237,15 +237,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.24,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.04,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 6.08,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1318.0,
@@ -303,15 +303,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.06,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.93,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 5.44,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1426.0,
@@ -369,15 +369,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.25,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 5.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1271.0,
@@ -435,15 +435,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.02,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.85,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 5.42,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1391.0,
@@ -501,15 +501,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.21,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.99,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 5.72,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1210.0,
@@ -567,15 +567,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.23,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.95,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 6.24,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1298.0,
@@ -633,15 +633,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.15,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 15.54,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 6.51,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 360.0,
@@ -715,15 +715,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 9.96,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.95,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 5.24,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1219.0,
@@ -781,15 +781,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.18,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.22,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 4.88,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1190.0,
@@ -847,15 +847,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.96,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.96,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 930.0,
@@ -938,15 +938,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.62,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.62,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1062.0,
@@ -1029,15 +1029,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.02,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.02,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 920.0,
@@ -1120,15 +1120,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.17,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.17,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 915.0,
@@ -1211,15 +1211,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.83,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.83,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 882.0,
@@ -1302,15 +1302,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.74,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.74,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 824.0,

--- a/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_xlsx.json
+++ b/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_xlsx.json
@@ -39,15 +39,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 8.88,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 9.53,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 4.5,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1342.0,
@@ -105,15 +105,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.25,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.94,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 5.66,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1310.0,
@@ -171,15 +171,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.86,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.59,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 6.69,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1304.0,
@@ -237,15 +237,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.24,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.04,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 6.08,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1318.0,
@@ -303,15 +303,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.06,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.93,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 5.44,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1426.0,
@@ -369,15 +369,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.4,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.25,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 5.7,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1271.0,
@@ -435,15 +435,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.02,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.85,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 5.42,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1391.0,
@@ -501,15 +501,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.21,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.99,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 5.72,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1210.0,
@@ -567,15 +567,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.23,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.95,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 6.24,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1298.0,
@@ -633,15 +633,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 15.15,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 15.54,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 6.51,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 360.0,
@@ -715,15 +715,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 9.96,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.95,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 5.24,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1219.0,
@@ -781,15 +781,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.18,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.22,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 4.88,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1190.0,
@@ -847,15 +847,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.96,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.96,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 930.0,
@@ -938,15 +938,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 12.62,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.62,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1062.0,
@@ -1029,15 +1029,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.02,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.02,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 920.0,
@@ -1120,15 +1120,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 13.17,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.17,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 915.0,
@@ -1211,15 +1211,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 11.83,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.83,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 882.0,
@@ -1302,15 +1302,15 @@
                                         },
                                         "average total cell diameter": {
                                             "value": 10.74,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.74,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "average dead cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 824.0,

--- a/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_1.json
+++ b/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_1.json
@@ -56,7 +56,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.46355247,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4504.0,
@@ -81,7 +81,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.36649704,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 475.6500549,
@@ -162,7 +162,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.38542843,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4199.0,
@@ -187,7 +187,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.06482315,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 471.4387817,
@@ -268,7 +268,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.02670956,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5573.0,
@@ -293,7 +293,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 50.64849091,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 448.8540344,
@@ -374,7 +374,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.00195885,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6253.0,
@@ -399,7 +399,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 50.55105972,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 447.7957458,
@@ -480,7 +480,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.37015438,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4018.0,
@@ -505,7 +505,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 51.99099731,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 469.8835144,
@@ -586,7 +586,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.27664661,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3994.0,
@@ -611,7 +611,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 51.6265564,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 464.9411621,
@@ -692,7 +692,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.85493851,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6556.0,
@@ -717,7 +717,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 49.97198868,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 438.7392883,
@@ -798,7 +798,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.74926472,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6206.0,
@@ -823,7 +823,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 49.55705261,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 432.0295105,

--- a/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_2.json
+++ b/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_2.json
@@ -56,7 +56,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.46355247,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4504.0,
@@ -81,7 +81,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.36649704,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 475.6500549,
@@ -162,7 +162,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.38542843,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4199.0,
@@ -187,7 +187,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.06482315,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 471.4387817,
@@ -268,7 +268,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.02670956,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5573.0,
@@ -293,7 +293,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 50.64849091,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 448.8540344,
@@ -374,7 +374,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.00195885,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6253.0,
@@ -399,7 +399,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 50.55105972,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 447.7957458,
@@ -480,7 +480,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.37015438,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4018.0,
@@ -505,7 +505,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 51.99099731,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 469.8835144,
@@ -586,7 +586,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.27664661,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3994.0,
@@ -611,7 +611,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 51.6265564,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 464.9411621,
@@ -692,7 +692,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.85493851,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6556.0,
@@ -717,7 +717,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 49.97198868,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 438.7392883,
@@ -798,7 +798,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.74926472,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 6206.0,
@@ -823,7 +823,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 49.55705261,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 432.0295105,

--- a/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_3.json
+++ b/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_3.json
@@ -56,7 +56,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.1762867,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2800.0,
@@ -81,7 +81,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 47.33285522,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 403.375885,
@@ -162,7 +162,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.71258354,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 133.0,
@@ -187,7 +187,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.38261032,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 488.0434875,
@@ -268,7 +268,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.75320816,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 117.0,
@@ -293,7 +293,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.56565475,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 490.6161499,
@@ -374,7 +374,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.73137665,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 125.0,
@@ -399,7 +399,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.46728897,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 489.2336426,
@@ -480,7 +480,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 14.01182365,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 37.0,
@@ -505,7 +505,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 54.54838562,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 506.6774292,
@@ -586,7 +586,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.63530922,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 40.0,
@@ -611,7 +611,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.11764526,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 483.2941284,
@@ -692,7 +692,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.63530922,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 40.0,
@@ -717,7 +717,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.11764526,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 483.2941284,
@@ -798,7 +798,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.61170387,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 136.0,
@@ -823,7 +823,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 481.7796631,
@@ -904,7 +904,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.75320816,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 117.0,
@@ -929,7 +929,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.56565475,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 490.6161499,
@@ -1010,7 +1010,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.73137665,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 125.0,
@@ -1035,7 +1035,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.46728897,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 489.2336426,
@@ -1116,7 +1116,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.75320816,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 117.0,
@@ -1141,7 +1141,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.56565475,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 490.6161499,
@@ -1222,7 +1222,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.73137665,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 250.0,
@@ -1247,7 +1247,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.46728897,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 489.2336426,
@@ -1328,7 +1328,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.66149426,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 269.0,
@@ -1353,7 +1353,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.18884277,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 484.8712463,
@@ -1434,7 +1434,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.6933794,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 237.0,
@@ -1459,7 +1459,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.33831024,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 486.9005127,
@@ -1540,7 +1540,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.74186897,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 242.0,
@@ -1565,7 +1565,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.51456451,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 489.8980713,
@@ -1646,7 +1646,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.75320816,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 234.0,
@@ -1671,7 +1671,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.56565475,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 490.6161499,
@@ -1752,7 +1752,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.86178493,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 236.0,
@@ -1777,7 +1777,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.97000122,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 497.3450012,
@@ -1858,7 +1858,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.60214901,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 144.0,
@@ -1883,7 +1883,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.95238113,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 481.1666565,
@@ -1964,7 +1964,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.75320816,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 117.0,
@@ -1989,7 +1989,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.56565475,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 490.6161499,
@@ -2070,7 +2070,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.56303406,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4337.0,
@@ -2095,7 +2095,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.90089417,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 364.4146118,
@@ -2176,7 +2176,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 14.72414313,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3522.0,
@@ -2201,7 +2201,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 57.32788798,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 575.9165694,
@@ -2282,7 +2282,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5433403,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5714.0,
@@ -2307,7 +2307,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.82298851,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 376.5725906,
@@ -2388,7 +2388,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 13.0,
@@ -2413,7 +2413,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 0.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 0.0,
@@ -2494,7 +2494,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.84303928,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1170.0,
@@ -2519,7 +2519,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.09075342,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 336.8724315,
@@ -2600,7 +2600,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.70926592,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 487.0,
@@ -2625,7 +2625,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.56404959,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 331.5309917,
@@ -2706,7 +2706,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9052063,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 522.0,
@@ -2731,7 +2731,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.32625483,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 341.6679537,
@@ -2812,7 +2812,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.80073829,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 555.0,
@@ -2837,7 +2837,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.89473684,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 336.9128857,
@@ -2918,7 +2918,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5885554,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4590.0,
@@ -2943,7 +2943,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 45.00494927,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 365.4501361,
@@ -3024,7 +3024,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 14.54743342,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3537.0,
@@ -3049,7 +3049,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 56.62496363,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 561.4783241,
@@ -3130,7 +3130,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.89848159,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4233.0,
@@ -3155,7 +3155,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 46.21981747,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 382.104824,
@@ -3236,7 +3236,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 14.03975134,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3408.0,
@@ -3261,7 +3261,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 54.62626563,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 524.8061346,
@@ -3342,7 +3342,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.99917172,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3913.0,
@@ -3367,7 +3367,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 46.61252502,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 387.7374893,
@@ -3448,7 +3448,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 14.12413347,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3447.0,
@@ -3473,7 +3473,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 54.95893648,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 530.5394387,
@@ -3554,7 +3554,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.99343712,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 548.0,
@@ -3579,7 +3579,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.65384615,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 346.7161172,
@@ -3660,7 +3660,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.58915742,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 522.0,
@@ -3685,7 +3685,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.06923077,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 324.5846154,
@@ -3766,7 +3766,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.7498311,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 517.0,
@@ -3791,7 +3791,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.73929961,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 333.2743191,
@@ -3872,7 +3872,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.90484746,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1099.0,
@@ -3897,7 +3897,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.31141553,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 340.9872146,
@@ -3978,7 +3978,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.55228805,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5873.0,
@@ -4003,7 +4003,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.85974562,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 376.1464421,
@@ -4084,7 +4084,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.48757517,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5136.0,
@@ -4109,7 +4109,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.60990956,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 372.7801809,
@@ -4190,7 +4190,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.33894962,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2784.0,
@@ -4215,7 +4215,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 47.93681207,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 407.3159397,
@@ -4296,7 +4296,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.56294283,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3189.0,
@@ -4321,7 +4321,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.76463145,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 490.9136349,
@@ -4402,7 +4402,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.36484135,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2114.0,
@@ -4427,7 +4427,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 48.0561423,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 409.3707615,
@@ -4508,7 +4508,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.56957334,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3074.0,
@@ -4533,7 +4533,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.78644291,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 491.5580783,
@@ -4614,7 +4614,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.78713912,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 529.0,
@@ -4639,7 +4639,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.84190476,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 335.7961905,
@@ -4720,7 +4720,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.7828125,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 568.0,
@@ -4745,7 +4745,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.8312611,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 333.7371226,
@@ -4826,7 +4826,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.72951317,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 528.0,
@@ -4851,7 +4851,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.64,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 332.1657143,
@@ -4932,7 +4932,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8565846,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1105.0,
@@ -4957,7 +4957,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.12579763,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 337.8277119,
@@ -5038,7 +5038,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.52690872,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5498.0,
@@ -5063,7 +5063,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.75505329,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 375.9678427,
@@ -5144,7 +5144,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.34373699,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1473.0,
@@ -5169,7 +5169,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 47.95874587,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 407.9389439,
@@ -5250,7 +5250,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.53540508,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2183.0,
@@ -5275,7 +5275,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.65791897,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 487.9834254,
@@ -5356,7 +5356,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.50700165,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1280.0,
@@ -5381,7 +5381,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 48.60649087,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 417.326572,
@@ -5462,7 +5462,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.89021013,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1733.0,
@@ -5487,7 +5487,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 54.04120071,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 510.3113596,
@@ -5568,7 +5568,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.04235332,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 532.0,
@@ -5593,7 +5593,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.88212928,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 348.9163498,
@@ -5674,7 +5674,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.98020271,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 493.0,
@@ -5699,7 +5699,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.61836735,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 349.5877551,
@@ -5780,7 +5780,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.78882402,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 560.0,
@@ -5805,7 +5805,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.85225225,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 337.0612613,
@@ -5886,7 +5886,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.95572943,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1123.0,
@@ -5911,7 +5911,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.51339286,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 344.4660714,
@@ -5992,7 +5992,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5723942,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5324.0,
@@ -6017,7 +6017,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.93821077,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 378.9228582,
@@ -6098,7 +6098,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.50393041,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1189.0,
@@ -6123,7 +6123,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.68548387,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 360.6693548,
@@ -6204,7 +6204,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.36907414,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1094.0,
@@ -6229,7 +6229,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.00645756,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 478.5885609,
@@ -6310,7 +6310,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.17491706,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 896.0,
@@ -6335,7 +6335,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 43.38167939,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 343.7755725,
@@ -6416,7 +6416,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.15599547,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 982.0,
@@ -6441,7 +6441,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 51.17184265,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 463.1811594,
@@ -6522,7 +6522,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9514215,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 475.0,
@@ -6547,7 +6547,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.49786325,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 345.2478632,
@@ -6628,7 +6628,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.92049868,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 552.0,
@@ -6653,7 +6653,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.3992674,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 341.2399267,
@@ -6734,7 +6734,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.85968109,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 507.0,
@@ -6759,7 +6759,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.11752988,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 338.0398406,
@@ -6840,7 +6840,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.59659766,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5698.0,
@@ -6865,7 +6865,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 45.03641855,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 378.6605081,
@@ -6946,7 +6946,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9775337,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1193.0,
@@ -6971,7 +6971,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.60292851,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 345.5839793,
@@ -7052,7 +7052,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.56989677,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10666.0,
@@ -7077,7 +7077,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.92957346,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 377.0648341,
@@ -7158,7 +7158,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.52992307,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10394.0,
@@ -7183,7 +7183,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.77608886,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 374.8547208,
@@ -7264,7 +7264,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.53341575,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10397.0,
@@ -7289,7 +7289,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.78583916,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 375.4004468,
@@ -7370,7 +7370,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.57882199,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10580.0,
@@ -7395,7 +7395,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.96911751,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 378.0525863,
@@ -7476,7 +7476,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.50565685,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10375.0,
@@ -7501,7 +7501,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.6763017,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 373.5433577,
@@ -7582,7 +7582,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.58497446,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10169.0,
@@ -7607,7 +7607,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.99383269,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 378.4623495,
@@ -7688,7 +7688,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.57222003,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10459.0,
@@ -7713,7 +7713,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.93628114,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 377.469106,
@@ -7794,7 +7794,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.56082443,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10590.0,
@@ -7819,7 +7819,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.89181705,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 376.7432445,
@@ -7900,7 +7900,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.53452132,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10285.0,
@@ -7925,7 +7925,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.79403367,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 375.1122379,
@@ -8006,7 +8006,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.62352867,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10361.0,
@@ -8031,7 +8031,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 45.14194998,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 380.507034,
@@ -8112,7 +8112,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.89500357,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2203.0,
@@ -8137,7 +8137,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.28213309,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 339.644485,
@@ -8218,7 +8218,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.90696654,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2054.0,
@@ -8243,7 +8243,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.31915934,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 340.5987292,
@@ -8324,7 +8324,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.87403435,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2093.0,
@@ -8349,7 +8349,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.19289827,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 339.8291747,
@@ -8430,7 +8430,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.91021203,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2098.0,
@@ -8455,7 +8455,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.33668582,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 340.9243295,
@@ -8536,7 +8536,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8849547,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1991.0,
@@ -8561,7 +8561,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.22929293,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 339.5808081,
@@ -8642,7 +8642,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.90154609,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2003.0,
@@ -8667,7 +8667,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.30537418,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 341.8613762,
@@ -8748,7 +8748,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.78152874,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2023.0,
@@ -8773,7 +8773,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.8390462,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 333.9379036,
@@ -8854,7 +8854,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8841488,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1990.0,
@@ -8879,7 +8879,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.22536635,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 340.2784234,
@@ -8960,7 +8960,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.93480917,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2059.0,
@@ -8985,7 +8985,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.43978547,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 342.4041931,
@@ -9066,7 +9066,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.85992705,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2095.0,
@@ -9091,7 +9091,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.13320556,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 337.8068999,
@@ -9172,7 +9172,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.80364891,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 853.0,
@@ -9197,7 +9197,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.91824645,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 335.5485782,
@@ -9278,7 +9278,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.08728418,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 943.0,
@@ -9303,7 +9303,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 43.03747323,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 350.6027837,
@@ -9384,7 +9384,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.66294648,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 853.0,
@@ -9409,7 +9409,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.36288416,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 327.0094563,
@@ -9490,7 +9490,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.86692294,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 877.0,
@@ -9515,7 +9515,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.15789474,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 338.180778,
@@ -9596,7 +9596,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.90435493,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 975.0,
@@ -9621,7 +9621,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.31237113,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 341.2391753,
@@ -9702,7 +9702,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.99530161,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 966.0,
@@ -9727,7 +9727,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.66736402,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 347.1903766,
@@ -9808,7 +9808,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.88356469,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 990.0,
@@ -9833,7 +9833,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.22380468,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 340.2370295,
@@ -9914,7 +9914,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.75117962,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 907.0,
@@ -9939,7 +9939,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.71049724,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 332.3016575,
@@ -10020,7 +10020,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.76678703,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 992.0,
@@ -10045,7 +10045,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.78216819,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 333.6200608,
@@ -10126,7 +10126,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.95499224,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 974.0,
@@ -10151,7 +10151,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.50207039,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 343.4554865,
@@ -10232,7 +10232,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.51800162,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5360.0,
@@ -10257,7 +10257,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 48.65636613,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 418.6966556,

--- a/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_4.json
+++ b/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_4.json
@@ -56,7 +56,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.1762866973877,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2800.0,
@@ -81,7 +81,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 47.3328552246094,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 403.375885009766,
@@ -162,7 +162,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.7125835418701,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 133.0,
@@ -187,7 +187,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.3826103210449,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 488.043487548828,
@@ -268,7 +268,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.7532081604004,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 117.0,
@@ -293,7 +293,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.5656547546387,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 490.616149902344,
@@ -374,7 +374,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.7313766479492,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 125.0,
@@ -399,7 +399,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.4672889709473,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 489.233642578125,
@@ -480,7 +480,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 14.0118236541748,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 37.0,
@@ -505,7 +505,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 54.5483856201172,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 506.677429199219,
@@ -586,7 +586,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.6353092193604,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 40.0,
@@ -611,7 +611,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.1176452636719,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 483.294128417969,
@@ -692,7 +692,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.6353092193604,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 40.0,
@@ -717,7 +717,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.1176452636719,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 483.294128417969,
@@ -798,7 +798,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.6117038726807,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 136.0,
@@ -823,7 +823,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 481.779663085938,
@@ -904,7 +904,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.7532081604004,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 117.0,
@@ -929,7 +929,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.5656547546387,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 490.616149902344,
@@ -1010,7 +1010,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.7313766479492,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 125.0,
@@ -1035,7 +1035,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.4672889709473,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 489.233642578125,
@@ -1116,7 +1116,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.7532081604004,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 117.0,
@@ -1141,7 +1141,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.5656547546387,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 490.616149902344,
@@ -1222,7 +1222,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.7313766479492,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 250.0,
@@ -1247,7 +1247,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.4672889709473,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 489.233642578125,
@@ -1328,7 +1328,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.6614942550659,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 269.0,
@@ -1353,7 +1353,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.1888427734375,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 484.871246337891,
@@ -1434,7 +1434,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.6933794021606,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 237.0,
@@ -1459,7 +1459,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.3383102416992,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 486.900512695313,
@@ -1540,7 +1540,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.7418689727783,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 242.0,
@@ -1565,7 +1565,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.5145645141602,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 489.898071289063,
@@ -1646,7 +1646,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.7532081604004,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 234.0,
@@ -1671,7 +1671,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.5656547546387,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 490.616149902344,
@@ -1752,7 +1752,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.8617849349976,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 236.0,
@@ -1777,7 +1777,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.9700012207031,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 497.345001220703,
@@ -1858,7 +1858,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.6021490097046,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 144.0,
@@ -1883,7 +1883,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.9523811340332,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 481.166656494141,
@@ -1964,7 +1964,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.7532081604004,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 117.0,
@@ -1989,7 +1989,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 53.5656547546387,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 490.616149902344,
@@ -2070,7 +2070,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5630340576172,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4337.0,
@@ -2095,7 +2095,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.9008941650391,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 364.414611816406,
@@ -2176,7 +2176,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 14.7241431297471,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3522.0,
@@ -2201,7 +2201,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 57.3278879813302,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 575.916569428238,
@@ -2282,7 +2282,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5433403005693,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5714.0,
@@ -2307,7 +2307,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.8229885057471,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 376.572590627763,
@@ -2388,7 +2388,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 0.0,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 13.0,
@@ -2413,7 +2413,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 0.0,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 0.0,
@@ -2494,7 +2494,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8430392800945,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1170.0,
@@ -2519,7 +2519,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.0907534246575,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 336.872431506849,
@@ -2600,7 +2600,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.709265923303,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 487.0,
@@ -2625,7 +2625,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.5640495867769,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 331.530991735537,
@@ -2706,7 +2706,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.905206300301,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 522.0,
@@ -2731,7 +2731,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.3262548262548,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 341.667953667954,
@@ -2812,7 +2812,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8007382913856,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 555.0,
@@ -2837,7 +2837,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.8947368421053,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 336.912885662432,
@@ -2918,7 +2918,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5885553986328,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4590.0,
@@ -2943,7 +2943,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 45.0049492699827,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 365.450136104925,
@@ -3024,7 +3024,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 14.5474334164071,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3537.0,
@@ -3049,7 +3049,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 56.6249636310736,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 561.478324119872,
@@ -3130,7 +3130,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.8984815945184,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 4233.0,
@@ -3155,7 +3155,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 46.2198174706649,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 382.10482398957,
@@ -3236,7 +3236,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 14.0397513368571,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3408.0,
@@ -3261,7 +3261,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 54.6262656343061,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 524.806134603931,
@@ -3342,7 +3342,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.9991717154481,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3913.0,
@@ -3367,7 +3367,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 46.612525021447,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 387.737489276523,
@@ -3448,7 +3448,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 14.1241334693717,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3447.0,
@@ -3473,7 +3473,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 54.9589364844904,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 530.539438700148,
@@ -3554,7 +3554,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9934371221633,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 548.0,
@@ -3579,7 +3579,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.6538461538462,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 346.716117216117,
@@ -3660,7 +3660,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.5891574155367,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 522.0,
@@ -3685,7 +3685,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.0692307692308,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 324.584615384615,
@@ -3766,7 +3766,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.7498310950016,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 517.0,
@@ -3791,7 +3791,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.7392996108949,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 333.274319066148,
@@ -3872,7 +3872,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9048474643655,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1099.0,
@@ -3897,7 +3897,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.3114155251142,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 340.987214611872,
@@ -3978,7 +3978,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5522880543709,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5873.0,
@@ -4003,7 +4003,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.8597456170505,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 376.146442076315,
@@ -4084,7 +4084,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.4875751739874,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5136.0,
@@ -4109,7 +4109,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.6099095556429,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 372.780180888714,
@@ -4190,7 +4190,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.3389496169963,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2784.0,
@@ -4215,7 +4215,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 47.9368120668569,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 407.315939665715,
@@ -4296,7 +4296,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.5629428280641,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3189.0,
@@ -4321,7 +4321,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.764631445745,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 490.913634925656,
@@ -4402,7 +4402,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.3648413543107,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2114.0,
@@ -4427,7 +4427,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 48.0561423012785,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 409.370761534186,
@@ -4508,7 +4508,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.5695733354373,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 3074.0,
@@ -4533,7 +4533,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.7864429088516,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 491.558078315235,
@@ -4614,7 +4614,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.7871391180129,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 529.0,
@@ -4639,7 +4639,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.8419047619048,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 335.79619047619,
@@ -4720,7 +4720,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.7828125013551,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 568.0,
@@ -4745,7 +4745,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.8312611012433,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 333.737122557726,
@@ -4826,7 +4826,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.7295131690616,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 528.0,
@@ -4851,7 +4851,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.64,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 332.165714285714,
@@ -4932,7 +4932,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8565846035452,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1105.0,
@@ -4957,7 +4957,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.1257976298997,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 337.827711941659,
@@ -5038,7 +5038,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5269087214191,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5498.0,
@@ -5063,7 +5063,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.7550532892319,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 375.967842704888,
@@ -5144,7 +5144,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.34373699226,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1473.0,
@@ -5169,7 +5169,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 47.9587458745875,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 407.938943894389,
@@ -5250,7 +5250,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.5354050845292,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2183.0,
@@ -5275,7 +5275,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.6579189686924,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 487.983425414365,
@@ -5356,7 +5356,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.5070016501158,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1280.0,
@@ -5381,7 +5381,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 48.606490872211,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 417.326572008114,
@@ -5462,7 +5462,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.8902101347206,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1733.0,
@@ -5487,7 +5487,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 54.0412007062978,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 510.311359623308,
@@ -5568,7 +5568,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.0423533232946,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 532.0,
@@ -5593,7 +5593,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.8821292775665,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 348.916349809886,
@@ -5674,7 +5674,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9802027114557,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 493.0,
@@ -5699,7 +5699,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.6183673469388,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 349.587755102041,
@@ -5780,7 +5780,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.7888240243723,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 560.0,
@@ -5805,7 +5805,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.8522522522522,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 337.061261261261,
@@ -5886,7 +5886,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9557294307436,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1123.0,
@@ -5911,7 +5911,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.5133928571429,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 344.466071428571,
@@ -5992,7 +5992,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5723942035794,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5324.0,
@@ -6017,7 +6017,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.9382107657316,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 378.922858225929,
@@ -6098,7 +6098,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5039304126792,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1189.0,
@@ -6123,7 +6123,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.6854838709677,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 360.66935483871,
@@ -6204,7 +6204,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.3690741401757,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1094.0,
@@ -6229,7 +6229,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 52.0064575645756,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 478.588560885609,
@@ -6310,7 +6310,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.1749170550863,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 896.0,
@@ -6335,7 +6335,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 43.381679389313,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 343.775572519084,
@@ -6416,7 +6416,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 13.155995473605,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 982.0,
@@ -6441,7 +6441,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 51.1718426501035,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 463.18115942029,
@@ -6522,7 +6522,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9514215029203,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 475.0,
@@ -6547,7 +6547,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.4978632478633,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 345.247863247863,
@@ -6628,7 +6628,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9204986837757,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 552.0,
@@ -6653,7 +6653,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.3992673992674,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 341.239926739927,
@@ -6734,7 +6734,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8596810907007,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 507.0,
@@ -6759,7 +6759,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.1175298804781,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 338.03984063745,
@@ -6840,7 +6840,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5965976619534,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5698.0,
@@ -6865,7 +6865,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 45.0364185468112,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 378.660508083141,
@@ -6946,7 +6946,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9775337002382,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1193.0,
@@ -6971,7 +6971,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.6029285099053,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 345.583979328165,
@@ -7052,7 +7052,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5698967663372,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10666.0,
@@ -7077,7 +7077,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.9295734597156,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 377.064834123223,
@@ -7158,7 +7158,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5299230701008,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10394.0,
@@ -7183,7 +7183,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.7760888629056,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 374.854720841859,
@@ -7264,7 +7264,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5334157469482,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10397.0,
@@ -7289,7 +7289,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.7858391608392,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 375.400446775447,
@@ -7370,7 +7370,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5788219887026,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10580.0,
@@ -7395,7 +7395,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.9691175064538,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 378.05258628932,
@@ -7476,7 +7476,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5056568488425,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10375.0,
@@ -7501,7 +7501,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.676301703163,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 373.543357664234,
@@ -7582,7 +7582,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5849744633017,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10169.0,
@@ -7607,7 +7607,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.9938326867602,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 378.462349547399,
@@ -7688,7 +7688,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5722200294608,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10459.0,
@@ -7713,7 +7713,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.9362811353543,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 377.46910600502,
@@ -7794,7 +7794,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.560824427973,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10590.0,
@@ -7819,7 +7819,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.8918170533753,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 376.743244533563,
@@ -7900,7 +7900,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.5345213225781,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10285.0,
@@ -7925,7 +7925,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 44.7940336713597,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 375.112237865511,
@@ -8006,7 +8006,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.6235286706684,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 10361.0,
@@ -8031,7 +8031,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 45.1419499804611,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 380.507033997655,
@@ -8112,7 +8112,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8950035672462,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2203.0,
@@ -8137,7 +8137,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.2821330902461,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 339.644484958979,
@@ -8218,7 +8218,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9069665362525,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2054.0,
@@ -8243,7 +8243,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.3191593352884,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 340.598729227762,
@@ -8324,7 +8324,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8740343496575,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2093.0,
@@ -8349,7 +8349,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.1928982725528,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 339.829174664107,
@@ -8430,7 +8430,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9102120289857,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2098.0,
@@ -8455,7 +8455,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.3366858237548,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 340.924329501916,
@@ -8536,7 +8536,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8849547022039,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1991.0,
@@ -8561,7 +8561,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.2292929292929,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 339.580808080808,
@@ -8642,7 +8642,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9015460870303,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2003.0,
@@ -8667,7 +8667,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.3053741838272,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 341.861376192868,
@@ -8748,7 +8748,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.7815287431318,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2023.0,
@@ -8773,7 +8773,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.8390461997019,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 333.937903626428,
@@ -8854,7 +8854,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8841488040656,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 1990.0,
@@ -8879,7 +8879,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.2253663466397,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 340.278423446185,
@@ -8960,7 +8960,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9348091728103,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2059.0,
@@ -8985,7 +8985,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.4397854705022,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 342.404193076548,
@@ -9066,7 +9066,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8599270541415,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 2095.0,
@@ -9091,7 +9091,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.1332055582175,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 337.806899856253,
@@ -9172,7 +9172,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8036489061835,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 853.0,
@@ -9197,7 +9197,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.9182464454976,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 335.548578199052,
@@ -9278,7 +9278,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 11.0872841771716,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 943.0,
@@ -9303,7 +9303,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 43.0374732334047,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 350.60278372591,
@@ -9384,7 +9384,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.6629464792022,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 853.0,
@@ -9409,7 +9409,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.3628841607565,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 327.009456264775,
@@ -9490,7 +9490,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.8669229424518,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 877.0,
@@ -9515,7 +9515,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.1578947368421,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 338.180778032037,
@@ -9596,7 +9596,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9043549284001,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 975.0,
@@ -9621,7 +9621,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.3123711340206,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 341.239175257732,
@@ -9702,7 +9702,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9953016089595,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 966.0,
@@ -9727,7 +9727,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.6673640167364,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 347.190376569038,
@@ -9808,7 +9808,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.883564690001,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 990.0,
@@ -9833,7 +9833,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.2238046795524,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 340.237029501526,
@@ -9914,7 +9914,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.7511796182032,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 907.0,
@@ -9939,7 +9939,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.7104972375691,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 332.301657458564,
@@ -10020,7 +10020,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.766787028675,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 992.0,
@@ -10045,7 +10045,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 41.7821681864235,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 333.620060790274,
@@ -10126,7 +10126,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 10.9549922437648,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 974.0,
@@ -10151,7 +10151,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 42.5020703933747,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 343.455486542443,
@@ -10232,7 +10232,7 @@
                                         },
                                         "average live cell diameter (cell counter)": {
                                             "value": 12.5180016241404,
-                                            "unit": "μm"
+                                            "unit": "µm"
                                         },
                                         "total cell count": {
                                             "value": 5360.0,
@@ -10257,7 +10257,7 @@
                                             },
                                             "average perimeter": {
                                                 "value": 48.6563661255623,
-                                                "unit": "μm"
+                                                "unit": "µm"
                                             },
                                             "average segment area": {
                                                 "value": 418.696655583806,


### PR DESCRIPTION
There are two characters with the same symbol to represent `micro` units. Allotrope uses a mixture of those symbols in its units definitions. This was previously handled by standardizing the use of the same `μ` character in all `allotropy` schemas. 
However, this might present a maintainability problem as we'd have to search and replace the character every time we add a new schema. Another drawback is that the `ASM` we generate would probably fail validation against the original Allotrope schemas.
This PR reconciles the characters used in our schemas with the source Allotrope units schema.