### PR TITLE
feat: Cell Counting - migrate adapters to the cell-counting/REC/2024/09 schema

### DIFF
--- a/SUPPORTED_INSTRUMENT_SOFTWARE.adoc
+++ b/SUPPORTED_INSTRUMENT_SOFTWARE.adoc
@@ -15,12 +15,12 @@ The parsers follow maturation levels of: Recommended, Candidate Release, Working
 [cols="4*^.^"]
 |===
 |Instrument Category|Instrument Software|Release Status|Exported ASM Schema
-.6+|Cell Counting|Beckman Vi-Cell BLU|Recommended|BENCHLING/2023/11
+.6+|Cell Counting|Beckman Vi-Cell BLU|Recommended|REC/2024/09
 |Beckman Vi-Cell XR|Recommended|REC/2024/09
-|ChemoMetec NC View|Recommended|BENCHLING/2023/11
-|ChemoMetec Nucleoview|Recommended|BENCHLING/2023/11
-|Revvity Matrix|Recommended|BENCHLING/2023/11
-|Roche Cedex HiRes|Recommended|BENCHLING/2023/11
+|ChemoMetec NC View|Recommended|REC/2024/09
+|ChemoMetec Nucleoview|Recommended|REC/2024/09
+|Revvity Matrix|Recommended|REC/2024/09
+|Roche Cedex HiRes|Recommended|REC/2024/09
 .1+|Electrophoresis|Agilent TapeStation Analysis|Recommended|BENCHLING/2024/09
 .1+|Liquid Chromatography|Cytiva Unicorn|Working Draft|BENCHLING/2023/09
 .1+|Liquid Handler|Beckman Coulter Biomek|Working Draft|BENCHLING/2024/11

--- a/src/allotropy/allotrope/schema_mappers/adm/cell_counting/rec/_2024/_09/cell_counting.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/cell_counting/rec/_2024/_09/cell_counting.py
@@ -26,7 +26,6 @@ from allotropy.allotrope.models.shared.definitions.custom import (
     TQuantityValuePercent,
     TQuantityValueUnitless,
 )
-from allotropy.allotrope.models.shared.definitions.definitions import JsonFloat
 from allotropy.allotrope.schema_mappers.schema_mapper import SchemaMapper
 from allotropy.constants import ASM_CONVERTER_VERSION
 from allotropy.parsers.utils.values import quantity_or_none
@@ -47,7 +46,7 @@ class Measurement:
 
     # Measurements
     viability: float
-    viable_cell_density: JsonFloat
+    viable_cell_density: float
 
     # Optional metadata
     batch_identifier: str | None = None
@@ -66,11 +65,11 @@ class Measurement:
     # Optional measurements
     viable_cell_count: float | None = None
     total_cell_count: float | None = None
-    total_cell_density: JsonFloat | None = None
+    total_cell_density: float | None = None
     dead_cell_count: float | None = None
-    dead_cell_density: JsonFloat | None = None
+    dead_cell_density: float | None = None
 
-    average_total_cell_diameter: JsonFloat | None = None
+    average_total_cell_diameter: float | None = None
     average_live_cell_diameter: float | None = None
     average_dead_cell_diameter: float | None = None
     average_total_cell_circularity: float | None = None
@@ -88,7 +87,7 @@ class Measurement:
 
     # customer information document fields
     debris_index: float | None = None
-    cell_aggregation_percentage: JsonFloat | None = None
+    cell_aggregation_percentage: float | None = None
 
 
 @dataclass(frozen=True)
@@ -102,8 +101,8 @@ class Metadata:
     asm_file_identifier: str
     data_system_instance_id: str
     device_type: str
-    device_identifier: str
     model_number: str
+    device_identifier: str | None = None
     detection_type: str | None = None
     software_name: str | None = None
     file_name: str | None = None

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_parser.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from allotropy.allotrope.models.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.models.adm.cell_counting.rec._2024._09.cell_counting import (
     Model,
 )
-from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.schema_mappers.adm.cell_counting.rec._2024._09.cell_counting import (
     Data,
     Mapper,
 )

--- a/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_structure.py
+++ b/src/allotropy/parsers/beckman_vi_cell_blu/vi_cell_blu_structure.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.schema_mappers.adm.cell_counting.rec._2024._09.cell_counting import (
     Measurement,
     MeasurementGroup,
     Metadata,
@@ -14,6 +14,7 @@ from allotropy.parsers.beckman_vi_cell_blu.constants import (
     DEVICE_TYPE,
     VICELL_BLU_SOFTWARE_NAME,
 )
+from allotropy.parsers.constants import NOT_APPLICABLE
 from allotropy.parsers.utils.pandas import SeriesData
 from allotropy.parsers.utils.uuids import random_uuid_str
 
@@ -58,7 +59,11 @@ def create_measurement_group(data: SeriesData) -> MeasurementGroup:
 
 
 def create_metadata(file_path: str) -> Metadata:
+    path = Path(file_path)
     return Metadata(
+        asm_file_identifier=path.with_suffix(".json").name,
+        data_system_instance_id=NOT_APPLICABLE,
+        device_identifier=NOT_APPLICABLE,
         device_type=DEVICE_TYPE,
         detection_type=DETECTION_TYPE,
         model_number=DEFAULT_MODEL_NUMBER,

--- a/src/allotropy/parsers/chemometec_nc_view/chemometec_nc_view_parser.py
+++ b/src/allotropy/parsers/chemometec_nc_view/chemometec_nc_view_parser.py
@@ -1,7 +1,7 @@
-from allotropy.allotrope.models.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.models.adm.cell_counting.rec._2024._09.cell_counting import (
     Model,
 )
-from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.schema_mappers.adm.cell_counting.rec._2024._09.cell_counting import (
     Data,
     Mapper,
 )

--- a/src/allotropy/parsers/chemometec_nc_view/chemometec_nc_view_structure.py
+++ b/src/allotropy/parsers/chemometec_nc_view/chemometec_nc_view_structure.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from pathlib import Path
 
-from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.schema_mappers.adm.cell_counting.rec._2024._09.cell_counting import (
     Measurement,
     MeasurementGroup,
     Metadata,
@@ -14,8 +14,12 @@ from allotropy.parsers.utils.values import try_float_or_none
 
 
 def create_metadata(data: SeriesData, file_path: str) -> Metadata:
+    path = Path(file_path)
     return Metadata(
-        file_name=Path(file_path).name,
+        asm_file_identifier=path.with_suffix(".json").name,
+        data_system_instance_id=NOT_APPLICABLE,
+        device_identifier=NOT_APPLICABLE,
+        file_name=path.name,
         unc_path=file_path,
         software_name=constants.SOFTWARE_NAME,
         device_type=constants.DEVICE_TYPE,

--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_parser.py
@@ -1,7 +1,7 @@
-from allotropy.allotrope.models.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.models.adm.cell_counting.rec._2024._09.cell_counting import (
     Model,
 )
-from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.schema_mappers.adm.cell_counting.rec._2024._09.cell_counting import (
     Data,
     Mapper,
 )

--- a/src/allotropy/parsers/revvity_matrix/revvity_matrix_parser.py
+++ b/src/allotropy/parsers/revvity_matrix/revvity_matrix_parser.py
@@ -1,7 +1,7 @@
-from allotropy.allotrope.models.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.models.adm.cell_counting.rec._2024._09.cell_counting import (
     Model,
 )
-from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.schema_mappers.adm.cell_counting.rec._2024._09.cell_counting import (
     Data,
     Mapper,
 )

--- a/src/allotropy/parsers/revvity_matrix/revvity_matrix_structure.py
+++ b/src/allotropy/parsers/revvity_matrix/revvity_matrix_structure.py
@@ -1,21 +1,26 @@
 from decimal import Decimal
 from pathlib import Path
 
-from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.schema_mappers.adm.cell_counting.rec._2024._09.cell_counting import (
     Error,
     Measurement,
     MeasurementGroup,
     Metadata,
 )
-from allotropy.parsers.constants import DEFAULT_EPOCH_TIMESTAMP
+from allotropy.parsers.constants import DEFAULT_EPOCH_TIMESTAMP, NOT_APPLICABLE
 from allotropy.parsers.revvity_matrix import constants
 from allotropy.parsers.utils.pandas import SeriesData
 from allotropy.parsers.utils.uuids import random_uuid_str
 
 
 def create_metadata(file_path: str) -> Metadata:
+    path = Path(file_path)
     return Metadata(
-        file_name=Path(file_path).name,
+        asm_file_identifier=path.with_suffix(".json").name,
+        data_system_instance_id=NOT_APPLICABLE,
+        device_identifier=NOT_APPLICABLE,
+        model_number=NOT_APPLICABLE,
+        file_name=path.name,
         unc_path=file_path,
         device_type=constants.DEVICE_TYPE,
     )

--- a/src/allotropy/parsers/roche_cedex_hires/roche_cedex_hires_parser.py
+++ b/src/allotropy/parsers/roche_cedex_hires/roche_cedex_hires_parser.py
@@ -1,7 +1,7 @@
-from allotropy.allotrope.models.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.models.adm.cell_counting.rec._2024._09.cell_counting import (
     Model,
 )
-from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.schema_mappers.adm.cell_counting.rec._2024._09.cell_counting import (
     Data,
     Mapper,
 )

--- a/src/allotropy/parsers/roche_cedex_hires/roche_cedex_hires_structure.py
+++ b/src/allotropy/parsers/roche_cedex_hires/roche_cedex_hires_structure.py
@@ -3,19 +3,23 @@ from __future__ import annotations
 from decimal import Decimal
 from pathlib import Path
 
-from allotropy.allotrope.schema_mappers.adm.cell_counting.benchling._2023._11.cell_counting import (
+from allotropy.allotrope.schema_mappers.adm.cell_counting.rec._2024._09.cell_counting import (
     Measurement,
     MeasurementGroup,
     Metadata,
 )
+from allotropy.parsers.constants import NOT_APPLICABLE
 from allotropy.parsers.roche_cedex_hires import constants
 from allotropy.parsers.utils.pandas import SeriesData
 from allotropy.parsers.utils.uuids import random_uuid_str
 
 
 def create_metadata(data: SeriesData, file_path: str) -> Metadata:
+    path = Path(file_path)
     return Metadata(
-        file_name=Path(file_path).name,
+        asm_file_identifier=path.with_suffix(".json").name,
+        data_system_instance_id=NOT_APPLICABLE,
+        file_name=path.name,
         unc_path=file_path,
         device_type=constants.DEVICE_TYPE,
         detection_type=constants.DETECTION_TYPE,
@@ -54,9 +58,9 @@ def create_measurement_groups(data: SeriesData) -> MeasurementGroup:
                 viable_cell_count=data.get(float, "Viable Cell Count"),
                 viable_cell_density=viable_cell_density,
                 total_cell_count=data.get(float, "Total Cell Count"),
-                total_cell_density=total_cell_density
-                if total_cell_density_val
-                else None,
+                total_cell_density=(
+                    total_cell_density if total_cell_density_val else None
+                ),
                 dead_cell_count=data.get(float, "Dead Cell Count"),
                 dead_cell_density=dead_cell_density if dead_cell_density_val else None,
                 cell_type_processing_method=data.get(str, "Cell type name"),

--- a/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_different_mu_character.json
+++ b/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_different_mu_character.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -82,15 +82,18 @@
                 "analyst": "Vi-CELL"
             }
         ],
-        "device system document": {
-            "model number": "Vi-Cell BLU"
-        },
         "data system document": {
+            "ASM file identifier": "Beckman_Vi-Cell-BLU_different_mu_character.json",
+            "data system instance identifier": "N/A",
             "file name": "Beckman_Vi-Cell-BLU_different_mu_character.csv",
             "UNC path": "tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_different_mu_character.csv",
-            "software name": "Vi-Cell BLU",
             "ASM converter name": "allotropy_beckman_vi_cell_blu",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "Vi-Cell BLU"
+        },
+        "device system document": {
+            "device identifier": "N/A",
+            "model number": "Vi-Cell BLU"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01.json
+++ b/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -785,15 +785,18 @@
                 "analyst": "Vi-CELL"
             }
         ],
-        "device system document": {
-            "model number": "Vi-Cell BLU"
-        },
         "data system document": {
+            "ASM file identifier": "Beckman_Vi-Cell-BLU_example01.json",
+            "data system instance identifier": "N/A",
             "file name": "Beckman_Vi-Cell-BLU_example01.csv",
             "UNC path": "tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01.csv",
-            "software name": "Vi-Cell BLU",
             "ASM converter name": "allotropy_beckman_vi_cell_blu",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "Vi-Cell BLU"
+        },
+        "device system document": {
+            "device identifier": "N/A",
+            "model number": "Vi-Cell BLU"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01_utf16.json
+++ b/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01_utf16.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -793,15 +793,18 @@
                 "analyst": "Vi-CELL"
             }
         ],
-        "device system document": {
-            "model number": "Vi-Cell BLU"
-        },
         "data system document": {
+            "ASM file identifier": "Beckman_Vi-Cell-BLU_example01_utf16.json",
+            "data system instance identifier": "N/A",
             "file name": "Beckman_Vi-Cell-BLU_example01_utf16.csv",
             "UNC path": "tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example01_utf16.csv",
-            "software name": "Vi-Cell BLU",
             "ASM converter name": "allotropy_beckman_vi_cell_blu",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "Vi-Cell BLU"
+        },
+        "device system document": {
+            "device identifier": "N/A",
+            "model number": "Vi-Cell BLU"
         }
     }
 }

--- a/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example02.json
+++ b/tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example02.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -398,15 +398,18 @@
                 "analyst": "Vi-CELL"
             }
         ],
-        "device system document": {
-            "model number": "Vi-Cell BLU"
-        },
         "data system document": {
+            "ASM file identifier": "Beckman_Vi-Cell-BLU_example02.json",
+            "data system instance identifier": "N/A",
             "file name": "Beckman_Vi-Cell-BLU_example02.csv",
             "UNC path": "tests/parsers/beckman_vi_cell_blu/testdata/Beckman_Vi-Cell-BLU_example02.csv",
-            "software name": "Vi-Cell BLU",
             "ASM converter name": "allotropy_beckman_vi_cell_blu",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "Vi-Cell BLU"
+        },
+        "device system document": {
+            "device identifier": "N/A",
+            "model number": "Vi-Cell BLU"
         }
     }
 }

--- a/tests/parsers/chemometec_nc_view/testdata/chememotec_nc_view_example.json
+++ b/tests/parsers/chemometec_nc_view/testdata/chememotec_nc_view_example.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -2083,17 +2083,20 @@
                 "analyst": "CHB"
             }
         ],
-        "device system document": {
-            "product manufacturer": "ChemoMetec",
-            "model number": "N/A",
-            "equipment serial number": "9002020102201902"
-        },
         "data system document": {
+            "ASM file identifier": "chememotec_nc_view_example.json",
+            "data system instance identifier": "N/A",
             "file name": "chememotec_nc_view_example.csv",
             "UNC path": "tests/parsers/chemometec_nc_view/testdata/chememotec_nc_view_example.csv",
-            "software name": "NC-View",
             "ASM converter name": "allotropy_chemometec_nc_view",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "NC-View"
+        },
+        "device system document": {
+            "device identifier": "N/A",
+            "equipment serial number": "9002020102201902",
+            "model number": "N/A",
+            "product manufacturer": "ChemoMetec"
         }
     }
 }

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example01.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example01.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -57,17 +57,20 @@
                 "analyst": "DrScientist"
             }
         ],
-        "device system document": {
-            "model number": "NucleoView NC-200",
-            "equipment serial number": "s/n 9000201099909999"
-        },
         "data system document": {
+            "ASM file identifier": "chemometec_nucleoview_example01.json",
+            "data system instance identifier": "N/A",
             "file name": "chemometec_nucleoview_example01.csv",
             "UNC path": "tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example01.csv",
-            "software name": "NucleoView",
-            "software version": "1.4.2.0",
             "ASM converter name": "allotropy_chemometec_nucleoview",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "NucleoView",
+            "software version": "1.4.2.0"
+        },
+        "device system document": {
+            "device identifier": "DESKTOP-A678B9H",
+            "equipment serial number": "s/n 9000201099909999",
+            "model number": "NucleoView NC-200"
         }
     }
 }

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example02.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example02.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -57,17 +57,20 @@
                 "analyst": "DrScientist"
             }
         ],
-        "device system document": {
-            "model number": "NucleoView NC-200",
-            "equipment serial number": "s/n 9000201099909999"
-        },
         "data system document": {
+            "ASM file identifier": "chemometec_nucleoview_example02.json",
+            "data system instance identifier": "N/A",
             "file name": "chemometec_nucleoview_example02.csv",
             "UNC path": "tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example02.csv",
-            "software name": "NucleoView",
-            "software version": "1.4.0.0",
             "ASM converter name": "allotropy_chemometec_nucleoview",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "NucleoView",
+            "software version": "1.4.0.0"
+        },
+        "device system document": {
+            "device identifier": "ABC0-NBBS-FQ01",
+            "equipment serial number": "s/n 9000201099909999",
+            "model number": "NucleoView NC-200"
         }
     }
 }

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example03.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example03.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -57,15 +57,17 @@
                 "analyst": "DrScientist"
             }
         ],
-        "device system document": {
-            "model number": "NucleoCounter NC-200"
-        },
         "data system document": {
+            "ASM file identifier": "chemometec_nucleoview_example03.json",
+            "data system instance identifier": "N/A",
             "file name": "chemometec_nucleoview_example03.csv",
             "UNC path": "tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example03.csv",
-            "software name": "NucleoView",
             "ASM converter name": "allotropy_chemometec_nucleoview",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "NucleoView"
+        },
+        "device system document": {
+            "model number": "NucleoCounter NC-200"
         }
     }
 }

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example04.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example04.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -36,17 +36,9 @@
                                                 "unit": "(unitless)"
                                             }
                                         },
-                                        "total cell density (cell counter)": {
-                                            "value": "NaN",
-                                            "unit": "10^6 cells/mL"
-                                        },
                                         "dead cell density (cell counter)": {
                                             "value": 1.14,
                                             "unit": "10^6 cells/mL"
-                                        },
-                                        "average total cell diameter": {
-                                            "value": "NaN",
-                                            "unit": "µm"
                                         }
                                     }
                                 ]
@@ -57,17 +49,20 @@
                 "analyst": "DrScientist"
             }
         ],
-        "device system document": {
-            "model number": "NucleoView NC-200",
-            "equipment serial number": "s/n 9000201099909999"
-        },
         "data system document": {
+            "ASM file identifier": "chemometec_nucleoview_example04.json",
+            "data system instance identifier": "N/A",
             "file name": "chemometec_nucleoview_example04.csv",
             "UNC path": "tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example04.csv",
-            "software name": "NucleoView",
-            "software version": "1.4.2.0",
             "ASM converter name": "allotropy_chemometec_nucleoview",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "NucleoView",
+            "software version": "1.4.2.0"
+        },
+        "device system document": {
+            "device identifier": "DESKTOP-A678B9H",
+            "equipment serial number": "s/n 9000201099909999",
+            "model number": "NucleoView NC-200"
         }
     }
 }

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example05.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example05.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -43,10 +43,6 @@
                                         "dead cell density (cell counter)": {
                                             "value": 1.14,
                                             "unit": "10^6 cells/mL"
-                                        },
-                                        "average total cell diameter": {
-                                            "value": "NaN",
-                                            "unit": "µm"
                                         }
                                     }
                                 ]
@@ -57,17 +53,20 @@
                 "analyst": "DrScientist"
             }
         ],
-        "device system document": {
-            "model number": "NucleoView NC-200",
-            "equipment serial number": "s/n 9000201099909999"
-        },
         "data system document": {
+            "ASM file identifier": "chemometec_nucleoview_example05.json",
+            "data system instance identifier": "N/A",
             "file name": "chemometec_nucleoview_example05.csv",
             "UNC path": "tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example05.csv",
-            "software name": "NucleoView",
-            "software version": "1.4.2.0",
             "ASM converter name": "allotropy_chemometec_nucleoview",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "NucleoView",
+            "software version": "1.4.2.0"
+        },
+        "device system document": {
+            "device identifier": "DESKTOP-A678B9H",
+            "equipment serial number": "s/n 9000201099909999",
+            "model number": "NucleoView NC-200"
         }
     }
 }

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example06.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example06.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -43,10 +43,6 @@
                                         "dead cell density (cell counter)": {
                                             "value": 0.122,
                                             "unit": "10^6 cells/mL"
-                                        },
-                                        "average total cell diameter": {
-                                            "value": "NaN",
-                                            "unit": "µm"
                                         }
                                     }
                                 ]
@@ -57,17 +53,20 @@
                 "analyst": "DrScientist"
             }
         ],
-        "device system document": {
-            "model number": "NucleoView NC-200",
-            "equipment serial number": "s/n 9000201099909999"
-        },
         "data system document": {
+            "ASM file identifier": "chemometec_nucleoview_example06.json",
+            "data system instance identifier": "N/A",
             "file name": "chemometec_nucleoview_example06.csv",
             "UNC path": "tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example06.csv",
-            "software name": "NucleoView",
-            "software version": "1.4.0.0",
             "ASM converter name": "allotropy_chemometec_nucleoview",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "NucleoView",
+            "software version": "1.4.0.0"
+        },
+        "device system document": {
+            "device identifier": "ABC0-NBBS-FQ01",
+            "equipment serial number": "s/n 9000201099909999",
+            "model number": "NucleoView NC-200"
         }
     }
 }

--- a/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_csv.json
+++ b/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_csv.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -1357,12 +1357,17 @@
                 }
             }
         ],
-        "device system document": {},
         "data system document": {
+            "ASM file identifier": "revvity_matrix_1_csv.json",
+            "data system instance identifier": "N/A",
             "file name": "revvity_matrix_1_csv.csv",
             "UNC path": "tests/parsers/revvity_matrix/testdata/revvity_matrix_1_csv.csv",
             "ASM converter name": "allotropy_revvity_matrix",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66"
+        },
+        "device system document": {
+            "device identifier": "N/A",
+            "model number": "N/A"
         }
     }
 }

--- a/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_xlsx.json
+++ b/tests/parsers/revvity_matrix/testdata/revvity_matrix_1_xlsx.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -1357,12 +1357,17 @@
                 }
             }
         ],
-        "device system document": {},
         "data system document": {
+            "ASM file identifier": "revvity_matrix_1_xlsx.json",
+            "data system instance identifier": "N/A",
             "file name": "revvity_matrix_1_xlsx.xlsx",
             "UNC path": "tests/parsers/revvity_matrix/testdata/revvity_matrix_1_xlsx.xlsx",
             "ASM converter name": "allotropy_revvity_matrix",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66"
+        },
+        "device system document": {
+            "device identifier": "N/A",
+            "model number": "N/A"
         }
     }
 }

--- a/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_1.json
+++ b/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_1.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -851,20 +851,22 @@
                 "analyst": "SuperUser"
             }
         ],
-        "device system document": {
-            "asset management identifier": "G037DE019",
-            "description": "my system",
-            "brand name": "Cedex",
-            "product manufacturer": "Roche",
-            "device identifier": "3714019",
-            "model number": "Cedex HiRes"
-        },
         "data system document": {
+            "ASM file identifier": "roche_cedex_hires_example_1.json",
+            "data system instance identifier": "N/A",
             "file name": "roche_cedex_hires_example_1.csv",
             "UNC path": "tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_1.csv",
-            "software name": "Cedex software",
             "ASM converter name": "allotropy_roche_cedex_hires",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "Cedex software"
+        },
+        "device system document": {
+            "asset management identifier": "G037DE019",
+            "brand name": "Cedex",
+            "description": "my system",
+            "device identifier": "3714019",
+            "model number": "Cedex HiRes",
+            "product manufacturer": "Roche"
         }
     }
 }

--- a/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_2.json
+++ b/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_2.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -851,20 +851,22 @@
                 "analyst": "SuperUser"
             }
         ],
-        "device system document": {
-            "asset management identifier": "G037DE019",
-            "description": "my system",
-            "brand name": "Cedex",
-            "product manufacturer": "Roche",
-            "device identifier": "3714019",
-            "model number": "Cedex HiRes"
-        },
         "data system document": {
+            "ASM file identifier": "roche_cedex_hires_example_2.json",
+            "data system instance identifier": "N/A",
             "file name": "roche_cedex_hires_example_2.xlsx",
             "UNC path": "tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_2.xlsx",
-            "software name": "Cedex software",
             "ASM converter name": "allotropy_roche_cedex_hires",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "Cedex software"
+        },
+        "device system document": {
+            "asset management identifier": "G037DE019",
+            "brand name": "Cedex",
+            "description": "my system",
+            "device identifier": "3714019",
+            "model number": "Cedex HiRes",
+            "product manufacturer": "Roche"
         }
     }
 }

--- a/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_3.json
+++ b/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_3.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -10285,20 +10285,22 @@
                 "analyst": "SuperUser"
             }
         ],
-        "device system document": {
-            "asset management identifier": "G037D0901, MS, prem",
-            "description": "G037D0901, MS, premium version, ID = 3700901",
-            "brand name": "Cedex",
-            "product manufacturer": "Roche",
-            "device identifier": "3700901",
-            "model number": "Cedex HiRes"
-        },
         "data system document": {
+            "ASM file identifier": "roche_cedex_hires_example_3.json",
+            "data system instance identifier": "N/A",
             "file name": "roche_cedex_hires_example_3.csv",
             "UNC path": "tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_3.csv",
-            "software name": "Cedex software",
             "ASM converter name": "allotropy_roche_cedex_hires",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "Cedex software"
+        },
+        "device system document": {
+            "asset management identifier": "G037D0901, MS, prem",
+            "brand name": "Cedex",
+            "description": "G037D0901, MS, premium version, ID = 3700901",
+            "device identifier": "3700901",
+            "model number": "Cedex HiRes",
+            "product manufacturer": "Roche"
         }
     }
 }

--- a/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_4.json
+++ b/tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_4.json
@@ -1,5 +1,5 @@
 {
-    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/BENCHLING/2023/11/cell-counting.manifest",
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
     "cell counting aggregate document": {
         "cell counting document": [
             {
@@ -10285,20 +10285,22 @@
                 "analyst": "SuperUser"
             }
         ],
-        "device system document": {
-            "asset management identifier": "G037D0901, MS, prem",
-            "description": "G037D0901, MS, premium version, ID = 3700901",
-            "brand name": "Cedex",
-            "product manufacturer": "Roche",
-            "device identifier": "3700901",
-            "model number": "Cedex HiRes"
-        },
         "data system document": {
+            "ASM file identifier": "roche_cedex_hires_example_4.json",
+            "data system instance identifier": "N/A",
             "file name": "roche_cedex_hires_example_4.xlsx",
             "UNC path": "tests/parsers/roche_cedex_hires/testdata/roche_cedex_hires_example_4.xlsx",
-            "software name": "Cedex software",
             "ASM converter name": "allotropy_roche_cedex_hires",
-            "ASM converter version": "0.1.61"
+            "ASM converter version": "0.1.66",
+            "software name": "Cedex software"
+        },
+        "device system document": {
+            "asset management identifier": "G037D0901, MS, prem",
+            "brand name": "Cedex",
+            "description": "G037D0901, MS, premium version, ID = 3700901",
+            "device identifier": "3700901",
+            "model number": "Cedex HiRes",
+            "product manufacturer": "Roche"
         }
     }
 }


### PR DESCRIPTION
Migrate the following Cell counting adapters to the `cell-counting/REC/2024/09` schema:

 - `Beckman Vi-Cell BLU`
 - `ChemoMetec NC View`
 - `ChemoMetec Nucleoview`
 - `Revvity Matrix`
 - `Roche Cedex HiRes`