### PR TITLE
feat: implement special views for Quantstudio design analysis in calcdoc module

### DIFF
--- a/src/allotropy/calcdocs/appbio_quantstudio_designandanalysis/views.py
+++ b/src/allotropy/calcdocs/appbio_quantstudio_designandanalysis/views.py
@@ -1,12 +1,35 @@
+from __future__ import annotations
+
 from collections import defaultdict
 
 from allotropy.calcdocs.extractor import Element
 from allotropy.calcdocs.view import View
 
 
-class SampleView(View):
-    def __init__(self, sub_view: View | None = None):
-        super().__init__(name="sample_id", sub_view=sub_view)
+class ViewWithReference(View):
+    def __init__(
+        self,
+        name: str,
+        sub_view: ViewWithReference | None,
+        reference: str | None = None,
+    ):
+        super().__init__(name, sub_view)
+        self.reference = reference
+
+    def filter_keys(self, keys: dict[str, str]) -> dict[str, str]:
+        filtered_keys = super().filter_keys(keys)
+        if self.reference is not None and self.name in filtered_keys:
+            filtered_keys[self.name] = self.reference
+        return filtered_keys
+
+
+class SampleView(ViewWithReference):
+    def __init__(
+        self,
+        sub_view: ViewWithReference | None = None,
+        reference: str | None = None,
+    ):
+        super().__init__(name="sample_id", sub_view=sub_view, reference=reference)
 
     def sort_elements(self, elements: list[Element]) -> dict[str, list[Element]]:
         items = defaultdict(list)
@@ -16,20 +39,27 @@ class SampleView(View):
         return dict(items)
 
 
-class TargetView(View):
-    def __init__(self, sub_view: View | None = None):
-        super().__init__(name="target_dna", sub_view=sub_view)
+class TargetView(ViewWithReference):
+    def __init__(
+        self,
+        sub_view: ViewWithReference | None = None,
+        reference: str | None = None,
+        blacklist: list[str] | None = None,
+    ):
+        super().__init__(name="target_dna", sub_view=sub_view, reference=reference)
+        self.blacklist = blacklist
 
     def sort_elements(self, elements: list[Element]) -> dict[str, list[Element]]:
         items = defaultdict(list)
         for element in elements:
             if target_dna_description := element.get_str("target_dna_description"):
-                items[str(target_dna_description)].append(element)
+                if self.blacklist is None or target_dna_description not in self.blacklist:
+                    items[str(target_dna_description)].append(element)
         return dict(items)
 
 
-class UuidView(View):
-    def __init__(self, sub_view: View | None = None):
+class UuidView(ViewWithReference):
+    def __init__(self, sub_view: ViewWithReference | None = None):
         super().__init__(name="uuid", sub_view=sub_view)
 
     def sort_elements(self, elements: list[Element]) -> dict[str, list[Element]]:
@@ -40,8 +70,8 @@ class UuidView(View):
         return dict(items)
 
 
-class TargetRoleView(View):
-    def __init__(self, sub_view: View | None = None):
+class TargetRoleView(ViewWithReference):
+    def __init__(self, sub_view: ViewWithReference | None = None):
         super().__init__(name="target_dna", sub_view=sub_view)
 
     def sort_elements(self, elements: list[Element]) -> dict[str, list[Element]]:

--- a/src/allotropy/calcdocs/appbio_quantstudio_designandanalysis/views.py
+++ b/src/allotropy/calcdocs/appbio_quantstudio_designandanalysis/views.py
@@ -52,9 +52,9 @@ class TargetView(ViewWithReference):
     def sort_elements(self, elements: list[Element]) -> dict[str, list[Element]]:
         items = defaultdict(list)
         for element in elements:
-            if target_dna_description := element.get_str("target_dna_description"):
-                if self.blacklist is None or target_dna_description not in self.blacklist:
-                    items[str(target_dna_description)].append(element)
+            if target_dna := element.get_str("target_dna_description"):
+                if self.blacklist is None or target_dna not in self.blacklist:
+                    items[str(target_dna)].append(element)
         return dict(items)
 
 


### PR DESCRIPTION
- Implement ViewWithReference to cover construction of delta calculated data documents
- Implement blacklist in TargetView to support the removal of some values of target dna just as in the original parser implentation
- move filter_keys from ViewData to View in order to use the structure of the instances instead of the data collected from them
