### PR TITLE
feat: AppBio QuantStudio RT-PCR - add back reference fields as custom data processing info

### DIFF
--- a/src/allotropy/allotrope/schema_mappers/adm/pcr/rec/_2024/_09/qpcr.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/pcr/rec/_2024/_09/qpcr.py
@@ -352,7 +352,7 @@ class Mapper(SchemaMapper[Data, Model]):
                         data.baseline_determination_end_cycle_setting,
                     ),
                 ),
-                data.data_processing_custom_info
+                data.data_processing_custom_info,
             ),
             cycle_threshold_result__qPCR_=quantity_or_none(
                 TQuantityValueUnitless, data.cycle_threshold_result

--- a/src/allotropy/allotrope/schema_mappers/adm/pcr/rec/_2024/_09/qpcr.py
+++ b/src/allotropy/allotrope/schema_mappers/adm/pcr/rec/_2024/_09/qpcr.py
@@ -123,6 +123,7 @@ class ProcessedData:
     # Metadata
     comments: str | None = None
 
+    data_processing_custom_info: dict[str, Any] | None = None
     custom_info: dict[str, Any] | None = None
 
 
@@ -331,24 +332,27 @@ class Mapper(SchemaMapper[Data, Model]):
         if not data:
             return None
         doc = ProcessedDataDocumentItem(
-            data_processing_document=DataProcessingDocument(
-                automatic_cycle_threshold_enabled_setting=data.automatic_cycle_threshold_enabled_setting,
-                cycle_threshold_value_setting__qPCR_=quantity_or_none(
-                    TQuantityValueUnitless, data.cycle_threshold_value_setting
+            data_processing_document=add_custom_information_document(
+                DataProcessingDocument(
+                    automatic_cycle_threshold_enabled_setting=data.automatic_cycle_threshold_enabled_setting,
+                    cycle_threshold_value_setting__qPCR_=quantity_or_none(
+                        TQuantityValueUnitless, data.cycle_threshold_value_setting
+                    ),
+                    automatic_baseline_determination_enabled_setting=data.automatic_baseline_determination_enabled_setting,
+                    genotyping_qPCR_method_setting__qPCR_=quantity_or_none(
+                        TQuantityValueUnitless,
+                        data.genotyping_determination_method_setting,
+                    ),
+                    baseline_determination_start_cycle_setting=quantity_or_none(
+                        TQuantityValueNumber,
+                        data.baseline_determination_start_cycle_setting,
+                    ),
+                    baseline_determination_end_cycle_setting=quantity_or_none(
+                        TQuantityValueNumber,
+                        data.baseline_determination_end_cycle_setting,
+                    ),
                 ),
-                automatic_baseline_determination_enabled_setting=data.automatic_baseline_determination_enabled_setting,
-                genotyping_qPCR_method_setting__qPCR_=quantity_or_none(
-                    TQuantityValueUnitless,
-                    data.genotyping_determination_method_setting,
-                ),
-                baseline_determination_start_cycle_setting=quantity_or_none(
-                    TQuantityValueNumber,
-                    data.baseline_determination_start_cycle_setting,
-                ),
-                baseline_determination_end_cycle_setting=quantity_or_none(
-                    TQuantityValueNumber,
-                    data.baseline_determination_end_cycle_setting,
-                ),
+                data.data_processing_custom_info
             ),
             cycle_threshold_result__qPCR_=quantity_or_none(
                 TQuantityValueUnitless, data.cycle_threshold_result

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_data_creator.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_data_creator.py
@@ -24,6 +24,7 @@ from allotropy.parsers.appbio_quantstudio.appbio_quantstudio_structure import (
     MeltCurveRawData,
     MulticomponentData,
     Result,
+    ResultMetadata,
     Well,
     WellItem,
 )
@@ -70,7 +71,7 @@ def _create_processed_data_cubes(
 
 
 def _create_processed_data(
-    amplification_data: AmplificationData | None, result: Result
+    amplification_data: AmplificationData | None, result: Result, result_metadata: ResultMetadata,
 ) -> ProcessedData:
     (
         normalized_reporter_data_cube,
@@ -89,6 +90,10 @@ def _create_processed_data(
         baseline_corrected_reporter_result=result.baseline_corrected_reporter_result,
         normalized_reporter_data_cube=normalized_reporter_data_cube,
         baseline_corrected_reporter_data_cube=baseline_corrected_reporter_data_cube,
+        data_processing_custom_info={
+            "reference dna description": result_metadata.reference_dna_description,
+            "reference sample description": result_metadata.reference_sample_description,
+        },
         custom_info=result.extra_data,
     )
 
@@ -168,6 +173,7 @@ def _create_measurement(
     melt_curve_raw_data: MeltCurveRawData | None,
     amplification_data: AmplificationData | None,
     result: Result | None,
+    result_metadata: ResultMetadata,
 ) -> Measurement | None:
     if not result:
         return None
@@ -201,7 +207,7 @@ def _create_measurement(
         reporter_dye_setting=well_item.reporter_dye_setting,
         quencher_dye_setting=well_item.quencher_dye_setting,
         passive_reference_dye_setting=header.passive_reference_dye_setting,
-        processed_data=_create_processed_data(amplification_data, result),
+        processed_data=_create_processed_data(amplification_data, result, result_metadata),
         sample_custom_info=well_item.extra_data,
         reporter_dye_data_cube=reporter_dye_data_cube,
         passive_reference_dye_data_cube=passive_reference_dye_data_cube,
@@ -274,6 +280,7 @@ def _create_measurement_group(
     results_data: dict[int, dict[str, Result]],
     melt_data: dict[int, MeltCurveRawData],
     plate_well_count: int | None,
+    result_metadata: ResultMetadata,
 ) -> MeasurementGroup | None:
     measurements = [
         _create_measurement(
@@ -283,6 +290,7 @@ def _create_measurement_group(
             melt_data.get(well.identifier),
             get_well_item_amp_data(well_item, amp_data),
             get_well_item_results(well_item, results_data),
+            result_metadata,
         )
         for well_item in well.items
         if get_well_item_results(well_item, results_data)
@@ -326,6 +334,7 @@ def create_measurement_groups(
     multi_data: dict[int, MulticomponentData],
     results_data: dict[int, dict[str, Result]],
     melt_data: dict[int, MeltCurveRawData],
+    result_metadata: ResultMetadata,
 ) -> list[MeasurementGroup]:
 
     plate_well_count = _get_plate_well_count(header, wells)
@@ -338,6 +347,7 @@ def create_measurement_groups(
             results_data,
             melt_data,
             plate_well_count,
+            result_metadata,
         )
         for well in wells
     ]

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_data_creator.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_data_creator.py
@@ -71,7 +71,9 @@ def _create_processed_data_cubes(
 
 
 def _create_processed_data(
-    amplification_data: AmplificationData | None, result: Result, result_metadata: ResultMetadata,
+    amplification_data: AmplificationData | None,
+    result: Result,
+    result_metadata: ResultMetadata,
 ) -> ProcessedData:
     (
         normalized_reporter_data_cube,
@@ -207,7 +209,9 @@ def _create_measurement(
         reporter_dye_setting=well_item.reporter_dye_setting,
         quencher_dye_setting=well_item.quencher_dye_setting,
         passive_reference_dye_setting=header.passive_reference_dye_setting,
-        processed_data=_create_processed_data(amplification_data, result, result_metadata),
+        processed_data=_create_processed_data(
+            amplification_data, result, result_metadata
+        ),
         sample_custom_info=well_item.extra_data,
         reporter_dye_data_cube=reporter_dye_data_cube,
         passive_reference_dye_data_cube=passive_reference_dye_data_cube,

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
@@ -38,20 +38,20 @@ class AppBioQuantStudioParser(VendorParser[Data, Model]):
         wells = Well.create(reader, header.experiment_type)
         amp_data = create_amplification_data(reader)
         multi_data = create_multicomponent_data(reader)
-        results_data, results_metadata = Result.create(reader, header.experiment_type)
+        results_data, result_metadata = Result.create(reader, header.experiment_type)
         melt_data = MeltCurveRawData.create(reader)
 
         calculated_data_documents = iter_calculated_data_documents(
             [well_item for well in wells for well_item in well.items],
             header.experiment_type,
-            results_metadata.reference_sample_description,
-            results_metadata.reference_dna_description,
+            result_metadata.reference_sample_description,
+            result_metadata.reference_dna_description,
         )
 
         return Data(
             metadata=create_metadata(header, named_file_contents.original_file_path),
             measurement_groups=create_measurement_groups(
-                header, wells, amp_data, multi_data, results_data, melt_data
+                header, wells, amp_data, multi_data, results_data, melt_data, result_metadata,
             ),
             calculated_data=create_calculated_data(calculated_data_documents),
         )

--- a/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
+++ b/src/allotropy/parsers/appbio_quantstudio/appbio_quantstudio_parser.py
@@ -51,7 +51,13 @@ class AppBioQuantStudioParser(VendorParser[Data, Model]):
         return Data(
             metadata=create_metadata(header, named_file_contents.original_file_path),
             measurement_groups=create_measurement_groups(
-                header, wells, amp_data, multi_data, results_data, melt_data, result_metadata,
+                header,
+                wells,
+                amp_data,
+                multi_data,
+                results_data,
+                melt_data,
+                result_metadata,
             ),
             calculated_data=create_calculated_data(calculated_data_documents),
         )

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example05.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example05.json
@@ -51,6 +51,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 39,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "normalized reporter data cube": {
@@ -560,6 +564,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 39,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "normalized reporter data cube": {
@@ -1069,6 +1077,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 39,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "normalized reporter data cube": {
@@ -1578,6 +1590,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 39,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "normalized reporter data cube": {
@@ -2087,6 +2103,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 39,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "normalized reporter data cube": {
@@ -2596,6 +2616,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 39,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "normalized reporter data cube": {
@@ -3106,6 +3130,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -3620,6 +3648,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -4134,6 +4166,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -4648,6 +4684,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -5162,6 +5202,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -5676,6 +5720,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -6190,6 +6238,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 22,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -6704,6 +6756,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 22,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -7218,6 +7274,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 22,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -7732,6 +7792,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -8246,6 +8310,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -8760,6 +8828,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -9274,6 +9346,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -9788,6 +9864,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -10302,6 +10382,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -10816,6 +10900,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -11330,6 +11418,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -11844,6 +11936,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -12358,6 +12454,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 22,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -12872,6 +12972,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 22,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -13386,6 +13490,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 23,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -13900,6 +14008,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -14414,6 +14526,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -14928,6 +15044,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -15442,6 +15562,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -15956,6 +16080,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -16470,6 +16598,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -16984,6 +17116,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -17498,6 +17634,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -18012,6 +18152,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -18526,6 +18670,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 22,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -19040,6 +19188,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 22,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -19554,6 +19706,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 23,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -20068,6 +20224,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -20582,6 +20742,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -21096,6 +21260,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -21610,6 +21778,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -22124,6 +22296,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -22638,6 +22814,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -23152,6 +23332,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -23666,6 +23850,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -24180,6 +24368,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 24,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -24694,6 +24886,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 22,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -25208,6 +25404,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 23,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -25722,6 +25922,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 22,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -26236,6 +26440,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -26750,6 +26958,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -27264,6 +27476,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -27778,6 +27994,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -28292,6 +28512,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -28806,6 +29030,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 28,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -29320,6 +29548,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -29834,6 +30066,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -30348,6 +30584,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -30862,6 +31102,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -31376,6 +31620,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -31890,6 +32138,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -32404,6 +32656,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -32918,6 +33174,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -33432,6 +33692,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -36931,7 +37195,7 @@
             "file name": "appbio_quantstudio_example05.txt",
             "UNC path": "tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example05.txt",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.69",
+            "ASM converter version": "0.1.73",
             "software name": "Thermo QuantStudio",
             "software version": "1.0"
         },

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example06.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example06.json
@@ -52,6 +52,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -192,6 +196,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -332,6 +340,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -472,6 +484,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -612,6 +628,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -752,6 +772,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -892,6 +916,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -1032,6 +1060,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -1172,6 +1204,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -1945,7 +1981,7 @@
             "file name": "appbio_quantstudio_example06.txt",
             "UNC path": "tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example06.txt",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.69",
+            "ASM converter version": "0.1.73",
             "software name": "Thermo QuantStudio",
             "software version": "1.0"
         },

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example07.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example07.json
@@ -51,6 +51,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "normalized reporter data cube": {
@@ -561,6 +565,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -1075,6 +1083,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -1589,6 +1601,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -2103,6 +2119,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -2617,6 +2637,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -3131,6 +3155,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "normalized reporter data cube": {
@@ -3641,6 +3669,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -4155,6 +4187,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -4669,6 +4705,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -5183,6 +5223,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -5697,6 +5741,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -6211,6 +6259,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "normalized reporter data cube": {
@@ -6721,6 +6773,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -7235,6 +7291,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -7749,6 +7809,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -8263,6 +8327,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -8777,6 +8845,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -9291,6 +9363,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "normalized reporter data cube": {
@@ -9801,6 +9877,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -10315,6 +10395,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -10829,6 +10913,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -11343,6 +11431,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -11857,6 +11949,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -12371,6 +12467,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "normalized reporter data cube": {
@@ -12881,6 +12981,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -13395,6 +13499,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -13909,6 +14017,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -14423,6 +14535,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -14937,6 +15053,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -15451,6 +15571,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "normalized reporter data cube": {
@@ -15961,6 +16085,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -16475,6 +16603,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -16989,6 +17121,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -17503,6 +17639,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -18017,6 +18157,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -18532,6 +18676,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -19047,6 +19195,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -19562,6 +19714,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -20077,6 +20233,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -20592,6 +20752,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -21107,6 +21271,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -21622,6 +21790,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -22137,6 +22309,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -22652,6 +22828,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -23167,6 +23347,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -23682,6 +23866,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -24197,6 +24385,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -24712,6 +24904,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -25227,6 +25423,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -25742,6 +25942,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -26257,6 +26461,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -26772,6 +26980,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -27287,6 +27499,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -27802,6 +28018,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -28317,6 +28537,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -28832,6 +29056,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -29347,6 +29575,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -29862,6 +30094,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -30377,6 +30613,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -30892,6 +31132,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -31407,6 +31651,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -31922,6 +32170,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -32437,6 +32689,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -32952,6 +33208,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -33467,6 +33727,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -33982,6 +34246,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -34497,6 +34765,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -35012,6 +35284,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -35527,6 +35803,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -36042,6 +36322,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -36557,6 +36841,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -37072,6 +37360,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -37587,6 +37879,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -38102,6 +38398,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -38617,6 +38917,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -39132,6 +39436,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -39647,6 +39955,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -40162,6 +40474,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -40677,6 +40993,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -41192,6 +41512,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -41707,6 +42031,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -42222,6 +42550,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -42737,6 +43069,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -43252,6 +43588,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -43767,6 +44107,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -44282,6 +44626,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -44797,6 +45145,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -45312,6 +45664,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -45827,6 +46183,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -46342,6 +46702,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -46857,6 +47221,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -47372,6 +47740,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -47887,6 +48259,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -48402,6 +48778,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -48917,6 +49297,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "IPC",
+                                                "reference sample description": "1000"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -56545,7 +56929,7 @@
             "file name": "appbio_quantstudio_example07.txt",
             "UNC path": "tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example07.txt",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.69",
+            "ASM converter version": "0.1.73",
             "software name": "Thermo QuantStudio",
             "software version": "1.0"
         },

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example08.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example08.json
@@ -52,6 +52,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -371,6 +375,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -707,6 +715,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -1026,6 +1038,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -1362,6 +1378,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -1681,6 +1701,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -2017,6 +2041,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -2336,6 +2364,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -2672,6 +2704,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -2991,6 +3027,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -3327,6 +3367,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -3646,6 +3690,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -3982,6 +4030,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -4301,6 +4353,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -4637,6 +4693,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -4956,6 +5016,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -5292,6 +5356,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -5611,6 +5679,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -5947,6 +6019,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -6266,6 +6342,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -6602,6 +6682,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -6921,6 +7005,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -7257,6 +7345,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -7576,6 +7668,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -7912,6 +8008,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -8231,6 +8331,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -8567,6 +8671,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -8886,6 +8994,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -9222,6 +9334,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -9541,6 +9657,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -9877,6 +9997,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -10196,6 +10320,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -10532,6 +10660,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -10851,6 +10983,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -11187,6 +11323,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -11506,6 +11646,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 50,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "18S",
+                                                "reference sample description": "13Jul2022-Hs-1"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -12955,7 +13099,7 @@
             "file name": "appbio_quantstudio_example08.xlsx",
             "UNC path": "tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_example08.xlsx",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.69",
+            "ASM converter version": "0.1.73",
             "software name": "Thermo QuantStudio",
             "software version": "1.0"
         },

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_broken_path_calc_doc.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_broken_path_calc_doc.json
@@ -52,6 +52,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "RNaseP",
+                                                "reference sample description": "800"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -217,7 +221,7 @@
             "file name": "appbio_quantstudio_minimal_broken_path_calc_doc.txt",
             "UNC path": "tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_broken_path_calc_doc.txt",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.69",
+            "ASM converter version": "0.1.73",
             "software name": "Thermo QuantStudio",
             "software version": "1.0"
         },

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test02.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test02.json
@@ -51,6 +51,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 40,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "N/A",
+                                                "reference sample description": "N/A"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -249,7 +253,7 @@
             "file name": "appbio_quantstudio_minimal_test02.txt",
             "UNC path": "tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test02.txt",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.69",
+            "ASM converter version": "0.1.73",
             "software name": "Thermo QuantStudio",
             "software version": "1.0"
         },

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test04.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test04.json
@@ -52,6 +52,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "RNaseP",
+                                                "reference sample description": "800"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -192,6 +196,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "RNaseP",
+                                                "reference sample description": "800"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -613,7 +621,7 @@
             "file name": "appbio_quantstudio_minimal_test04.txt",
             "UNC path": "tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test04.txt",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.69",
+            "ASM converter version": "0.1.73",
             "software name": "Thermo QuantStudio",
             "software version": "1.0"
         },

--- a/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test07.json
+++ b/tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test07.json
@@ -52,6 +52,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -192,6 +196,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -332,6 +340,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -472,6 +484,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -612,6 +628,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 25,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -752,6 +772,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -892,6 +916,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -1032,6 +1060,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -1172,6 +1204,10 @@
                                             "baseline determination end cycle setting": {
                                                 "value": 29,
                                                 "unit": "#"
+                                            },
+                                            "custom information document": {
+                                                "reference dna description": "GAPDH",
+                                                "reference sample description": "Liver"
                                             }
                                         },
                                         "cycle threshold result (qPCR)": {
@@ -1945,7 +1981,7 @@
             "file name": "appbio_quantstudio_minimal_test07.txt",
             "UNC path": "tests/parsers/appbio_quantstudio/testdata/appbio_quantstudio_minimal_test07.txt",
             "ASM converter name": "allotropy_appbio_quantstudio_rt_pcr",
-            "ASM converter version": "0.1.69",
+            "ASM converter version": "0.1.73",
             "software name": "Thermo QuantStudio",
             "software version": "1.0"
         },


### PR DESCRIPTION
The migration to REC/2024/09 dropped two important pieces of metadata, reference DNA description and reference sample description. Add them back as custom info, since they are not in the REC schema.