### PR TITLE
feat: ChemoMetec NucleoView - Incorporate error document when viable cell density is missing

### DIFF
--- a/src/allotropy/parsers/chemometec_nucleoview/nucleoview_structure.py
+++ b/src/allotropy/parsers/chemometec_nucleoview/nucleoview_structure.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pandas as pd
 
 from allotropy.allotrope.schema_mappers.adm.cell_counting.rec._2024._09.cell_counting import (
+    Error,
     Measurement,
     MeasurementGroup,
     Metadata,
@@ -16,7 +17,11 @@ from allotropy.parsers.chemometec_nucleoview.constants import (
     NUCLEOCOUNTER_DEVICE_TYPE,
     NUCLEOCOUNTER_SOFTWARE_NAME,
 )
-from allotropy.parsers.constants import DEFAULT_EPOCH_TIMESTAMP, NOT_APPLICABLE
+from allotropy.parsers.constants import (
+    DEFAULT_EPOCH_TIMESTAMP,
+    NEGATIVE_ZERO,
+    NOT_APPLICABLE,
+)
 from allotropy.parsers.utils.pandas import SeriesData
 from allotropy.parsers.utils.uuids import random_uuid_str
 
@@ -39,6 +44,7 @@ def create_metadata(data: SeriesData, file_path: str) -> Metadata:
 
 def create_measurement_groups(data: SeriesData) -> MeasurementGroup:
     timestamp = data.get(str, "Date time")
+    errors = []
     if timestamp:
         offset = data.get(str, "Time zone offset", "0")
         timestamp = pd.to_datetime(
@@ -48,6 +54,14 @@ def create_measurement_groups(data: SeriesData) -> MeasurementGroup:
     def _converted_value_or_none(key: str) -> float | None:
         return value / 1e6 if (value := data.get(float, key)) is not None else None
 
+    viable_cell_density = data.get(float, "Live (cells/ml)")
+    if viable_cell_density is None:
+        errors.append(
+            Error(
+                error=NOT_APPLICABLE,
+                feature="viable cell density",
+            )
+        )
     return MeasurementGroup(
         analyst=data.get(str, "Operator", DEFAULT_ANALYST),
         measurements=[
@@ -58,12 +72,15 @@ def create_measurement_groups(data: SeriesData) -> MeasurementGroup:
                 cell_density_dilution_factor=data.get(float, "Multiplication factor"),
                 viability=data[float, "Viability (%)"],
                 # Cell counts are measured in cells/mL, but reported in millions of cells/mL
-                viable_cell_density=data[float, "Live (cells/ml)"] / 1e6,
+                viable_cell_density=(viable_cell_density / 1e6)
+                if viable_cell_density
+                else NEGATIVE_ZERO,
                 dead_cell_density=_converted_value_or_none("Dead (cells/ml)"),
                 total_cell_density=_converted_value_or_none("Total (cells/ml)"),
                 average_total_cell_diameter=data.get(
                     float, "Estimated cell diameter (um)"
                 ),
+                errors=errors,
             )
         ],
     )

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example07.csv
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example07.csv
@@ -1,0 +1,47 @@
+Viability and Cell Count Assay - example cell counting; ;
+Image;20231120-0002-c-cellsABCD;
+Operator;DrScientist;
+Viability (%);92.8;
+Dead (cells/ml);1.22E5;
+Total (cells/ml);1.70E6;
+; ;
+Estimated cell diameter (um);13.2 (Uncertain
+determination);
+Cell diameter standard deviation (um);7.7;
+(%) of cells in aggregates with five or more cells;5;
+Sample Volume (ul);200.0;
+Dilution Volume (ul);0.000;
+Multiplication factor;1.000;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+cm filename;20231120-0039-c-cellsABCD.cm
+Protocol template title;Viability and Cell Count Assay
+Protocol template purpose;Cell Count and Viability with AO and DAPI
+Protocol template filename;Viability and Cell Count Assay - NC-200.cmsx
+Protocol adaptation title;example cell counting
+Protocol adaptation purpose;Cell Count and Viability with AO and DAPI
+Protocol adaptation filename;287764ADc8824786b882bfc202a12044.cmsu
+Instrument type;NucleoView NC-200
+Instrument s/n;s/n 9000201099909999
+Date time;20231120 110300
+Time zone offset;-7
+Login ID;admin
+PC;ABC0-NBBS-FQ01
+Application SW version;1.4.0.0
+21 CFR Part 11;disabled
+Event log format;Plain text
+csv file version;2
+
+//[25FDBA08]

--- a/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example07.json
+++ b/tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example07.json
@@ -1,0 +1,79 @@
+{
+    "$asm.manifest": "http://purl.allotrope.org/manifests/cell-counting/REC/2024/09/cell-counting.manifest",
+    "cell counting aggregate document": {
+        "cell counting document": [
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "dark field imager (cell counter)",
+                                        "detection type": "dark field"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "CHEMOMETEC_NUCLEOVIEW_TEST_ID_0",
+                            "measurement time": "2023-11-20T11:03:00-07:00",
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "cell density dilution factor": {
+                                                "value": 1.0,
+                                                "unit": "(unitless)"
+                                            }
+                                        },
+                                        "viability (cell counter)": {
+                                            "value": 92.8,
+                                            "unit": "%"
+                                        },
+                                        "viable cell density (cell counter)": {
+                                            "value": -0.0,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "total cell density (cell counter)": {
+                                            "value": 1.7,
+                                            "unit": "10^6 cells/mL"
+                                        },
+                                        "dead cell density (cell counter)": {
+                                            "value": 0.122,
+                                            "unit": "10^6 cells/mL"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "cellsABCD"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "viable cell density"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "analyst": "DrScientist"
+            }
+        ],
+        "data system document": {
+            "ASM file identifier": "chemometec_nucleoview_example07.json",
+            "data system instance identifier": "ABC0-NBBS-FQ01",
+            "file name": "chemometec_nucleoview_example07.csv",
+            "UNC path": "tests/parsers/chemometec_nucleoview/testdata/chemometec_nucleoview_example07.csv",
+            "ASM converter name": "allotropy_chemometec_nucleoview",
+            "ASM converter version": "0.1.68",
+            "software name": "NucleoView",
+            "software version": "1.4.0.0"
+        },
+        "device system document": {
+            "equipment serial number": "s/n 9000201099909999",
+            "model number": "NucleoView NC-200"
+        }
+    }
+}


### PR DESCRIPTION
- Updated adapter to handle missing viable cell density