### PR TITLE
fix: Unchained Labs Lunatic - handle different cases for column headers

### DIFF
--- a/src/allotropy/parsers/unchained_labs_lunatic/constants.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/constants.py
@@ -9,7 +9,7 @@ PRODUCT_MANUFACTURER = "Unchained Labs"
 SOFTWARE_NAME = "Lunatic and Stunner Analysis"
 
 # Wavelength columns will be "A<3-digit number>" with an optional pathlength specification, e.g. 'A260' or 'A260 (10mm)'
-WAVELENGTH_COLUMNS_RE = re.compile(r"^A(\d{3})(?:\s\((\d+)?mm\))?$")
+WAVELENGTH_COLUMNS_RE = re.compile(r"^a(\d{3})(?:\s\((\d+)?mm\))?$")
 NO_WAVELENGTH_COLUMN_ERROR_MSG = (
     "The file is required to include an absorbance measurement column (e.g. A280)"
 )

--- a/src/allotropy/parsers/unchained_labs_lunatic/constants.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/constants.py
@@ -9,7 +9,7 @@ PRODUCT_MANUFACTURER = "Unchained Labs"
 SOFTWARE_NAME = "Lunatic and Stunner Analysis"
 
 # Wavelength columns will be "A<3-digit number>" with an optional pathlength specification, e.g. 'A260' or 'A260 (10mm)'
-WAVELENGTH_COLUMNS_RE = re.compile(r"^a(\d{3})(?:\s\((\d+)?mm\))?$")
+WAVELENGTH_COLUMNS_RE = re.compile(r"(?i)^A(\d{3})(?:\s\((\d+)?mm\))?$")
 NO_WAVELENGTH_COLUMN_ERROR_MSG = (
     "The file is required to include an absorbance measurement column (e.g. A280)"
 )
@@ -23,53 +23,53 @@ NO_MEASUREMENT_IN_PLATE_ERROR_MSG = (
 )
 
 CALCULATED_DATA_LOOKUP = {
-    "A260": [
+    "a260": [
         {
-            "column": "A260 Concentration (ng/ul)",
+            "column": "a260 concentration (ng/ul)",
             "name": "Concentration",
             "feature": "absorbance",
             "unit": "ng/µL",
         },
         {
-            "column": "Concentration (ng/ul)",
+            "column": "concentration (ng/ul)",
             "name": "Concentration",
             "feature": "absorbance",
             "unit": "ng/µL",
         },
         {
-            "column": "Background (A260)",
+            "column": "background (a260)",
             "name": "Background (A260)",
             "feature": "absorbance",
             "unit": "mAU",
         },
         {
-            "column": "A260/A230",
+            "column": "a260/a230",
             "name": "A260/A230",
             "feature": "absorbance",
             "unit": UNITLESS,
         },
         {
-            "column": "A260/A280",
+            "column": "a260/a280",
             "name": "A260/A280",
             "feature": "absorbance",
             "unit": UNITLESS,
         },
     ],
-    "A280": [
+    "a280": [
         {
-            "column": "Concentration (mg/ml)",
+            "column": "concentration (mg/ml)",
             "name": "Concentration",
             "feature": "absorbance",
             "unit": "mg/mL",
         },
         {
-            "column": "Background (A280)",
+            "column": "background (a280)",
             "name": "Background (A280)",
             "feature": "absorbance",
             "unit": "mAU",
         },
         {
-            "column": "A260/A280",
+            "column": "a260/a280",
             "name": "A260/A280",
             "feature": "absorbance",
             "unit": UNITLESS,

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_reader.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_reader.py
@@ -33,7 +33,7 @@ class UnchainedLabsLunaticReader:
                 table_header_index = int(str(idx))
                 break
         if table_header_index is None:
-            msg = "Unable to find a table header row with 'Sample name'."
+            msg = "Unable to find a table header row with 'Sample Name'."
             raise AllotropeConversionError(msg)
 
         header_data = data[:table_header_index].dropna(how="all").T.dropna(how="all")

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_reader.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_reader.py
@@ -30,7 +30,7 @@ class UnchainedLabsLunaticReader:
         table_header_index = None
         for idx, row in data.iterrows():
             if row.str.lower().str.contains("sample name").any():
-                table_header_index = idx
+                table_header_index = int(str(idx))
                 break
         if table_header_index is None:
             msg = "Unable to find a table header row with 'Sample name'."

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_reader.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_reader.py
@@ -27,15 +27,26 @@ class UnchainedLabsLunaticReader:
         assert_not_empty_df(data, "Unable to parse data from empty dataset.")
 
         # Find the header row by searching for a row with "Sample name".
-        table_header_index = data.index.get_loc(
-            data[(data == "Sample name").any(axis=1)].first_valid_index()
-        )
+        table_header_index = None
+        for idx, row in data.iterrows():
+            if row.str.lower().str.contains("sample name").any():
+                table_header_index = idx
+                break
         if table_header_index is None:
             msg = "Unable to find a table header row with 'Sample name'."
             raise AllotropeConversionError(msg)
 
         header_data = data[:table_header_index].dropna(how="all").T.dropna(how="all")
         data = parse_header_row(data[table_header_index:])
+
+        # Fix column names in excel sheets with newlines/other whitespace.
+        data.columns = (
+            data.columns.astype(str)
+            .str.replace("\n", " ")
+            .str.replace("\r", "")
+            .str.strip()
+            .str.lower()
+        )
         # If the table header is the first row, or the non-empty data above the table header is a single title,
         # there is no metadata header, so attempt to read metadata from the first row of the table.
         # Otherwise, read in the metadata header and save it as a single series.
@@ -45,14 +56,8 @@ class UnchainedLabsLunaticReader:
             self.header = df_to_series_data(
                 parse_header_row(header_data).dropna(axis="columns")
             )
+            self.header.series.index = self.header.series.index.astype(str).str.lower()
 
-        # Fix column names in excel sheets with newlines/other whitespace.
-        data.columns = (
-            data.columns.astype(str)
-            .str.replace("\n", " ")
-            .str.replace("\r", "")
-            .str.strip()
-        )
         # Rows with no Sample name are assumed to be skipped measurements, and are dropped from the results.
-        data = data.dropna(subset=["Sample name"])
+        data = data.dropna(subset=["sample name"])
         self.data = data.replace(np.nan, None)

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
@@ -59,11 +59,11 @@ def _create_measurement(
         wavelength = wavelength_match.groups()[0]
         path_length = None
 
-    background_wavelength = well_plate_data.get(float, "Background Wvl. (nm)")
+    background_wavelength = well_plate_data.get(float, "background wvl. (nm)")
     background_absorbance = None
     if background_wavelength is not None:
         background_absorbance = well_plate_data.get(
-            float, f"Background (A{int(background_wavelength)})"
+            float, f"background (a{int(background_wavelength)})"
         )
 
     measurement_identifier = random_uuid_str()
@@ -95,17 +95,17 @@ def _create_measurement(
             "electronic_absorbance_reference_absorbance": background_absorbance
         },
         absorbance=absorbance if absorbance is not None else NEGATIVE_ZERO,
-        sample_identifier=well_plate_data[str, "Sample name"],
-        location_identifier=well_plate_data[str, "Plate Position"],
-        well_plate_identifier=well_plate_data.get(str, "Plate ID"),
-        batch_identifier=well_plate_data.get(str, "Sample Group"),
-        firmware_version=header.get(str, "Client version"),
+        sample_identifier=well_plate_data[str, "sample name"],
+        location_identifier=well_plate_data[str, "plate position"],
+        well_plate_identifier=well_plate_data.get(str, "plate id"),
+        batch_identifier=well_plate_data.get(str, "sample group"),
+        firmware_version=header.get(str, "client version"),
         sample_custom_info={
             "path length": float(path_length) if path_length is not None else None,
         },
         device_control_custom_info={
-            "path length mode": well_plate_data.get(str, "Path length mode"),
-            "pump": well_plate_data.get(str, "Pump"),
+            "path length mode": well_plate_data.get(str, "path length mode"),
+            "pump": well_plate_data.get(str, "pump"),
         },
         error_document=error_documents,
         processed_data_document=ProcessedDataDocument(
@@ -157,18 +157,19 @@ def _create_measurement_group(
     calculated_data: list[CalculatedDataItem],
     header: SeriesData,
 ) -> MeasurementGroup:
-    timestamp = header.get(str, "Date")
+    print(header.series)
+    timestamp = header.get(str, "date")
     # Support timestamp from metadata section, but overide with columns in data if specified.
-    date = data.get(str, "Date")
-    time = data.get(str, "Time")
+    date = data.get(str, "date")
+    time = data.get(str, "time")
     if date and time:
         timestamp = f"{date} {time}"
 
     return MeasurementGroup(
         measurement_time=assert_not_none(timestamp, msg=NO_DATE_OR_TIME_ERROR_MSG),
-        analyst=header.get(str, "Test performed by"),
-        analytical_method_identifier=data.get(str, "Application"),
-        experimental_data_identifier=header.get(str, "Experiment name"),
+        analyst=header.get(str, "test performed by"),
+        analytical_method_identifier=data.get(str, "application"),
+        experimental_data_identifier=header.get(str, "experiment name"),
         plate_well_count=96,
         measurements=[
             _create_measurement(data, header, wavelength_column, calculated_data)
@@ -179,8 +180,8 @@ def _create_measurement_group(
 
 def create_metadata(header: SeriesData, file_path: str) -> Metadata:
     asm_file_identifier = Path(file_path).with_suffix(".json")
-    device_identifier = header.get(str, "Instrument ID") or header.get(
-        str, "Instrument"
+    device_identifier = header.get(str, "instrument id") or header.get(
+        str, "instrument"
     )
     return Metadata(
         model_number=MODEL_NUMBER,
@@ -189,7 +190,7 @@ def create_metadata(header: SeriesData, file_path: str) -> Metadata:
             device_identifier, msg=NO_DEVICE_IDENTIFIER_ERROR_MSG
         ),
         software_name=SOFTWARE_NAME,
-        software_version=header.get(str, "Software version"),
+        software_version=header.get(str, "software version"),
         file_name=Path(file_path).name,
         unc_path=file_path,
         asm_file_identifier=asm_file_identifier.name,

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
@@ -83,7 +83,7 @@ def _create_measurement(
             )
         )
 
-    concentration_factor = well_plate_data.get(float, "Concentration factor (ng/ul)")
+    concentration_factor = well_plate_data.get(float, "concentration factor (ng/ul)")
     return Measurement(
         type_=MeasurementType.ULTRAVIOLET_ABSORBANCE,
         device_type=DEVICE_TYPE,

--- a/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
+++ b/src/allotropy/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure.py
@@ -157,7 +157,6 @@ def _create_measurement_group(
     calculated_data: list[CalculatedDataItem],
     header: SeriesData,
 ) -> MeasurementGroup:
-    print(header.series)
     timestamp = header.get(str, "date")
     # Support timestamp from metadata section, but overide with columns in data if specified.
     date = data.get(str, "date")

--- a/tests/parsers/unchained_labs_lunatic/testdata/2024-07-12_CW288_Plate1.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/2024-07-12_CW288_Plate1.json
@@ -26,32 +26,222 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
                                 "value": 5.83,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                            "sample document": {
+                                "sample identifier": "sample_B1",
+                                "location identifier": "B1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.38,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                            "sample document": {
+                                "sample identifier": "sample_C1",
+                                "location identifier": "C1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.13,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                            "sample document": {
+                                "sample identifier": "sample_D1",
+                                "location identifier": "D1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.85,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                            "sample document": {
+                                "sample identifier": "sample_E1",
+                                "location identifier": "E1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 8.08,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                            "sample document": {
+                                "sample identifier": "sample_F1",
+                                "location identifier": "F1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.07,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -86,34 +276,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                             "sample document": {
-                                "sample identifier": "sample_B1",
-                                "location identifier": "B1",
+                                "sample identifier": "sample_G1",
+                                "location identifier": "G1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.38,
+                                "value": 6.77,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                            "sample document": {
+                                "sample identifier": "sample_H1",
+                                "location identifier": "H1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 7.82,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                            "sample document": {
+                                "sample identifier": "sample_A2",
+                                "location identifier": "A2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.18,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
+                            "sample document": {
+                                "sample identifier": "sample_B2",
+                                "location identifier": "B2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 1.24,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                            "sample document": {
+                                "sample identifier": "sample_C2",
+                                "location identifier": "C2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.1,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
+                            "sample document": {
+                                "sample identifier": "sample_D2",
+                                "location identifier": "D2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.14,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -148,34 +528,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                             "sample document": {
-                                "sample identifier": "sample_C1",
-                                "location identifier": "C1",
+                                "sample identifier": "sample_E2",
+                                "location identifier": "E2",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.13,
+                                "value": 4.5,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                            "sample document": {
+                                "sample identifier": "sample_F2",
+                                "location identifier": "F2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.42,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                            "sample document": {
+                                "sample identifier": "sample_G2",
+                                "location identifier": "G2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.82,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                            "sample document": {
+                                "sample identifier": "sample_H2",
+                                "location identifier": "H2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.94,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
+                            "sample document": {
+                                "sample identifier": "sample_A3",
+                                "location identifier": "A3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.66,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
+                            "sample document": {
+                                "sample identifier": "sample_B3",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.24,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -210,34 +780,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                             "sample document": {
-                                "sample identifier": "sample_D1",
-                                "location identifier": "D1",
+                                "sample identifier": "sample_C3",
+                                "location identifier": "C3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 4.85,
+                                "value": 4.93,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
+                            "sample document": {
+                                "sample identifier": "sample_D3",
+                                "location identifier": "D3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.4,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                            "sample document": {
+                                "sample identifier": "sample_E3",
+                                "location identifier": "E3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.05,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
+                            "sample document": {
+                                "sample identifier": "sample_F3",
+                                "location identifier": "F3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.92,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
+                            "sample document": {
+                                "sample identifier": "sample_G3",
+                                "location identifier": "G3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.14,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                            "sample document": {
+                                "sample identifier": "sample_H3",
+                                "location identifier": "H3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.98,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -272,34 +1032,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                             "sample document": {
-                                "sample identifier": "sample_E1",
-                                "location identifier": "E1",
+                                "sample identifier": "sample_A4",
+                                "location identifier": "A4",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 8.08,
+                                "value": 5.87,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                            "sample document": {
+                                "sample identifier": "sample_B4",
+                                "location identifier": "B4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.32,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
+                            "sample document": {
+                                "sample identifier": "sample_C4",
+                                "location identifier": "C4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.9,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
+                            "sample document": {
+                                "sample identifier": "sample_D4",
+                                "location identifier": "D4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.12,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
+                            "sample document": {
+                                "sample identifier": "sample_E4",
+                                "location identifier": "E4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.53,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
+                            "sample document": {
+                                "sample identifier": "sample_F4",
+                                "location identifier": "F4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.67,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -334,34 +1284,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
                             "sample document": {
-                                "sample identifier": "sample_F1",
-                                "location identifier": "F1",
+                                "sample identifier": "sample_G4",
+                                "location identifier": "G4",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.07,
+                                "value": 4.6,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
+                            "sample document": {
+                                "sample identifier": "sample_H4",
+                                "location identifier": "H4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.27,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
+                            "sample document": {
+                                "sample identifier": "sample_A5",
+                                "location identifier": "A5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 3.63,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
+                            "sample document": {
+                                "sample identifier": "sample_B5",
+                                "location identifier": "B5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.5,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
+                            "sample document": {
+                                "sample identifier": "sample_C5",
+                                "location identifier": "C5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.04,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                            "sample document": {
+                                "sample identifier": "sample_D5",
+                                "location identifier": "D5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.63,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -396,34 +1536,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
                             "sample document": {
-                                "sample identifier": "sample_G1",
-                                "location identifier": "G1",
+                                "sample identifier": "sample_E5",
+                                "location identifier": "E5",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.77,
+                                "value": 7.66,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
+                            "sample document": {
+                                "sample identifier": "sample_F5",
+                                "location identifier": "F5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.94,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                            "sample document": {
+                                "sample identifier": "sample_G5",
+                                "location identifier": "G5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.88,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
+                            "sample document": {
+                                "sample identifier": "sample_H5",
+                                "location identifier": "H5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.84,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                            "sample document": {
+                                "sample identifier": "sample_A6",
+                                "location identifier": "A6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.32,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
+                            "sample document": {
+                                "sample identifier": "sample_B6",
+                                "location identifier": "B6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.63,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -458,34 +1788,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                             "sample document": {
-                                "sample identifier": "sample_H1",
-                                "location identifier": "H1",
+                                "sample identifier": "sample_C6",
+                                "location identifier": "C6",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 7.82,
+                                "value": 5.12,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                            "sample document": {
+                                "sample identifier": "sample_D6",
+                                "location identifier": "D6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.79,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
+                            "sample document": {
+                                "sample identifier": "sample_E6",
+                                "location identifier": "E6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.81,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                            "sample document": {
+                                "sample identifier": "sample_F6",
+                                "location identifier": "F6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.52,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                            "sample document": {
+                                "sample identifier": "sample_G6",
+                                "location identifier": "G6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.5,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                            "sample document": {
+                                "sample identifier": "sample_H6",
+                                "location identifier": "H6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.73,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -520,34 +2040,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
                             "sample document": {
-                                "sample identifier": "sample_A2",
-                                "location identifier": "A2",
+                                "sample identifier": "sample_A7",
+                                "location identifier": "A7",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.18,
+                                "value": 6.38,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                            "sample document": {
+                                "sample identifier": "sample_B7",
+                                "location identifier": "B7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.09,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                            "sample document": {
+                                "sample identifier": "sample_C7",
+                                "location identifier": "C7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.25,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                            "sample document": {
+                                "sample identifier": "sample_D7",
+                                "location identifier": "D7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.8,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                            "sample document": {
+                                "sample identifier": "sample_E7",
+                                "location identifier": "E7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 7.55,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
+                            "sample document": {
+                                "sample identifier": "sample_F7",
+                                "location identifier": "F7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.11,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -582,34 +2292,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
                             "sample document": {
-                                "sample identifier": "sample_B2",
-                                "location identifier": "B2",
+                                "sample identifier": "sample_G7",
+                                "location identifier": "G7",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 1.24,
+                                "value": 5.12,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                            "sample document": {
+                                "sample identifier": "sample_H7",
+                                "location identifier": "H7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 7.24,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                            "sample document": {
+                                "sample identifier": "sample_A8",
+                                "location identifier": "A8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 1.82,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
+                            "sample document": {
+                                "sample identifier": "sample_B8",
+                                "location identifier": "B8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.16,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
+                            "sample document": {
+                                "sample identifier": "sample_C8",
+                                "location identifier": "C8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.25,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
+                            "sample document": {
+                                "sample identifier": "sample_D8",
+                                "location identifier": "D8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.4,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -644,34 +2544,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
                             "sample document": {
-                                "sample identifier": "sample_C2",
-                                "location identifier": "C2",
+                                "sample identifier": "sample_E8",
+                                "location identifier": "E8",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.1,
+                                "value": 2.25,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                            "sample document": {
+                                "sample identifier": "sample_F8",
+                                "location identifier": "F8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.61,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
+                            "sample document": {
+                                "sample identifier": "sample_G8",
+                                "location identifier": "G8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 1.7,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
+                            "sample document": {
+                                "sample identifier": "sample_H8",
+                                "location identifier": "H8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.55,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
+                            "sample document": {
+                                "sample identifier": "sample_A9",
+                                "location identifier": "A9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.3,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                            "sample document": {
+                                "sample identifier": "sample_B9",
+                                "location identifier": "B9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.48,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -706,3444 +2796,14 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
                             "sample document": {
-                                "sample identifier": "sample_D2",
-                                "location identifier": "D2",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.14,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                            "sample document": {
-                                "sample identifier": "sample_E2",
-                                "location identifier": "E2",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.5,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                            "sample document": {
-                                "sample identifier": "sample_F2",
-                                "location identifier": "F2",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.42,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                            "sample document": {
-                                "sample identifier": "sample_G2",
-                                "location identifier": "G2",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.82,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                            "sample document": {
-                                "sample identifier": "sample_H2",
-                                "location identifier": "H2",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.94,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                            "sample document": {
-                                "sample identifier": "sample_A3",
-                                "location identifier": "A3",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.66,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                            "sample document": {
-                                "sample identifier": "sample_B3",
-                                "location identifier": "B3",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.24,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                            "sample document": {
-                                "sample identifier": "sample_C3",
-                                "location identifier": "C3",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.93,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                            "sample document": {
-                                "sample identifier": "sample_D3",
-                                "location identifier": "D3",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.4,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                            "sample document": {
-                                "sample identifier": "sample_E3",
-                                "location identifier": "E3",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.05,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                            "sample document": {
-                                "sample identifier": "sample_F3",
-                                "location identifier": "F3",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.92,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                            "sample document": {
-                                "sample identifier": "sample_G3",
-                                "location identifier": "G3",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.14,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                            "sample document": {
-                                "sample identifier": "sample_H3",
-                                "location identifier": "H3",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.98,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                            "sample document": {
-                                "sample identifier": "sample_A4",
-                                "location identifier": "A4",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.87,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                            "sample document": {
-                                "sample identifier": "sample_B4",
-                                "location identifier": "B4",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.32,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                            "sample document": {
-                                "sample identifier": "sample_C4",
-                                "location identifier": "C4",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.9,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                            "sample document": {
-                                "sample identifier": "sample_D4",
-                                "location identifier": "D4",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.12,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                            "sample document": {
-                                "sample identifier": "sample_E4",
-                                "location identifier": "E4",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.53,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
-                            "sample document": {
-                                "sample identifier": "sample_F4",
-                                "location identifier": "F4",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.67,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
-                            "sample document": {
-                                "sample identifier": "sample_G4",
-                                "location identifier": "G4",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.6,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
-                            "sample document": {
-                                "sample identifier": "sample_H4",
-                                "location identifier": "H4",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.27,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_191"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
-                            "sample document": {
-                                "sample identifier": "sample_A5",
-                                "location identifier": "A5",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 3.63,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_197"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
-                            "sample document": {
-                                "sample identifier": "sample_B5",
-                                "location identifier": "B5",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.5,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_203"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
-                            "sample document": {
-                                "sample identifier": "sample_C5",
-                                "location identifier": "C5",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.04,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_209"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
-                            "sample document": {
-                                "sample identifier": "sample_D5",
-                                "location identifier": "D5",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.63,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
-                            "sample document": {
-                                "sample identifier": "sample_E5",
-                                "location identifier": "E5",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 7.66,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_221"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
-                            "sample document": {
-                                "sample identifier": "sample_F5",
-                                "location identifier": "F5",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.94,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_227"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
-                            "sample document": {
-                                "sample identifier": "sample_G5",
-                                "location identifier": "G5",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.88,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_233"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
-                            "sample document": {
-                                "sample identifier": "sample_H5",
-                                "location identifier": "H5",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.84,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_239"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
-                            "sample document": {
-                                "sample identifier": "sample_A6",
-                                "location identifier": "A6",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.32,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                            "sample document": {
-                                "sample identifier": "sample_B6",
-                                "location identifier": "B6",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.63,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_251"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
-                            "sample document": {
-                                "sample identifier": "sample_C6",
-                                "location identifier": "C6",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.12,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_257"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
-                            "sample document": {
-                                "sample identifier": "sample_D6",
-                                "location identifier": "D6",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.79,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_263"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
-                            "sample document": {
-                                "sample identifier": "sample_E6",
-                                "location identifier": "E6",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.81,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_269"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
-                            "sample document": {
-                                "sample identifier": "sample_F6",
-                                "location identifier": "F6",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.52,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
-                            "sample document": {
-                                "sample identifier": "sample_G6",
-                                "location identifier": "G6",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.5,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_281"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
-                            "sample document": {
-                                "sample identifier": "sample_H6",
-                                "location identifier": "H6",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.73,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_287"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
-                            "sample document": {
-                                "sample identifier": "sample_A7",
-                                "location identifier": "A7",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.38,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_293"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
-                            "sample document": {
-                                "sample identifier": "sample_B7",
-                                "location identifier": "B7",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.09,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_299"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
-                            "sample document": {
-                                "sample identifier": "sample_C7",
-                                "location identifier": "C7",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.25,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
-                            "sample document": {
-                                "sample identifier": "sample_D7",
-                                "location identifier": "D7",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.8,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_311"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
-                            "sample document": {
-                                "sample identifier": "sample_E7",
-                                "location identifier": "E7",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 7.55,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_317"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
-                            "sample document": {
-                                "sample identifier": "sample_F7",
-                                "location identifier": "F7",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.11,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_323"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
-                            "sample document": {
-                                "sample identifier": "sample_G7",
-                                "location identifier": "G7",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.12,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_329"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
-                            "sample document": {
-                                "sample identifier": "sample_H7",
-                                "location identifier": "H7",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 7.24,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
-                            "sample document": {
-                                "sample identifier": "sample_A8",
-                                "location identifier": "A8",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 1.82,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_341"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
-                            "sample document": {
-                                "sample identifier": "sample_B8",
-                                "location identifier": "B8",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.16,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_347"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
-                            "sample document": {
-                                "sample identifier": "sample_C8",
-                                "location identifier": "C8",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.25,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_353"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
-                            "sample document": {
-                                "sample identifier": "sample_D8",
-                                "location identifier": "D8",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.4,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_359"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
-                            "sample document": {
-                                "sample identifier": "sample_E8",
-                                "location identifier": "E8",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.25,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
-                            "sample document": {
-                                "sample identifier": "sample_F8",
-                                "location identifier": "F8",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.61,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_371"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
-                            "sample document": {
-                                "sample identifier": "sample_G8",
-                                "location identifier": "G8",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 1.7,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_377"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
-                            "sample document": {
-                                "sample identifier": "sample_H8",
-                                "location identifier": "H8",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.55,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_383"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
-                            "sample document": {
-                                "sample identifier": "sample_A9",
-                                "location identifier": "A9",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.3,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_389"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
-                            "sample document": {
-                                "sample identifier": "sample_B9",
-                                "location identifier": "B9",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.48,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
-                            "sample document": {
                                 "sample identifier": "sample_C9",
                                 "location identifier": "C9",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
                                 "value": 2.03,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_401"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -4176,36 +2836,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
                             "sample document": {
                                 "sample identifier": "sample_D9",
                                 "location identifier": "D9",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
                                 "value": 2.21,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_407"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -4238,36 +2878,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
                             "sample document": {
                                 "sample identifier": "sample_E9",
                                 "location identifier": "E9",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
                                 "value": 2.33,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_413"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -4300,36 +2920,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
                             "sample document": {
                                 "sample identifier": "sample_F9",
                                 "location identifier": "F9",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
                                 "value": 1.98,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_419"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -4362,36 +2962,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
                             "sample document": {
                                 "sample identifier": "sample_G9",
                                 "location identifier": "G9",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
                                 "value": 2.33,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -4424,36 +3004,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
                             "sample document": {
                                 "sample identifier": "sample_H9",
                                 "location identifier": "H9",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
                                 "value": 2.61,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_431"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -4467,4625 +3027,13 @@
                 "analyst": "admin"
             }
         ],
-        "calculated data aggregate document": {
-            "calculated data document": [
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 291.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.11,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.38,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 269.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.09,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 256.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 242.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 403.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.12,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 303.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 338.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.33,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 390.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.02,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.36,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 259.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 61.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 305.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.09,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 207.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.38,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 224.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.17,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.35,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 220.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.21,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 341.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.15,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.38,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 347.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.2,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.37,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 233.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.35,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 262.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.11,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 246.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.08,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.37,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 319.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.15,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 302.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.15,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 296.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 307.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.03,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 348.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.34,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 293.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.23,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.33,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 266.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.22,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_152",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_153",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_154",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 244.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.21,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.36,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 305.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 226.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 233.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 230.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_181",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.17,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_182",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.38,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_183",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.88,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_184",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 313.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_187",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.25,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_188",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.38,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_189",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 181.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_193",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_194",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.29,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_196",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 225.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_199",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.2,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_201",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.88,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_202",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 302.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_206",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_207",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_208",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 281.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_211",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.2,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_212",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.37,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_213",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_214",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 383.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_217",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.2,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_218",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_219",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 247.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_223",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.15,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_224",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.45,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_226",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 244.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_229",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.23,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_231",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_232",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 242.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_236",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.36,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_237",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_238",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 215.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_241",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.24,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_242",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.38,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_243",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.88,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_244",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 281.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_247",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.21,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_248",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_249",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 255.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_253",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_254",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.31,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_256",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 339.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_259",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_261",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_262",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 290.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.22,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_266",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_267",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_268",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 275.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_271",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_272",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.38,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_273",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_274",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 274.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_277",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_278",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_279",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 336.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_283",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.28,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_284",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.36,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_286",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 318.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_289",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.37,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_291",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_292",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 254.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.04,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_296",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_297",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_298",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 312.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_301",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.15,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_302",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_303",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_304",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 289.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_307",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_308",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_309",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 377.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_313",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.2,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_314",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_316",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 255.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_319",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.17,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_321",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_322",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 255.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.25,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_326",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_327",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_328",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 362.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_331",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.02,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_332",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.37,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_333",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_334",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 90.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_337",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_338",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.34,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_339",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 107.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_343",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_344",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_346",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 112.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_349",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.21,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.57,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_351",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_352",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 119.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_356",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_357",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_358",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 112.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_361",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_362",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_363",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_364",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 130.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_367",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_368",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_369",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 84.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_373",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.2,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_374",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.73,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.88,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_376",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 127.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_379",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_381",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_382",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 115.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.17,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_386",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_387",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_388",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 123.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_391",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_392",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.46,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_393",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_394",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 101.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_397",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_398",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_399",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 110.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_403",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.25,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_404",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_406",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 116.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_409",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.54,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_411",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_412",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 98.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_416",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.31,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_417",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_418",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 116.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_421",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_422",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.38,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_423",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_424",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 130.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_427",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_428",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_429",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
         "data system document": {
             "ASM file identifier": "2024-07-12_CW288_Plate1.json",
             "data system instance identifier": "N/A",
             "file name": "2024-07-12_CW288_Plate1.xlsx",
             "UNC path": "tests/parsers/unchained_labs_lunatic/testdata/2024-07-12_CW288_Plate1.xlsx",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.69",
+            "ASM converter version": "0.1.74",
             "software name": "Lunatic and Stunner Analysis",
             "software version": "6.0.0.99"
         },

--- a/tests/parsers/unchained_labs_lunatic/testdata/2024-07-12_CW288_Plate1.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/2024-07-12_CW288_Plate1.json
@@ -40,6 +40,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -72,7 +85,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                             "sample document": {
                                 "sample identifier": "sample_B1",
                                 "location identifier": "B1",
@@ -90,6 +103,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -122,7 +148,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                             "sample document": {
                                 "sample identifier": "sample_C1",
                                 "location identifier": "C1",
@@ -140,6 +166,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -172,7 +211,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                             "sample document": {
                                 "sample identifier": "sample_D1",
                                 "location identifier": "D1",
@@ -190,6 +229,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -222,7 +274,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                             "sample document": {
                                 "sample identifier": "sample_E1",
                                 "location identifier": "E1",
@@ -240,54 +292,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                            "sample document": {
-                                "sample identifier": "sample_F1",
-                                "location identifier": "F1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.07,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29"
                                     }
                                 ]
                             }
@@ -324,13 +339,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
                             "sample document": {
-                                "sample identifier": "sample_G1",
-                                "location identifier": "G1",
+                                "sample identifier": "sample_F1",
+                                "location identifier": "F1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.77,
+                                "value": 6.07,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -338,6 +353,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35"
                                     }
                                 ]
                             }
@@ -372,7 +400,70 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
+                            "sample document": {
+                                "sample identifier": "sample_G1",
+                                "location identifier": "G1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.77,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                             "sample document": {
                                 "sample identifier": "sample_H1",
                                 "location identifier": "H1",
@@ -390,6 +481,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -422,7 +526,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
                             "sample document": {
                                 "sample identifier": "sample_A2",
                                 "location identifier": "A2",
@@ -440,6 +544,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -472,7 +589,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
                             "sample document": {
                                 "sample identifier": "sample_B2",
                                 "location identifier": "B2",
@@ -490,104 +607,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                            "sample document": {
-                                "sample identifier": "sample_C2",
-                                "location identifier": "C2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.1,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                            "sample document": {
-                                "sample identifier": "sample_D2",
-                                "location identifier": "D2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.14,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59"
                                     }
                                 ]
                             }
@@ -624,13 +654,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
                             "sample document": {
-                                "sample identifier": "sample_E2",
-                                "location identifier": "E2",
+                                "sample identifier": "sample_C2",
+                                "location identifier": "C2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 4.5,
+                                "value": 6.1,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -638,6 +668,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65"
                                     }
                                 ]
                             }
@@ -672,7 +715,133 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                            "sample document": {
+                                "sample identifier": "sample_D2",
+                                "location identifier": "D2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.14,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                            "sample document": {
+                                "sample identifier": "sample_E2",
+                                "location identifier": "E2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.5,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                             "sample document": {
                                 "sample identifier": "sample_F2",
                                 "location identifier": "F2",
@@ -690,6 +859,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -722,7 +904,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
                             "sample document": {
                                 "sample identifier": "sample_G2",
                                 "location identifier": "G2",
@@ -740,154 +922,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                            "sample document": {
-                                "sample identifier": "sample_H2",
-                                "location identifier": "H2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.94,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                            "sample document": {
-                                "sample identifier": "sample_A3",
-                                "location identifier": "A3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.66,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
-                            "sample document": {
-                                "sample identifier": "sample_B3",
-                                "location identifier": "B3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.24,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89"
                                     }
                                 ]
                             }
@@ -924,13 +969,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
                             "sample document": {
-                                "sample identifier": "sample_C3",
-                                "location identifier": "C3",
+                                "sample identifier": "sample_H2",
+                                "location identifier": "H2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 4.93,
+                                "value": 6.94,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -938,6 +983,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95"
                                     }
                                 ]
                             }
@@ -972,7 +1030,196 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
+                            "sample document": {
+                                "sample identifier": "sample_A3",
+                                "location identifier": "A3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.66,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                            "sample document": {
+                                "sample identifier": "sample_B3",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.24,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                            "sample document": {
+                                "sample identifier": "sample_C3",
+                                "location identifier": "C3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.93,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
                             "sample document": {
                                 "sample identifier": "sample_D3",
                                 "location identifier": "D3",
@@ -990,204 +1237,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                            "sample document": {
-                                "sample identifier": "sample_E3",
-                                "location identifier": "E3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.05,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
-                            "sample document": {
-                                "sample identifier": "sample_F3",
-                                "location identifier": "F3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.92,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                            "sample document": {
-                                "sample identifier": "sample_G3",
-                                "location identifier": "G3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.14,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
-                            "sample document": {
-                                "sample identifier": "sample_H3",
-                                "location identifier": "H3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.98,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119"
                                     }
                                 ]
                             }
@@ -1224,6 +1284,258 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
                             "sample document": {
+                                "sample identifier": "sample_E3",
+                                "location identifier": "E3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.05,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                            "sample document": {
+                                "sample identifier": "sample_F3",
+                                "location identifier": "F3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.92,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
+                            "sample document": {
+                                "sample identifier": "sample_G3",
+                                "location identifier": "G3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.14,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                            "sample document": {
+                                "sample identifier": "sample_H3",
+                                "location identifier": "H3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.98,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                            "sample document": {
                                 "sample identifier": "sample_A4",
                                 "location identifier": "A4",
                                 "batch identifier": "Sample Group",
@@ -1240,254 +1552,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
-                            "sample document": {
-                                "sample identifier": "sample_B4",
-                                "location identifier": "B4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.32,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
-                            "sample document": {
-                                "sample identifier": "sample_C4",
-                                "location identifier": "C4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.9,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
-                            "sample document": {
-                                "sample identifier": "sample_D4",
-                                "location identifier": "D4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.12,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
-                            "sample document": {
-                                "sample identifier": "sample_E4",
-                                "location identifier": "E4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.53,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
-                            "sample document": {
-                                "sample identifier": "sample_F4",
-                                "location identifier": "F4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.67,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149"
                                     }
                                 ]
                             }
@@ -1524,13 +1599,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
                             "sample document": {
-                                "sample identifier": "sample_G4",
-                                "location identifier": "G4",
+                                "sample identifier": "sample_B4",
+                                "location identifier": "B4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 4.6,
+                                "value": 5.32,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1538,6 +1613,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155"
                                     }
                                 ]
                             }
@@ -1572,15 +1660,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
                             "sample document": {
-                                "sample identifier": "sample_H4",
-                                "location identifier": "H4",
+                                "sample identifier": "sample_C4",
+                                "location identifier": "C4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.27,
+                                "value": 4.9,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1588,6 +1676,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161"
                                     }
                                 ]
                             }
@@ -1622,15 +1723,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
                             "sample document": {
-                                "sample identifier": "sample_A5",
-                                "location identifier": "A5",
+                                "sample identifier": "sample_D4",
+                                "location identifier": "D4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 3.63,
+                                "value": 6.12,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1638,6 +1739,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167"
                                     }
                                 ]
                             }
@@ -1672,15 +1786,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
                             "sample document": {
-                                "sample identifier": "sample_B5",
-                                "location identifier": "B5",
+                                "sample identifier": "sample_E4",
+                                "location identifier": "E4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 4.5,
+                                "value": 4.53,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1688,6 +1802,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173"
                                     }
                                 ]
                             }
@@ -1722,15 +1849,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
                             "sample document": {
-                                "sample identifier": "sample_C5",
-                                "location identifier": "C5",
+                                "sample identifier": "sample_F4",
+                                "location identifier": "F4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.04,
+                                "value": 4.67,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1740,54 +1867,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
-                            "sample document": {
-                                "sample identifier": "sample_D5",
-                                "location identifier": "D5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.63,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179"
                                     }
                                 ]
                             }
@@ -1824,13 +1914,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
                             "sample document": {
-                                "sample identifier": "sample_E5",
-                                "location identifier": "E5",
+                                "sample identifier": "sample_G4",
+                                "location identifier": "G4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 7.66,
+                                "value": 4.6,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1838,6 +1928,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185"
                                     }
                                 ]
                             }
@@ -1872,15 +1975,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
                             "sample document": {
-                                "sample identifier": "sample_F5",
-                                "location identifier": "F5",
+                                "sample identifier": "sample_H4",
+                                "location identifier": "H4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 4.94,
+                                "value": 6.27,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1888,6 +1991,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_191"
                                     }
                                 ]
                             }
@@ -1922,15 +2038,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
                             "sample document": {
-                                "sample identifier": "sample_G5",
-                                "location identifier": "G5",
+                                "sample identifier": "sample_A5",
+                                "location identifier": "A5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 4.88,
+                                "value": 3.63,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1938,6 +2054,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_197"
                                     }
                                 ]
                             }
@@ -1972,15 +2101,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
                             "sample document": {
-                                "sample identifier": "sample_H5",
-                                "location identifier": "H5",
+                                "sample identifier": "sample_B5",
+                                "location identifier": "B5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 4.84,
+                                "value": 4.5,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1988,6 +2117,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_203"
                                     }
                                 ]
                             }
@@ -2022,15 +2164,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
                             "sample document": {
-                                "sample identifier": "sample_A6",
-                                "location identifier": "A6",
+                                "sample identifier": "sample_C5",
+                                "location identifier": "C5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 4.32,
+                                "value": 6.04,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2040,54 +2182,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
-                            "sample document": {
-                                "sample identifier": "sample_B6",
-                                "location identifier": "B6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.63,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_209"
                                     }
                                 ]
                             }
@@ -2124,13 +2229,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
                             "sample document": {
-                                "sample identifier": "sample_C6",
-                                "location identifier": "C6",
+                                "sample identifier": "sample_D5",
+                                "location identifier": "D5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.12,
+                                "value": 5.63,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2138,6 +2243,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215"
                                     }
                                 ]
                             }
@@ -2172,15 +2290,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
                             "sample document": {
-                                "sample identifier": "sample_D6",
-                                "location identifier": "D6",
+                                "sample identifier": "sample_E5",
+                                "location identifier": "E5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.79,
+                                "value": 7.66,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2188,6 +2306,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_221"
                                     }
                                 ]
                             }
@@ -2222,15 +2353,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
                             "sample document": {
-                                "sample identifier": "sample_E6",
-                                "location identifier": "E6",
+                                "sample identifier": "sample_F5",
+                                "location identifier": "F5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.81,
+                                "value": 4.94,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2238,6 +2369,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_227"
                                     }
                                 ]
                             }
@@ -2272,15 +2416,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
                             "sample document": {
-                                "sample identifier": "sample_F6",
-                                "location identifier": "F6",
+                                "sample identifier": "sample_G5",
+                                "location identifier": "G5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.52,
+                                "value": 4.88,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2288,6 +2432,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_233"
                                     }
                                 ]
                             }
@@ -2322,15 +2479,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
                             "sample document": {
-                                "sample identifier": "sample_G6",
-                                "location identifier": "G6",
+                                "sample identifier": "sample_H5",
+                                "location identifier": "H5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.5,
+                                "value": 4.84,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2340,54 +2497,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
-                            "sample document": {
-                                "sample identifier": "sample_H6",
-                                "location identifier": "H6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.73,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_239"
                                     }
                                 ]
                             }
@@ -2424,13 +2544,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
                             "sample document": {
-                                "sample identifier": "sample_A7",
-                                "location identifier": "A7",
+                                "sample identifier": "sample_A6",
+                                "location identifier": "A6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.38,
+                                "value": 4.32,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2438,6 +2558,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245"
                                     }
                                 ]
                             }
@@ -2472,15 +2605,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
                             "sample document": {
-                                "sample identifier": "sample_B7",
-                                "location identifier": "B7",
+                                "sample identifier": "sample_B6",
+                                "location identifier": "B6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.09,
+                                "value": 5.63,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2488,6 +2621,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_251"
                                     }
                                 ]
                             }
@@ -2522,15 +2668,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
                             "sample document": {
-                                "sample identifier": "sample_C7",
-                                "location identifier": "C7",
+                                "sample identifier": "sample_C6",
+                                "location identifier": "C6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.25,
+                                "value": 5.12,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2538,6 +2684,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_257"
                                     }
                                 ]
                             }
@@ -2572,15 +2731,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
                             "sample document": {
-                                "sample identifier": "sample_D7",
-                                "location identifier": "D7",
+                                "sample identifier": "sample_D6",
+                                "location identifier": "D6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.8,
+                                "value": 6.79,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2588,6 +2747,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_263"
                                     }
                                 ]
                             }
@@ -2622,15 +2794,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
                             "sample document": {
-                                "sample identifier": "sample_E7",
-                                "location identifier": "E7",
+                                "sample identifier": "sample_E6",
+                                "location identifier": "E6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 7.55,
+                                "value": 5.81,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2640,54 +2812,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
-                            "sample document": {
-                                "sample identifier": "sample_F7",
-                                "location identifier": "F7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.11,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_269"
                                     }
                                 ]
                             }
@@ -2724,13 +2859,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
                             "sample document": {
-                                "sample identifier": "sample_G7",
-                                "location identifier": "G7",
+                                "sample identifier": "sample_F6",
+                                "location identifier": "F6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.12,
+                                "value": 5.52,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2738,6 +2873,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275"
                                     }
                                 ]
                             }
@@ -2772,15 +2920,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
                             "sample document": {
-                                "sample identifier": "sample_H7",
-                                "location identifier": "H7",
+                                "sample identifier": "sample_G6",
+                                "location identifier": "G6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 7.24,
+                                "value": 5.5,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2788,6 +2936,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_281"
                                     }
                                 ]
                             }
@@ -2822,15 +2983,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
                             "sample document": {
-                                "sample identifier": "sample_A8",
-                                "location identifier": "A8",
+                                "sample identifier": "sample_H6",
+                                "location identifier": "H6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 1.82,
+                                "value": 6.73,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2838,6 +2999,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_287"
                                     }
                                 ]
                             }
@@ -2872,15 +3046,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
                             "sample document": {
-                                "sample identifier": "sample_B8",
-                                "location identifier": "B8",
+                                "sample identifier": "sample_A7",
+                                "location identifier": "A7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 2.16,
+                                "value": 6.38,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2888,6 +3062,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_293"
                                     }
                                 ]
                             }
@@ -2922,15 +3109,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
                             "sample document": {
-                                "sample identifier": "sample_C8",
-                                "location identifier": "C8",
+                                "sample identifier": "sample_B7",
+                                "location identifier": "B7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 2.25,
+                                "value": 5.09,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2940,54 +3127,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
-                            "sample document": {
-                                "sample identifier": "sample_D8",
-                                "location identifier": "D8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.4,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_299"
                                     }
                                 ]
                             }
@@ -3024,13 +3174,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
                             "sample document": {
-                                "sample identifier": "sample_E8",
-                                "location identifier": "E8",
+                                "sample identifier": "sample_C7",
+                                "location identifier": "C7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 2.25,
+                                "value": 6.25,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3038,6 +3188,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305"
                                     }
                                 ]
                             }
@@ -3072,15 +3235,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
                             "sample document": {
-                                "sample identifier": "sample_F8",
-                                "location identifier": "F8",
+                                "sample identifier": "sample_D7",
+                                "location identifier": "D7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 2.61,
+                                "value": 5.8,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3088,6 +3251,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_311"
                                     }
                                 ]
                             }
@@ -3122,15 +3298,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
                             "sample document": {
-                                "sample identifier": "sample_G8",
-                                "location identifier": "G8",
+                                "sample identifier": "sample_E7",
+                                "location identifier": "E7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 1.7,
+                                "value": 7.55,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3138,6 +3314,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_317"
                                     }
                                 ]
                             }
@@ -3172,15 +3361,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
                             "sample document": {
-                                "sample identifier": "sample_H8",
-                                "location identifier": "H8",
+                                "sample identifier": "sample_F7",
+                                "location identifier": "F7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 2.55,
+                                "value": 5.11,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3188,6 +3377,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_323"
                                     }
                                 ]
                             }
@@ -3222,15 +3424,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
                             "sample document": {
-                                "sample identifier": "sample_A9",
-                                "location identifier": "A9",
+                                "sample identifier": "sample_G7",
+                                "location identifier": "G7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 2.3,
+                                "value": 5.12,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3240,54 +3442,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
-                            "sample document": {
-                                "sample identifier": "sample_B9",
-                                "location identifier": "B9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.48,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_329"
                                     }
                                 ]
                             }
@@ -3324,13 +3489,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
                             "sample document": {
-                                "sample identifier": "sample_C9",
-                                "location identifier": "C9",
+                                "sample identifier": "sample_H7",
+                                "location identifier": "H7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 2.03,
+                                "value": 7.24,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3338,6 +3503,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335"
                                     }
                                 ]
                             }
@@ -3372,7 +3550,700 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
+                            "sample document": {
+                                "sample identifier": "sample_A8",
+                                "location identifier": "A8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 1.82,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_341"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
+                            "sample document": {
+                                "sample identifier": "sample_B8",
+                                "location identifier": "B8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.16,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_347"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                            "sample document": {
+                                "sample identifier": "sample_C8",
+                                "location identifier": "C8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.25,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_353"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
+                            "sample document": {
+                                "sample identifier": "sample_D8",
+                                "location identifier": "D8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.4,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_359"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
+                            "sample document": {
+                                "sample identifier": "sample_E8",
+                                "location identifier": "E8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.25,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
+                            "sample document": {
+                                "sample identifier": "sample_F8",
+                                "location identifier": "F8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.61,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_371"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
+                            "sample document": {
+                                "sample identifier": "sample_G8",
+                                "location identifier": "G8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 1.7,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_377"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
+                            "sample document": {
+                                "sample identifier": "sample_H8",
+                                "location identifier": "H8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.55,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_383"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
+                            "sample document": {
+                                "sample identifier": "sample_A9",
+                                "location identifier": "A9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.3,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_389"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
+                            "sample document": {
+                                "sample identifier": "sample_B9",
+                                "location identifier": "B9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.48,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
+                            "sample document": {
+                                "sample identifier": "sample_C9",
+                                "location identifier": "C9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.03,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_401"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
                             "sample document": {
                                 "sample identifier": "sample_D9",
                                 "location identifier": "D9",
@@ -3390,6 +4261,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_407"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -3422,7 +4306,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
                             "sample document": {
                                 "sample identifier": "sample_E9",
                                 "location identifier": "E9",
@@ -3440,6 +4324,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_413"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -3472,7 +4369,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
                             "sample document": {
                                 "sample identifier": "sample_F9",
                                 "location identifier": "F9",
@@ -3490,6 +4387,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_419"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -3522,7 +4432,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
                             "sample document": {
                                 "sample identifier": "sample_G9",
                                 "location identifier": "G9",
@@ -3540,6 +4450,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -3572,7 +4495,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
                             "sample document": {
                                 "sample identifier": "sample_H9",
                                 "location identifier": "H9",
@@ -3588,6 +4511,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_431"
                                     }
                                 ]
                             }
@@ -3675,11 +4611,11 @@
                         "value": 269.1,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3691,11 +4627,11 @@
                         "value": 0.09,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3707,11 +4643,11 @@
                         "value": 2.39,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3723,11 +4659,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3739,11 +4675,11 @@
                         "value": 256.5,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3755,11 +4691,11 @@
                         "value": 0.19,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3771,11 +4707,11 @@
                         "value": 2.4,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3787,11 +4723,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3803,11 +4739,11 @@
                         "value": 242.3,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3819,11 +4755,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3835,11 +4771,11 @@
                         "value": 2.4,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3851,11 +4787,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3867,11 +4803,11 @@
                         "value": 403.9,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3883,11 +4819,11 @@
                         "value": 0.12,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3899,11 +4835,11 @@
                         "value": 2.39,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3915,11 +4851,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3929,70 +4865,6 @@
                     "calculated data name": "Concentration",
                     "calculated result": {
                         "value": 303.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 338.7,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
@@ -4008,7 +4880,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.16,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
@@ -4024,7 +4896,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.33,
+                        "value": 2.39,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
@@ -4040,7 +4912,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.91,
+                        "value": 1.89,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
@@ -4056,142 +4928,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 390.9,
+                        "value": 338.7,
                         "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.02,
-                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.36,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 259.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 61.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4203,11 +4947,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4216,14 +4960,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.41,
+                        "value": 2.33,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4235,11 +4979,11 @@
                         "value": 1.91,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4248,14 +4992,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 305.0,
+                        "value": 390.9,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4264,14 +5008,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.09,
+                        "value": 0.02,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4280,78 +5024,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.39,
+                        "value": 2.36,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 207.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.38,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4363,11 +5043,11 @@
                         "value": 1.9,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4376,7 +5056,135 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 224.9,
+                        "value": 259.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 61.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 305.0,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
@@ -4392,7 +5200,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.17,
+                        "value": 0.09,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
@@ -4408,7 +5216,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.35,
+                        "value": 2.39,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
@@ -4440,78 +5248,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 220.8,
+                        "value": 207.0,
                         "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.21,
-                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 341.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4520,14 +5264,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.15,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4539,11 +5283,11 @@
                         "value": 2.38,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4552,110 +5296,46 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.89,
+                        "value": 1.9,
                         "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 224.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.17,
+                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 347.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.2,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.37,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 233.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4667,11 +5347,11 @@
                         "value": 2.35,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4683,11 +5363,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4696,14 +5376,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 262.0,
+                        "value": 220.8,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4712,14 +5392,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.11,
+                        "value": 0.21,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4728,14 +5408,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.42,
+                        "value": 2.43,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4747,11 +5427,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4760,7 +5440,71 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 246.6,
+                        "value": 341.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.38,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 347.1,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
@@ -4776,7 +5520,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.08,
+                        "value": 0.2,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
@@ -4824,14 +5568,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 319.8,
+                        "value": 233.1,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4840,14 +5584,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.15,
+                        "value": 0.18,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4856,14 +5600,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.39,
+                        "value": 2.35,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4875,11 +5619,203 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 262.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.11,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 246.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.08,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.37,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 319.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4889,262 +5825,6 @@
                     "calculated data name": "Concentration",
                     "calculated result": {
                         "value": 302.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.15,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 296.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 307.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.03,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 348.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.34,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 293.6,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
@@ -5160,7 +5840,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.23,
+                        "value": 0.15,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
@@ -5176,7 +5856,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.33,
+                        "value": 2.39,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
@@ -5192,7 +5872,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.9,
+                        "value": 1.89,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
@@ -5208,14 +5888,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 266.0,
+                        "value": 296.1,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5224,14 +5904,78 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.22,
+                        "value": 0.16,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 307.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.03,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5243,11 +5987,11 @@
                         "value": 2.39,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5258,92 +6002,28 @@
                     "calculated result": {
                         "value": 1.89,
                         "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 244.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.21,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.36,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 305.8,
-                        "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 348.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5355,11 +6035,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5368,14 +6048,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.39,
+                        "value": 2.34,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5387,11 +6067,11 @@
                         "value": 1.9,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5400,14 +6080,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 226.6,
+                        "value": 293.6,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5416,14 +6096,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.23,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5432,14 +6112,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.41,
+                        "value": 2.33,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5448,78 +6128,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 233.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
+                        "value": 1.9,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5528,7 +6144,7 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 230.0,
+                        "value": 266.0,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
@@ -5544,7 +6160,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.17,
+                        "value": 0.22,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_152",
@@ -5560,7 +6176,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.38,
+                        "value": 2.39,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_153",
@@ -5576,7 +6192,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.88,
+                        "value": 1.89,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_154",
@@ -5592,14 +6208,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 313.4,
+                        "value": 244.8,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5608,14 +6224,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.25,
+                        "value": 0.21,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5624,14 +6240,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.38,
+                        "value": 2.36,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5643,11 +6259,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5656,14 +6272,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 181.4,
+                        "value": 305.8,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5675,75 +6291,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.29,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 225.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.2,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5755,11 +6307,11 @@
                         "value": 2.39,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5768,14 +6320,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.88,
+                        "value": 1.9,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5784,14 +6336,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 302.1,
+                        "value": 226.6,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5800,14 +6352,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.16,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5819,11 +6371,11 @@
                         "value": 2.41,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5835,11 +6387,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5848,14 +6400,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 281.5,
+                        "value": 233.4,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5864,14 +6416,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.2,
+                        "value": 0.19,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5880,14 +6432,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.37,
+                        "value": 2.43,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5899,11 +6451,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5912,7 +6464,7 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 383.0,
+                        "value": 230.0,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_181",
@@ -5928,7 +6480,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.2,
+                        "value": 0.17,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_182",
@@ -5944,7 +6496,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.39,
+                        "value": 2.38,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_183",
@@ -5960,7 +6512,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.89,
+                        "value": 1.88,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_184",
@@ -5976,222 +6528,30 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 247.1,
+                        "value": 313.4,
                         "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.15,
-                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_187",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
                                 "data source feature": "absorbance"
                             }
                         ]
                     }
                 },
                 {
-                    "calculated data name": "A260/A230",
+                    "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 2.45,
-                        "unit": "(unitless)"
+                        "value": 0.25,
+                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_188",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_189",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 244.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_191",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.23,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_193",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_194",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 242.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_196",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_197",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.36,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_199",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 215.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_201",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.24,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_202",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6203,75 +6563,11 @@
                         "value": 2.38,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_203",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_189",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.88,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 281.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_206",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.21,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_207",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_208",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6283,11 +6579,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_209",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6296,7 +6592,199 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 255.9,
+                        "value": 181.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_193",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_194",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.29,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_196",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 225.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_199",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.2,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_201",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_202",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 302.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_206",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_207",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_208",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 281.5,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_211",
@@ -6312,7 +6800,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.2,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_212",
@@ -6328,7 +6816,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.31,
+                        "value": 2.37,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_213",
@@ -6344,7 +6832,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.9,
+                        "value": 1.89,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_214",
@@ -6360,222 +6848,30 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 339.5,
+                        "value": 383.0,
                         "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_217",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
                                 "data source feature": "absorbance"
                             }
                         ]
                     }
                 },
                 {
-                    "calculated data name": "A260/A230",
+                    "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
+                        "value": 0.2,
+                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_218",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_219",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 290.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_221",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.22,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_223",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_224",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 275.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_226",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_227",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.38,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_229",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 274.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_231",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_232",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6587,75 +6883,11 @@
                         "value": 2.39,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_233",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_219",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 336.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_236",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.28,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_237",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.36,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_238",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6667,11 +6899,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_239",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6680,7 +6912,199 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 318.9,
+                        "value": 247.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_223",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_224",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.45,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_226",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 244.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_229",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.23,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_231",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_232",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 242.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_236",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.36,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_237",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_238",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 215.8,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_241",
@@ -6696,7 +7120,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.24,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_242",
@@ -6712,7 +7136,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.37,
+                        "value": 2.38,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_243",
@@ -6728,7 +7152,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.9,
+                        "value": 1.88,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_244",
@@ -6744,14 +7168,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 254.4,
+                        "value": 281.5,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_247",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6760,14 +7184,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.04,
+                        "value": 0.21,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_247",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_248",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6776,78 +7200,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_248",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
+                        "value": 2.41,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_249",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 312.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_251",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.15,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_253",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6859,203 +7219,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_254",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 289.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_256",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_257",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_259",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 377.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_261",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.2,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_262",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_263",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 255.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_266",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.17,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_267",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_268",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_269",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7065,6 +7233,198 @@
                     "calculated data name": "Concentration",
                     "calculated result": {
                         "value": 255.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_253",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_254",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.31,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_256",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 339.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_259",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_261",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_262",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 290.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.22,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_266",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_267",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_268",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 275.8,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_271",
@@ -7080,7 +7440,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.25,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_272",
@@ -7096,7 +7456,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.41,
+                        "value": 2.38,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_273",
@@ -7112,7 +7472,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.89,
+                        "value": 1.9,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_274",
@@ -7128,14 +7488,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 362.2,
+                        "value": 274.8,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_277",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7144,14 +7504,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.02,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_277",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_278",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7160,14 +7520,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.37,
+                        "value": 2.39,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_278",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_279",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7179,11 +7539,11 @@
                         "value": 1.9,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_279",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7192,206 +7552,78 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 90.8,
+                        "value": 336.7,
                         "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_281",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.34,
-                        "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_283",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
                                 "data source feature": "absorbance"
                             }
                         ]
                     }
                 },
                 {
-                    "calculated data name": "A260/A280",
+                    "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
+                        "value": 0.28,
+                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_284",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
                                 "data source feature": "absorbance"
                             }
                         ]
                     }
                 },
                 {
-                    "calculated data name": "Concentration",
+                    "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 107.8,
-                        "unit": "ng/µL"
+                        "value": 2.36,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_286",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
                                 "data source feature": "absorbance"
                             }
                         ]
                     }
                 },
                 {
-                    "calculated data name": "Background (A260)",
+                    "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_287",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
+                        "value": 318.9,
+                        "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_289",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 112.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_291",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.21,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_292",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.57,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_293",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 119.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_296",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7403,11 +7635,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_297",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7416,30 +7648,94 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.44,
+                        "value": 2.37,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_291",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_292",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 254.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.04,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_296",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_297",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_298",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_299",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7448,7 +7744,7 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 112.7,
+                        "value": 312.3,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_301",
@@ -7464,7 +7760,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.15,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_302",
@@ -7480,7 +7776,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.41,
+                        "value": 2.43,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_303",
@@ -7496,7 +7792,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.9,
+                        "value": 1.89,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_304",
@@ -7512,14 +7808,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 130.5,
+                        "value": 289.9,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_307",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7528,14 +7824,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.19,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_307",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_308",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7544,14 +7840,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.42,
+                        "value": 2.39,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_308",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_309",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7560,14 +7856,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.9,
+                        "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_309",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7576,14 +7872,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 84.8,
+                        "value": 377.3,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_311",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_313",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7595,11 +7891,11 @@
                         "value": 0.2,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_314",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7608,14 +7904,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.73,
+                        "value": 2.4,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_313",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7624,78 +7920,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.88,
+                        "value": 1.89,
                         "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_314",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 127.7,
-                        "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_316",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_317",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_319",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7704,14 +7936,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 115.1,
+                        "value": 255.4,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_321",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_319",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7723,11 +7955,11 @@
                         "value": 0.17,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_322",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7736,14 +7968,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.41,
+                        "value": 2.44,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_323",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_321",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7755,11 +7987,11 @@
                         "value": 1.9,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_322",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7768,14 +8000,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 123.9,
+                        "value": 255.9,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_326",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7784,14 +8016,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.25,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_327",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_326",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7800,14 +8032,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.46,
+                        "value": 2.41,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_328",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_327",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7816,14 +8048,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.91,
+                        "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_329",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_328",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7832,7 +8064,7 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 101.4,
+                        "value": 362.2,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_331",
@@ -7848,7 +8080,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.02,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_332",
@@ -7864,7 +8096,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.44,
+                        "value": 2.37,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_333",
@@ -7880,7 +8112,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.91,
+                        "value": 1.9,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_334",
@@ -7896,142 +8128,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 110.7,
+                        "value": 90.8,
                         "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.25,
-                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_337",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_338",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_339",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 116.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_341",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.54,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_343",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_344",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 98.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_346",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8043,11 +8147,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_347",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_338",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8056,14 +8160,270 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.31,
+                        "value": 2.34,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_339",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 107.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_343",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_344",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_346",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 112.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_349",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.21,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.57,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_351",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_352",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 119.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_356",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_357",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_358",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 112.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_361",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_362",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_363",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8075,11 +8435,11 @@
                         "value": 1.9,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_349",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_364",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8088,14 +8448,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 116.5,
+                        "value": 130.5,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_351",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_367",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8107,75 +8467,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_352",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_368",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.38,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_353",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 130.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_356",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_357",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8187,11 +8483,139 @@
                         "value": 2.42,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_358",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_369",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 84.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_373",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.2,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_374",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.73,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_376",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 127.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_379",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_381",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8203,11 +8627,523 @@
                         "value": 1.91,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_359",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_382",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 115.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.17,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_386",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_387",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_388",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 123.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_391",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_392",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.46,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_393",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_394",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 101.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_397",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_398",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_399",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 110.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_403",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.25,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_404",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.52,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_406",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 116.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_409",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.54,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_411",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_412",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 98.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_416",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.31,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_417",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_418",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 116.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_421",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_422",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.38,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_423",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_424",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 130.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_427",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_428",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_429",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
                                 "data source feature": "absorbance"
                             }
                         ]

--- a/tests/parsers/unchained_labs_lunatic/testdata/2024-07-12_CW288_Plate1.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/2024-07-12_CW288_Plate1.json
@@ -32,174 +32,14 @@
                             "absorbance": {
                                 "value": 5.83,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                            "sample document": {
-                                "sample identifier": "sample_B1",
-                                "location identifier": "B1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.38,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                            "sample document": {
-                                "sample identifier": "sample_C1",
-                                "location identifier": "C1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.13,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
-                            "sample document": {
-                                "sample identifier": "sample_D1",
-                                "location identifier": "D1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.85,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                            "sample document": {
-                                "sample identifier": "sample_E1",
-                                "location identifier": "E1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 8.08,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -234,182 +74,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
                             "sample document": {
-                                "sample identifier": "sample_F1",
-                                "location identifier": "F1",
+                                "sample identifier": "sample_B1",
+                                "location identifier": "B1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.07,
+                                "value": 5.38,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                            "sample document": {
-                                "sample identifier": "sample_G1",
-                                "location identifier": "G1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.77,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
-                            "sample document": {
-                                "sample identifier": "sample_H1",
-                                "location identifier": "H1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 7.82,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
-                            "sample document": {
-                                "sample identifier": "sample_A2",
-                                "location identifier": "A2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.18,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
-                            "sample document": {
-                                "sample identifier": "sample_B2",
-                                "location identifier": "B2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 1.24,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -444,182 +124,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
                             "sample document": {
-                                "sample identifier": "sample_C2",
-                                "location identifier": "C2",
+                                "sample identifier": "sample_C1",
+                                "location identifier": "C1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.1,
+                                "value": 5.13,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
-                            "sample document": {
-                                "sample identifier": "sample_D2",
-                                "location identifier": "D2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.14,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                            "sample document": {
-                                "sample identifier": "sample_E2",
-                                "location identifier": "E2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.5,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
-                            "sample document": {
-                                "sample identifier": "sample_F2",
-                                "location identifier": "F2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.42,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
-                            "sample document": {
-                                "sample identifier": "sample_G2",
-                                "location identifier": "G2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.82,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -654,182 +174,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
                             "sample document": {
-                                "sample identifier": "sample_H2",
-                                "location identifier": "H2",
+                                "sample identifier": "sample_D1",
+                                "location identifier": "D1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.94,
+                                "value": 4.85,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
-                            "sample document": {
-                                "sample identifier": "sample_A3",
-                                "location identifier": "A3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.66,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
-                            "sample document": {
-                                "sample identifier": "sample_B3",
-                                "location identifier": "B3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.24,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                            "sample document": {
-                                "sample identifier": "sample_C3",
-                                "location identifier": "C3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.93,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
-                            "sample document": {
-                                "sample identifier": "sample_D3",
-                                "location identifier": "D3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.4,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -864,182 +224,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
                             "sample document": {
-                                "sample identifier": "sample_E3",
-                                "location identifier": "E3",
+                                "sample identifier": "sample_E1",
+                                "location identifier": "E1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.05,
+                                "value": 8.08,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
-                            "sample document": {
-                                "sample identifier": "sample_F3",
-                                "location identifier": "F3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.92,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                            "sample document": {
-                                "sample identifier": "sample_G3",
-                                "location identifier": "G3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.14,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
-                            "sample document": {
-                                "sample identifier": "sample_H3",
-                                "location identifier": "H3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.98,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                            "sample document": {
-                                "sample identifier": "sample_A4",
-                                "location identifier": "A4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.87,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -1074,182 +274,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
                             "sample document": {
-                                "sample identifier": "sample_B4",
-                                "location identifier": "B4",
+                                "sample identifier": "sample_F1",
+                                "location identifier": "F1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.32,
+                                "value": 6.07,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                            "sample document": {
-                                "sample identifier": "sample_C4",
-                                "location identifier": "C4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.9,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
-                            "sample document": {
-                                "sample identifier": "sample_D4",
-                                "location identifier": "D4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.12,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
-                            "sample document": {
-                                "sample identifier": "sample_E4",
-                                "location identifier": "E4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.53,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
-                            "sample document": {
-                                "sample identifier": "sample_F4",
-                                "location identifier": "F4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.67,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -1284,182 +324,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
                             "sample document": {
-                                "sample identifier": "sample_G4",
-                                "location identifier": "G4",
+                                "sample identifier": "sample_G1",
+                                "location identifier": "G1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 4.6,
+                                "value": 6.77,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
-                            "sample document": {
-                                "sample identifier": "sample_H4",
-                                "location identifier": "H4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.27,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
-                            "sample document": {
-                                "sample identifier": "sample_A5",
-                                "location identifier": "A5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 3.63,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
-                            "sample document": {
-                                "sample identifier": "sample_B5",
-                                "location identifier": "B5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.5,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                            "sample document": {
-                                "sample identifier": "sample_C5",
-                                "location identifier": "C5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.04,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -1494,182 +374,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
                             "sample document": {
-                                "sample identifier": "sample_D5",
-                                "location identifier": "D5",
+                                "sample identifier": "sample_H1",
+                                "location identifier": "H1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.63,
+                                "value": 7.82,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                            "sample document": {
-                                "sample identifier": "sample_E5",
-                                "location identifier": "E5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 7.66,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
-                            "sample document": {
-                                "sample identifier": "sample_F5",
-                                "location identifier": "F5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.94,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                            "sample document": {
-                                "sample identifier": "sample_G5",
-                                "location identifier": "G5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.88,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
-                            "sample document": {
-                                "sample identifier": "sample_H5",
-                                "location identifier": "H5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 4.84,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -1704,182 +424,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
                             "sample document": {
-                                "sample identifier": "sample_A6",
-                                "location identifier": "A6",
+                                "sample identifier": "sample_A2",
+                                "location identifier": "A2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 4.32,
+                                "value": 5.18,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
-                            "sample document": {
-                                "sample identifier": "sample_B6",
-                                "location identifier": "B6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.63,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                            "sample document": {
-                                "sample identifier": "sample_C6",
-                                "location identifier": "C6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.12,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
-                            "sample document": {
-                                "sample identifier": "sample_D6",
-                                "location identifier": "D6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.79,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
-                            "sample document": {
-                                "sample identifier": "sample_E6",
-                                "location identifier": "E6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.81,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -1914,182 +474,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
                             "sample document": {
-                                "sample identifier": "sample_F6",
-                                "location identifier": "F6",
+                                "sample identifier": "sample_B2",
+                                "location identifier": "B2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 5.52,
+                                "value": 1.24,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
-                            "sample document": {
-                                "sample identifier": "sample_G6",
-                                "location identifier": "G6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.5,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
-                            "sample document": {
-                                "sample identifier": "sample_H6",
-                                "location identifier": "H6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.73,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                            "sample document": {
-                                "sample identifier": "sample_A7",
-                                "location identifier": "A7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 6.38,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
-                            "sample document": {
-                                "sample identifier": "sample_B7",
-                                "location identifier": "B7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.09,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -2124,182 +524,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
                             "sample document": {
-                                "sample identifier": "sample_C7",
-                                "location identifier": "C7",
+                                "sample identifier": "sample_C2",
+                                "location identifier": "C2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 6.25,
+                                "value": 6.1,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
-                            "sample document": {
-                                "sample identifier": "sample_D7",
-                                "location identifier": "D7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.8,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                            "sample document": {
-                                "sample identifier": "sample_E7",
-                                "location identifier": "E7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 7.55,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
-                            "sample document": {
-                                "sample identifier": "sample_F7",
-                                "location identifier": "F7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.11,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                            "sample document": {
-                                "sample identifier": "sample_G7",
-                                "location identifier": "G7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 5.12,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -2334,182 +574,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
                             "sample document": {
-                                "sample identifier": "sample_H7",
-                                "location identifier": "H7",
+                                "sample identifier": "sample_D2",
+                                "location identifier": "D2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 7.24,
+                                "value": 4.14,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                            "sample document": {
-                                "sample identifier": "sample_A8",
-                                "location identifier": "A8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 1.82,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
-                            "sample document": {
-                                "sample identifier": "sample_B8",
-                                "location identifier": "B8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.16,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
-                            "sample document": {
-                                "sample identifier": "sample_C8",
-                                "location identifier": "C8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.25,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
-                            "sample document": {
-                                "sample identifier": "sample_D8",
-                                "location identifier": "D8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.4,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -2544,182 +624,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
                             "sample document": {
-                                "sample identifier": "sample_E8",
-                                "location identifier": "E8",
+                                "sample identifier": "sample_E2",
+                                "location identifier": "E2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 2.25,
+                                "value": 4.5,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
-                            "sample document": {
-                                "sample identifier": "sample_F8",
-                                "location identifier": "F8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.61,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
-                            "sample document": {
-                                "sample identifier": "sample_G8",
-                                "location identifier": "G8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 1.7,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
-                            "sample document": {
-                                "sample identifier": "sample_H8",
-                                "location identifier": "H8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.55,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
-                            "sample document": {
-                                "sample identifier": "sample_A9",
-                                "location identifier": "A9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.3,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -2754,182 +674,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
                             "sample document": {
-                                "sample identifier": "sample_B9",
-                                "location identifier": "B9",
+                                "sample identifier": "sample_F2",
+                                "location identifier": "F2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 2.48,
+                                "value": 4.42,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                            "sample document": {
-                                "sample identifier": "sample_C9",
-                                "location identifier": "C9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.03,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
-                            "sample document": {
-                                "sample identifier": "sample_D9",
-                                "location identifier": "D9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.21,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                            "sample document": {
-                                "sample identifier": "sample_E9",
-                                "location identifier": "E9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 2.33,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-12T10:38:09+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
-                            "sample document": {
-                                "sample identifier": "sample_F9",
-                                "location identifier": "F9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7116"
-                            },
-                            "absorbance": {
-                                "value": 1.98,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -2964,14 +724,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
                             "sample document": {
-                                "sample identifier": "sample_G9",
-                                "location identifier": "G9",
+                                "sample identifier": "sample_G2",
+                                "location identifier": "G2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7116"
                             },
                             "absorbance": {
-                                "value": 2.33,
+                                "value": 6.82,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -3004,7 +772,2807 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                            "sample document": {
+                                "sample identifier": "sample_H2",
+                                "location identifier": "H2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.94,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                            "sample document": {
+                                "sample identifier": "sample_A3",
+                                "location identifier": "A3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.66,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                            "sample document": {
+                                "sample identifier": "sample_B3",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.24,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                            "sample document": {
+                                "sample identifier": "sample_C3",
+                                "location identifier": "C3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.93,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                            "sample document": {
+                                "sample identifier": "sample_D3",
+                                "location identifier": "D3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.4,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
+                            "sample document": {
+                                "sample identifier": "sample_E3",
+                                "location identifier": "E3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.05,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                            "sample document": {
+                                "sample identifier": "sample_F3",
+                                "location identifier": "F3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.92,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                            "sample document": {
+                                "sample identifier": "sample_G3",
+                                "location identifier": "G3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.14,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                            "sample document": {
+                                "sample identifier": "sample_H3",
+                                "location identifier": "H3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.98,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                            "sample document": {
+                                "sample identifier": "sample_A4",
+                                "location identifier": "A4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.87,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                            "sample document": {
+                                "sample identifier": "sample_B4",
+                                "location identifier": "B4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.32,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                            "sample document": {
+                                "sample identifier": "sample_C4",
+                                "location identifier": "C4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.9,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                            "sample document": {
+                                "sample identifier": "sample_D4",
+                                "location identifier": "D4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.12,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                            "sample document": {
+                                "sample identifier": "sample_E4",
+                                "location identifier": "E4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.53,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                            "sample document": {
+                                "sample identifier": "sample_F4",
+                                "location identifier": "F4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.67,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                            "sample document": {
+                                "sample identifier": "sample_G4",
+                                "location identifier": "G4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.6,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                            "sample document": {
+                                "sample identifier": "sample_H4",
+                                "location identifier": "H4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.27,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                            "sample document": {
+                                "sample identifier": "sample_A5",
+                                "location identifier": "A5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 3.63,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                            "sample document": {
+                                "sample identifier": "sample_B5",
+                                "location identifier": "B5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.5,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                            "sample document": {
+                                "sample identifier": "sample_C5",
+                                "location identifier": "C5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.04,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                            "sample document": {
+                                "sample identifier": "sample_D5",
+                                "location identifier": "D5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.63,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                            "sample document": {
+                                "sample identifier": "sample_E5",
+                                "location identifier": "E5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 7.66,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                            "sample document": {
+                                "sample identifier": "sample_F5",
+                                "location identifier": "F5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.94,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                            "sample document": {
+                                "sample identifier": "sample_G5",
+                                "location identifier": "G5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.88,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                            "sample document": {
+                                "sample identifier": "sample_H5",
+                                "location identifier": "H5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.84,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                            "sample document": {
+                                "sample identifier": "sample_A6",
+                                "location identifier": "A6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 4.32,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                            "sample document": {
+                                "sample identifier": "sample_B6",
+                                "location identifier": "B6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.63,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
+                            "sample document": {
+                                "sample identifier": "sample_C6",
+                                "location identifier": "C6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.12,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                            "sample document": {
+                                "sample identifier": "sample_D6",
+                                "location identifier": "D6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.79,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                            "sample document": {
+                                "sample identifier": "sample_E6",
+                                "location identifier": "E6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.81,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                            "sample document": {
+                                "sample identifier": "sample_F6",
+                                "location identifier": "F6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.52,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                            "sample document": {
+                                "sample identifier": "sample_G6",
+                                "location identifier": "G6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.5,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                            "sample document": {
+                                "sample identifier": "sample_H6",
+                                "location identifier": "H6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.73,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
+                            "sample document": {
+                                "sample identifier": "sample_A7",
+                                "location identifier": "A7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.38,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                            "sample document": {
+                                "sample identifier": "sample_B7",
+                                "location identifier": "B7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.09,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                            "sample document": {
+                                "sample identifier": "sample_C7",
+                                "location identifier": "C7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 6.25,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                            "sample document": {
+                                "sample identifier": "sample_D7",
+                                "location identifier": "D7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.8,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                            "sample document": {
+                                "sample identifier": "sample_E7",
+                                "location identifier": "E7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 7.55,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                            "sample document": {
+                                "sample identifier": "sample_F7",
+                                "location identifier": "F7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.11,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
+                            "sample document": {
+                                "sample identifier": "sample_G7",
+                                "location identifier": "G7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 5.12,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                            "sample document": {
+                                "sample identifier": "sample_H7",
+                                "location identifier": "H7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 7.24,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                            "sample document": {
+                                "sample identifier": "sample_A8",
+                                "location identifier": "A8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 1.82,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                            "sample document": {
+                                "sample identifier": "sample_B8",
+                                "location identifier": "B8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.16,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                            "sample document": {
+                                "sample identifier": "sample_C8",
+                                "location identifier": "C8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.25,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                            "sample document": {
+                                "sample identifier": "sample_D8",
+                                "location identifier": "D8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.4,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
+                            "sample document": {
+                                "sample identifier": "sample_E8",
+                                "location identifier": "E8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.25,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                            "sample document": {
+                                "sample identifier": "sample_F8",
+                                "location identifier": "F8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.61,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                            "sample document": {
+                                "sample identifier": "sample_G8",
+                                "location identifier": "G8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 1.7,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                            "sample document": {
+                                "sample identifier": "sample_H8",
+                                "location identifier": "H8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.55,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                            "sample document": {
+                                "sample identifier": "sample_A9",
+                                "location identifier": "A9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.3,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                            "sample document": {
+                                "sample identifier": "sample_B9",
+                                "location identifier": "B9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.48,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
+                            "sample document": {
+                                "sample identifier": "sample_C9",
+                                "location identifier": "C9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.03,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                            "sample document": {
+                                "sample identifier": "sample_D9",
+                                "location identifier": "D9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.21,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                            "sample document": {
+                                "sample identifier": "sample_E9",
+                                "location identifier": "E9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.33,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                            "sample document": {
+                                "sample identifier": "sample_F9",
+                                "location identifier": "F9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 1.98,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                            "sample document": {
+                                "sample identifier": "sample_G9",
+                                "location identifier": "G9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7116"
+                            },
+                            "absorbance": {
+                                "value": 2.33,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-12T10:38:09+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
                             "sample document": {
                                 "sample identifier": "sample_H9",
                                 "location identifier": "H9",
@@ -3014,6 +3582,14 @@
                             "absorbance": {
                                 "value": 2.61,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -3027,6 +3603,4618 @@
                 "analyst": "admin"
             }
         ],
+        "calculated data aggregate document": {
+            "calculated data document": [
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 291.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.11,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.38,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 269.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.09,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 256.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 242.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 403.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.12,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 303.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 338.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.33,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 390.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.02,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.36,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 259.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 61.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 305.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.09,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 207.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.38,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 224.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.17,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.35,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 220.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.21,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.43,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 341.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.38,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 347.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.2,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.37,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 233.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.35,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 262.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.11,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 246.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.08,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.37,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 319.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 302.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 296.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 307.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.03,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 348.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.34,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 293.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.23,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.33,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 266.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.22,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 244.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.21,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.36,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 305.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 226.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 233.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.43,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 230.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.17,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_152",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.38,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_153",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_154",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 313.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.25,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.38,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 181.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.29,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 225.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.2,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 302.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 281.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.2,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.37,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 383.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_181",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.2,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_182",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_183",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_184",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 247.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_187",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.45,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_188",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_189",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 244.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_191",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.23,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_193",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_194",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 242.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_196",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_197",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.36,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_199",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 215.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_201",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.24,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_202",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.38,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_203",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 281.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_206",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.21,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_207",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_208",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_209",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 255.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_211",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_212",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.31,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_213",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_214",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 339.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_217",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_218",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_219",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 290.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_221",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.22,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_223",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_224",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 275.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_226",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_227",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.38,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_229",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 274.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_231",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_232",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_233",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 336.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_236",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.28,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_237",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.36,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_238",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_239",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 318.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_241",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_242",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.37,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_243",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_244",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 254.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.04,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_247",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_248",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_249",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 312.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_251",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.43,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_253",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_254",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 289.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_256",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_257",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_259",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 377.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_261",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.2,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_262",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_263",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 255.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_266",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.17,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_267",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_268",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_269",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 255.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_271",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.25,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_272",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_273",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_274",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 362.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.02,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_277",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.37,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_278",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_279",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 90.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_281",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.34,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_283",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_284",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 107.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_286",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_287",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_289",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 112.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_291",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.21,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_292",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.57,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_293",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 119.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_296",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_297",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_298",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_299",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 112.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_301",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_302",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_303",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_304",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 130.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_307",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_308",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_309",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 84.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_311",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.2,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.73,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_313",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_314",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 127.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_316",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_317",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_319",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 115.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_321",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.17,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_322",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_323",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 123.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_326",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_327",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.46,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_328",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_329",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 101.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_331",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_332",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_333",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_334",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 110.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.25,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_337",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.52,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_338",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_339",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 116.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_341",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.54,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_343",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_344",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 98.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_346",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_347",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.31,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_349",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 116.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_351",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_352",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.38,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_353",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 130.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_356",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_357",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_358",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_359",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
         "data system document": {
             "ASM file identifier": "2024-07-12_CW288_Plate1.json",
             "data system instance identifier": "N/A",

--- a/tests/parsers/unchained_labs_lunatic/testdata/2024-07-16_CW288_Plate2.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/2024-07-16_CW288_Plate2.json
@@ -32,174 +32,14 @@
                             "absorbance": {
                                 "value": 1.23,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                            "sample document": {
-                                "sample identifier": "sample_B1",
-                                "location identifier": "B1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.96,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                            "sample document": {
-                                "sample identifier": "sample_C1",
-                                "location identifier": "C1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.7,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
-                            "sample document": {
-                                "sample identifier": "sample_D1",
-                                "location identifier": "D1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.88,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                            "sample document": {
-                                "sample identifier": "sample_E1",
-                                "location identifier": "E1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.92,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -234,182 +74,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
                             "sample document": {
-                                "sample identifier": "sample_F1",
-                                "location identifier": "F1",
+                                "sample identifier": "sample_B1",
+                                "location identifier": "B1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.91,
+                                "value": 0.96,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                            "sample document": {
-                                "sample identifier": "sample_G1",
-                                "location identifier": "G1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.7,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
-                            "sample document": {
-                                "sample identifier": "sample_H1",
-                                "location identifier": "H1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.84,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
-                            "sample document": {
-                                "sample identifier": "sample_A2",
-                                "location identifier": "A2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.25,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
-                            "sample document": {
-                                "sample identifier": "sample_B2",
-                                "location identifier": "B2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.17,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -444,182 +124,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
                             "sample document": {
-                                "sample identifier": "sample_C2",
-                                "location identifier": "C2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.18,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
-                            "sample document": {
-                                "sample identifier": "sample_D2",
-                                "location identifier": "D2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.83,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                            "sample document": {
-                                "sample identifier": "sample_E2",
-                                "location identifier": "E2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.75,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
-                            "sample document": {
-                                "sample identifier": "sample_F2",
-                                "location identifier": "F2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.79,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
-                            "sample document": {
-                                "sample identifier": "sample_G2",
-                                "location identifier": "G2",
+                                "sample identifier": "sample_C1",
+                                "location identifier": "C1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
                                 "value": 0.7,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -654,182 +174,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
                             "sample document": {
-                                "sample identifier": "sample_H2",
-                                "location identifier": "H2",
+                                "sample identifier": "sample_D1",
+                                "location identifier": "D1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.85,
+                                "value": 0.88,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
-                            "sample document": {
-                                "sample identifier": "sample_A3",
-                                "location identifier": "A3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.02,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
-                            "sample document": {
-                                "sample identifier": "sample_B3",
-                                "location identifier": "B3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.03,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                            "sample document": {
-                                "sample identifier": "sample_C3",
-                                "location identifier": "C3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.21,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
-                            "sample document": {
-                                "sample identifier": "sample_D3",
-                                "location identifier": "D3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.16,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -864,182 +224,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
                             "sample document": {
-                                "sample identifier": "sample_E3",
-                                "location identifier": "E3",
+                                "sample identifier": "sample_E1",
+                                "location identifier": "E1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.07,
+                                "value": 0.92,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
-                            "sample document": {
-                                "sample identifier": "sample_F3",
-                                "location identifier": "F3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.9,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                            "sample document": {
-                                "sample identifier": "sample_G3",
-                                "location identifier": "G3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.83,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
-                            "sample document": {
-                                "sample identifier": "sample_H3",
-                                "location identifier": "H3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.79,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                            "sample document": {
-                                "sample identifier": "sample_A4",
-                                "location identifier": "A4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.84,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -1074,182 +274,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
                             "sample document": {
-                                "sample identifier": "sample_B4",
-                                "location identifier": "B4",
+                                "sample identifier": "sample_F1",
+                                "location identifier": "F1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.39,
+                                "value": 0.91,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                            "sample document": {
-                                "sample identifier": "sample_C4",
-                                "location identifier": "C4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.12,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
-                            "sample document": {
-                                "sample identifier": "sample_D4",
-                                "location identifier": "D4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.19,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
-                            "sample document": {
-                                "sample identifier": "sample_E4",
-                                "location identifier": "E4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.96,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
-                            "sample document": {
-                                "sample identifier": "sample_F4",
-                                "location identifier": "F4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.79,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -1284,182 +324,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
                             "sample document": {
-                                "sample identifier": "sample_G4",
-                                "location identifier": "G4",
+                                "sample identifier": "sample_G1",
+                                "location identifier": "G1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.76,
+                                "value": 0.7,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
-                            "sample document": {
-                                "sample identifier": "sample_H4",
-                                "location identifier": "H4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.69,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
-                            "sample document": {
-                                "sample identifier": "sample_A5",
-                                "location identifier": "A5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.56,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
-                            "sample document": {
-                                "sample identifier": "sample_B5",
-                                "location identifier": "B5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.42,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                            "sample document": {
-                                "sample identifier": "sample_C5",
-                                "location identifier": "C5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.44,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -1494,182 +374,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
                             "sample document": {
-                                "sample identifier": "sample_D5",
-                                "location identifier": "D5",
+                                "sample identifier": "sample_H1",
+                                "location identifier": "H1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.42,
+                                "value": 0.84,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                            "sample document": {
-                                "sample identifier": "sample_E5",
-                                "location identifier": "E5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.29,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
-                            "sample document": {
-                                "sample identifier": "sample_F5",
-                                "location identifier": "F5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.4,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                            "sample document": {
-                                "sample identifier": "sample_G5",
-                                "location identifier": "G5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.17,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
-                            "sample document": {
-                                "sample identifier": "sample_H5",
-                                "location identifier": "H5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.11,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -1704,182 +424,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
                             "sample document": {
-                                "sample identifier": "sample_A6",
-                                "location identifier": "A6",
+                                "sample identifier": "sample_A2",
+                                "location identifier": "A2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.94,
+                                "value": 1.25,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
-                            "sample document": {
-                                "sample identifier": "sample_B6",
-                                "location identifier": "B6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.22,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                            "sample document": {
-                                "sample identifier": "sample_C6",
-                                "location identifier": "C6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.32,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
-                            "sample document": {
-                                "sample identifier": "sample_D6",
-                                "location identifier": "D6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.21,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
-                            "sample document": {
-                                "sample identifier": "sample_E6",
-                                "location identifier": "E6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.24,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -1914,182 +474,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
                             "sample document": {
-                                "sample identifier": "sample_F6",
-                                "location identifier": "F6",
+                                "sample identifier": "sample_B2",
+                                "location identifier": "B2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.3,
+                                "value": 1.17,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
-                            "sample document": {
-                                "sample identifier": "sample_G6",
-                                "location identifier": "G6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.06,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
-                            "sample document": {
-                                "sample identifier": "sample_H6",
-                                "location identifier": "H6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.95,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                            "sample document": {
-                                "sample identifier": "sample_A7",
-                                "location identifier": "A7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.13,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
-                            "sample document": {
-                                "sample identifier": "sample_B7",
-                                "location identifier": "B7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.27,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -2124,182 +524,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
                             "sample document": {
-                                "sample identifier": "sample_C7",
-                                "location identifier": "C7",
+                                "sample identifier": "sample_C2",
+                                "location identifier": "C2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.84,
+                                "value": 1.18,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
-                            "sample document": {
-                                "sample identifier": "sample_D7",
-                                "location identifier": "D7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.65,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                            "sample document": {
-                                "sample identifier": "sample_E7",
-                                "location identifier": "E7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.06,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
-                            "sample document": {
-                                "sample identifier": "sample_F7",
-                                "location identifier": "F7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.36,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                            "sample document": {
-                                "sample identifier": "sample_G7",
-                                "location identifier": "G7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.07,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -2334,182 +574,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
                             "sample document": {
-                                "sample identifier": "sample_H7",
-                                "location identifier": "H7",
+                                "sample identifier": "sample_D2",
+                                "location identifier": "D2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.21,
+                                "value": 0.83,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                            "sample document": {
-                                "sample identifier": "sample_A8",
-                                "location identifier": "A8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.62,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
-                            "sample document": {
-                                "sample identifier": "sample_B8",
-                                "location identifier": "B8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.34,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
-                            "sample document": {
-                                "sample identifier": "sample_C8",
-                                "location identifier": "C8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.21,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
-                            "sample document": {
-                                "sample identifier": "sample_D8",
-                                "location identifier": "D8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.9,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -2544,182 +624,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
                             "sample document": {
-                                "sample identifier": "sample_E8",
-                                "location identifier": "E8",
+                                "sample identifier": "sample_E2",
+                                "location identifier": "E2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.79,
+                                "value": 0.75,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
-                            "sample document": {
-                                "sample identifier": "sample_F8",
-                                "location identifier": "F8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.79,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
-                            "sample document": {
-                                "sample identifier": "sample_G8",
-                                "location identifier": "G8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.48,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
-                            "sample document": {
-                                "sample identifier": "sample_H8",
-                                "location identifier": "H8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.92,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
-                            "sample document": {
-                                "sample identifier": "sample_A9",
-                                "location identifier": "A9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.1,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -2754,182 +674,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
                             "sample document": {
-                                "sample identifier": "sample_B9",
-                                "location identifier": "B9",
+                                "sample identifier": "sample_F2",
+                                "location identifier": "F2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.49,
+                                "value": 0.79,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                            "sample document": {
-                                "sample identifier": "sample_C9",
-                                "location identifier": "C9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.06,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
-                            "sample document": {
-                                "sample identifier": "sample_D9",
-                                "location identifier": "D9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.91,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                            "sample document": {
-                                "sample identifier": "sample_E9",
-                                "location identifier": "E9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.72,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
-                            "sample document": {
-                                "sample identifier": "sample_F9",
-                                "location identifier": "F9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.26,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -2964,182 +724,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
                             "sample document": {
-                                "sample identifier": "sample_G9",
-                                "location identifier": "G9",
+                                "sample identifier": "sample_G2",
+                                "location identifier": "G2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.89,
+                                "value": 0.7,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
-                            "sample document": {
-                                "sample identifier": "sample_H9",
-                                "location identifier": "H9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.01,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                            "sample document": {
-                                "sample identifier": "sample_A10",
-                                "location identifier": "A10",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.4,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
-                            "sample document": {
-                                "sample identifier": "sample_B10",
-                                "location identifier": "B10",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.34,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
-                            "sample document": {
-                                "sample identifier": "sample_C10",
-                                "location identifier": "C10",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.14,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -3174,182 +774,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
                             "sample document": {
-                                "sample identifier": "sample_D10",
-                                "location identifier": "D10",
+                                "sample identifier": "sample_H2",
+                                "location identifier": "H2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.11,
+                                "value": 0.85,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
-                            "sample document": {
-                                "sample identifier": "sample_E10",
-                                "location identifier": "E10",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.43,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
-                            "sample document": {
-                                "sample identifier": "sample_F10",
-                                "location identifier": "F10",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.48,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                            "sample document": {
-                                "sample identifier": "sample_G10",
-                                "location identifier": "G10",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.27,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
-                            "sample document": {
-                                "sample identifier": "sample_H10",
-                                "location identifier": "H10",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.2,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -3384,182 +824,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
                             "sample document": {
-                                "sample identifier": "sample_A11",
-                                "location identifier": "A11",
+                                "sample identifier": "sample_A3",
+                                "location identifier": "A3",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.21,
+                                "value": 1.02,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
-                            "sample document": {
-                                "sample identifier": "sample_B11",
-                                "location identifier": "B11",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.04,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
-                            "sample document": {
-                                "sample identifier": "sample_C11",
-                                "location identifier": "C11",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.28,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
-                            "sample document": {
-                                "sample identifier": "sample_D11",
-                                "location identifier": "D11",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.19,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                            "sample document": {
-                                "sample identifier": "sample_E11",
-                                "location identifier": "E11",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.19,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -3594,182 +874,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
                             "sample document": {
-                                "sample identifier": "sample_F11",
-                                "location identifier": "F11",
+                                "sample identifier": "sample_B3",
+                                "location identifier": "B3",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.62,
+                                "value": 1.03,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
-                            "sample document": {
-                                "sample identifier": "sample_G11",
-                                "location identifier": "G11",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.09,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
-                            "sample document": {
-                                "sample identifier": "sample_H11",
-                                "location identifier": "H11",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.04,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
-                            "sample document": {
-                                "sample identifier": "sample_A12",
-                                "location identifier": "A12",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.78,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89",
-                            "sample document": {
-                                "sample identifier": "sample_B12",
-                                "location identifier": "B12",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.77,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -3804,182 +924,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
                             "sample document": {
-                                "sample identifier": "sample_C12",
-                                "location identifier": "C12",
+                                "sample identifier": "sample_C3",
+                                "location identifier": "C3",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.46,
+                                "value": 1.21,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
-                            "sample document": {
-                                "sample identifier": "sample_D12",
-                                "location identifier": "D12",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.96,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
-                            "sample document": {
-                                "sample identifier": "sample_E12",
-                                "location identifier": "E12",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.0,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
-                            "sample document": {
-                                "sample identifier": "sample_F12",
-                                "location identifier": "F12",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.93,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
-                            "sample document": {
-                                "sample identifier": "sample_G12",
-                                "location identifier": "G12",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.04,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -4014,6 +974,3806 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
                             "sample document": {
+                                "sample identifier": "sample_D3",
+                                "location identifier": "D3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.16,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
+                            "sample document": {
+                                "sample identifier": "sample_E3",
+                                "location identifier": "E3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.07,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                            "sample document": {
+                                "sample identifier": "sample_F3",
+                                "location identifier": "F3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.9,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                            "sample document": {
+                                "sample identifier": "sample_G3",
+                                "location identifier": "G3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.83,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                            "sample document": {
+                                "sample identifier": "sample_H3",
+                                "location identifier": "H3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.79,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                            "sample document": {
+                                "sample identifier": "sample_A4",
+                                "location identifier": "A4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.84,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                            "sample document": {
+                                "sample identifier": "sample_B4",
+                                "location identifier": "B4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.39,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                            "sample document": {
+                                "sample identifier": "sample_C4",
+                                "location identifier": "C4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.12,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                            "sample document": {
+                                "sample identifier": "sample_D4",
+                                "location identifier": "D4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.19,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                            "sample document": {
+                                "sample identifier": "sample_E4",
+                                "location identifier": "E4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.96,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                            "sample document": {
+                                "sample identifier": "sample_F4",
+                                "location identifier": "F4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.79,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                            "sample document": {
+                                "sample identifier": "sample_G4",
+                                "location identifier": "G4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.76,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                            "sample document": {
+                                "sample identifier": "sample_H4",
+                                "location identifier": "H4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.69,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                            "sample document": {
+                                "sample identifier": "sample_A5",
+                                "location identifier": "A5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.56,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                            "sample document": {
+                                "sample identifier": "sample_B5",
+                                "location identifier": "B5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.42,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                            "sample document": {
+                                "sample identifier": "sample_C5",
+                                "location identifier": "C5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.44,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                            "sample document": {
+                                "sample identifier": "sample_D5",
+                                "location identifier": "D5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.42,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                            "sample document": {
+                                "sample identifier": "sample_E5",
+                                "location identifier": "E5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.29,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                            "sample document": {
+                                "sample identifier": "sample_F5",
+                                "location identifier": "F5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.4,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                            "sample document": {
+                                "sample identifier": "sample_G5",
+                                "location identifier": "G5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.17,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                            "sample document": {
+                                "sample identifier": "sample_H5",
+                                "location identifier": "H5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.11,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                            "sample document": {
+                                "sample identifier": "sample_A6",
+                                "location identifier": "A6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.94,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                            "sample document": {
+                                "sample identifier": "sample_B6",
+                                "location identifier": "B6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.22,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
+                            "sample document": {
+                                "sample identifier": "sample_C6",
+                                "location identifier": "C6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.32,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                            "sample document": {
+                                "sample identifier": "sample_D6",
+                                "location identifier": "D6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.21,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                            "sample document": {
+                                "sample identifier": "sample_E6",
+                                "location identifier": "E6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.24,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                            "sample document": {
+                                "sample identifier": "sample_F6",
+                                "location identifier": "F6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.3,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                            "sample document": {
+                                "sample identifier": "sample_G6",
+                                "location identifier": "G6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.06,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                            "sample document": {
+                                "sample identifier": "sample_H6",
+                                "location identifier": "H6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.95,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
+                            "sample document": {
+                                "sample identifier": "sample_A7",
+                                "location identifier": "A7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.13,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                            "sample document": {
+                                "sample identifier": "sample_B7",
+                                "location identifier": "B7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.27,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                            "sample document": {
+                                "sample identifier": "sample_C7",
+                                "location identifier": "C7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.84,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                            "sample document": {
+                                "sample identifier": "sample_D7",
+                                "location identifier": "D7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.65,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                            "sample document": {
+                                "sample identifier": "sample_E7",
+                                "location identifier": "E7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.06,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                            "sample document": {
+                                "sample identifier": "sample_F7",
+                                "location identifier": "F7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.36,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
+                            "sample document": {
+                                "sample identifier": "sample_G7",
+                                "location identifier": "G7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.07,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                            "sample document": {
+                                "sample identifier": "sample_H7",
+                                "location identifier": "H7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.21,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                            "sample document": {
+                                "sample identifier": "sample_A8",
+                                "location identifier": "A8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.62,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                            "sample document": {
+                                "sample identifier": "sample_B8",
+                                "location identifier": "B8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.34,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                            "sample document": {
+                                "sample identifier": "sample_C8",
+                                "location identifier": "C8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.21,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                            "sample document": {
+                                "sample identifier": "sample_D8",
+                                "location identifier": "D8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.9,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
+                            "sample document": {
+                                "sample identifier": "sample_E8",
+                                "location identifier": "E8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.79,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                            "sample document": {
+                                "sample identifier": "sample_F8",
+                                "location identifier": "F8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.79,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                            "sample document": {
+                                "sample identifier": "sample_G8",
+                                "location identifier": "G8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.48,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                            "sample document": {
+                                "sample identifier": "sample_H8",
+                                "location identifier": "H8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.92,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                            "sample document": {
+                                "sample identifier": "sample_A9",
+                                "location identifier": "A9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.1,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                            "sample document": {
+                                "sample identifier": "sample_B9",
+                                "location identifier": "B9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.49,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
+                            "sample document": {
+                                "sample identifier": "sample_C9",
+                                "location identifier": "C9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.06,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                            "sample document": {
+                                "sample identifier": "sample_D9",
+                                "location identifier": "D9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.91,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                            "sample document": {
+                                "sample identifier": "sample_E9",
+                                "location identifier": "E9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.72,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                            "sample document": {
+                                "sample identifier": "sample_F9",
+                                "location identifier": "F9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.26,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                            "sample document": {
+                                "sample identifier": "sample_G9",
+                                "location identifier": "G9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.89,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                            "sample document": {
+                                "sample identifier": "sample_H9",
+                                "location identifier": "H9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.01,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
+                            "sample document": {
+                                "sample identifier": "sample_A10",
+                                "location identifier": "A10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.4,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365",
+                            "sample document": {
+                                "sample identifier": "sample_B10",
+                                "location identifier": "B10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.34,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
+                            "sample document": {
+                                "sample identifier": "sample_C10",
+                                "location identifier": "C10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.14,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
+                            "sample document": {
+                                "sample identifier": "sample_D10",
+                                "location identifier": "D10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.11,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
+                            "sample document": {
+                                "sample identifier": "sample_E10",
+                                "location identifier": "E10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.43,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
+                            "sample document": {
+                                "sample identifier": "sample_F10",
+                                "location identifier": "F10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.48,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
+                            "sample document": {
+                                "sample identifier": "sample_G10",
+                                "location identifier": "G10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.27,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395",
+                            "sample document": {
+                                "sample identifier": "sample_H10",
+                                "location identifier": "H10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.2,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
+                            "sample document": {
+                                "sample identifier": "sample_A11",
+                                "location identifier": "A11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.21,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
+                            "sample document": {
+                                "sample identifier": "sample_B11",
+                                "location identifier": "B11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.04,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
+                            "sample document": {
+                                "sample identifier": "sample_C11",
+                                "location identifier": "C11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.28,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
+                            "sample document": {
+                                "sample identifier": "sample_D11",
+                                "location identifier": "D11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.19,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
+                            "sample document": {
+                                "sample identifier": "sample_E11",
+                                "location identifier": "E11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.19,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425",
+                            "sample document": {
+                                "sample identifier": "sample_F11",
+                                "location identifier": "F11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.62,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
+                            "sample document": {
+                                "sample identifier": "sample_G11",
+                                "location identifier": "G11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.09,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_435",
+                            "sample document": {
+                                "sample identifier": "sample_H11",
+                                "location identifier": "H11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.04,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_440",
+                            "sample document": {
+                                "sample identifier": "sample_A12",
+                                "location identifier": "A12",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.78,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_445",
+                            "sample document": {
+                                "sample identifier": "sample_B12",
+                                "location identifier": "B12",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.77,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_450",
+                            "sample document": {
+                                "sample identifier": "sample_C12",
+                                "location identifier": "C12",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.46,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_455",
+                            "sample document": {
+                                "sample identifier": "sample_D12",
+                                "location identifier": "D12",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.96,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_460",
+                            "sample document": {
+                                "sample identifier": "sample_E12",
+                                "location identifier": "E12",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.0,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_465",
+                            "sample document": {
+                                "sample identifier": "sample_F12",
+                                "location identifier": "F12",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.93,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_470",
+                            "sample document": {
+                                "sample identifier": "sample_G12",
+                                "location identifier": "G12",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.04,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_475",
+                            "sample document": {
                                 "sample identifier": "sample_H12",
                                 "location identifier": "H12",
                                 "batch identifier": "Sample Group",
@@ -4022,6 +4782,14 @@
                             "absorbance": {
                                 "value": 0.95,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -4035,6 +4803,6154 @@
                 "analyst": "admin"
             }
         ],
+        "calculated data aggregate document": {
+            "calculated data document": [
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 61.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.76,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 48.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.46,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.95,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 35.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 2.0,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 44.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.25,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.63,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 46.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.22,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.53,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 45.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.46,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 34.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 41.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.05,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.43,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 62.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.25,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.53,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 58.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.61,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 58.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.34,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.96,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 41.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.97,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 37.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.25,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.73,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 39.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.12,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 34.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.49,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 42.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.75,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 51.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.48,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 51.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.3,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 60.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.14,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.32,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 57.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.2,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.31,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 53.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.63,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.98,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 44.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 41.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.12,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.75,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.98,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 39.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.27,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.75,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 42.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.28,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.57,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 69.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.47,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 56.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.17,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 59.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.12,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.7,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 47.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.54,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 39.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.21,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.77,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 38.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.22,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_152",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.74,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_153",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_154",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 34.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.26,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.61,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 77.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.13,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 70.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.37,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.95,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 71.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.09,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 71.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.52,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 64.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_181",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_182",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.37,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_183",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_184",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 70.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_187",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.58,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_188",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_189",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 58.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_191",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.23,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.63,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_193",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_194",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 55.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_196",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_197",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.64,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_199",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 46.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_201",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.22,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_202",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.53,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_203",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.87,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 61.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_206",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_207",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.49,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_208",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_209",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 66.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_211",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.2,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_212",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.49,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_213",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_214",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 60.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_217",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.57,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_218",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.96,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_219",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 62.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_221",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_223",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_224",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 64.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_226",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.09,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_227",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.52,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_229",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 53.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_231",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_232",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.51,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_233",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 47.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_236",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.22,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_237",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.53,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_238",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_239",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 56.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_241",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.25,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_242",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.51,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_243",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_244",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 63.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.05,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_247",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.59,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_248",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.96,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_249",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 42.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_251",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.52,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_253",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_254",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 82.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_256",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_257",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.41,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_259",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 53.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_261",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_262",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.69,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_263",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.97,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 68.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_266",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_267",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.66,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_268",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.95,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_269",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 53.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_271",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_272",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.72,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_273",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.95,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_274",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 60.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.12,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_277",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.65,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_278",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_279",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 80.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_281",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.03,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.52,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_283",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_284",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 66.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_286",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_287",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.77,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_289",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 60.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_291",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.02,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_292",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.5,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_293",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 94.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_296",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.28,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_297",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.58,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_298",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_299",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 89.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_301",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.22,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_302",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.66,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_303",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_304",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 89.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.25,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_307",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.56,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_308",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_309",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 74.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_311",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.26,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_313",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_314",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 45.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_316",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_317",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.76,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.96,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_319",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 55.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_321",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_322",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_323",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 74.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_326",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.14,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_327",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.54,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_328",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_329",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 53.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_331",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_332",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.39,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_333",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_334",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 45.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.01,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_337",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.65,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_338",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.97,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_339",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 35.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_341",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.59,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_343",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.95,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_344",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 62.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_346",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_347",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.45,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.97,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_349",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 44.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_351",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_352",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.5,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_353",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 50.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_356",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.23,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_357",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.61,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_358",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_359",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 69.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_361",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.23,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_362",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.49,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_363",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_364",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 66.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.22,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_367",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.5,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_368",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_369",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 57.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_371",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.45,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_373",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_374",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 55.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_376",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_377",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.59,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.95,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_379",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 71.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_381",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_382",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.49,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_383",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 74.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_386",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.27,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_387",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.62,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_388",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_389",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 63.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_391",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_392",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.63,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_393",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_394",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 60.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.17,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_397",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.72,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_398",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_399",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 60.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_401",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.48,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_403",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.95,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_404",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 51.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_406",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_407",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.34,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.95,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_409",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 63.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_411",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_412",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.73,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_413",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 59.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_416",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_417",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.53,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_418",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.96,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_419",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 59.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_421",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_422",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.43,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_423",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.97,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_424",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 81.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.23,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_427",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.57,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_428",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_429",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 54.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_431",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.02,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_432",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_433",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_434",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 51.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_436",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_435",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.27,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_437",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_435",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.69,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_438",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_435",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_439",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_435",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 39.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_441",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_440",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.24,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_442",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_440",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_443",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_440",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.86,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_444",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_440",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 38.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_446",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_445",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_447",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_445",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.61,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_448",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_445",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_449",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_445",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 72.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_451",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_450",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_452",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_450",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_453",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_450",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_454",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_450",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 48.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_456",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_455",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_457",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_455",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.7,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_458",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_455",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_459",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_455",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 49.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_461",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_460",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.23,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_462",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_460",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_463",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_460",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_464",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_460",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 46.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_466",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_465",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_467",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_465",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.49,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_468",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_465",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.98,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_469",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_465",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 52.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_471",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_470",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_472",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_470",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.99,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_473",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_470",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_474",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_470",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 47.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_476",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_475",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_477",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_475",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.64,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_478",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_475",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.96,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_479",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_475",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
         "data system document": {
             "ASM file identifier": "2024-07-16_CW288_Plate2.json",
             "data system instance identifier": "N/A",

--- a/tests/parsers/unchained_labs_lunatic/testdata/2024-07-16_CW288_Plate2.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/2024-07-16_CW288_Plate2.json
@@ -26,32 +26,222 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
                                 "value": 1.23,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                            "sample document": {
+                                "sample identifier": "sample_B1",
+                                "location identifier": "B1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.96,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                            "sample document": {
+                                "sample identifier": "sample_C1",
+                                "location identifier": "C1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.7,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                            "sample document": {
+                                "sample identifier": "sample_D1",
+                                "location identifier": "D1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.88,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                            "sample document": {
+                                "sample identifier": "sample_E1",
+                                "location identifier": "E1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.92,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                            "sample document": {
+                                "sample identifier": "sample_F1",
+                                "location identifier": "F1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.91,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -86,34 +276,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                             "sample document": {
-                                "sample identifier": "sample_B1",
-                                "location identifier": "B1",
+                                "sample identifier": "sample_G1",
+                                "location identifier": "G1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.96,
+                                "value": 0.7,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                            "sample document": {
+                                "sample identifier": "sample_H1",
+                                "location identifier": "H1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.84,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                            "sample document": {
+                                "sample identifier": "sample_A2",
+                                "location identifier": "A2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.25,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
+                            "sample document": {
+                                "sample identifier": "sample_B2",
+                                "location identifier": "B2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.17,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                            "sample document": {
+                                "sample identifier": "sample_C2",
+                                "location identifier": "C2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.18,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
+                            "sample document": {
+                                "sample identifier": "sample_D2",
+                                "location identifier": "D2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.83,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -148,34 +528,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                             "sample document": {
-                                "sample identifier": "sample_C1",
-                                "location identifier": "C1",
+                                "sample identifier": "sample_E2",
+                                "location identifier": "E2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.75,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                            "sample document": {
+                                "sample identifier": "sample_F2",
+                                "location identifier": "F2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.79,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                            "sample document": {
+                                "sample identifier": "sample_G2",
+                                "location identifier": "G2",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
                                 "value": 0.7,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                            "sample document": {
+                                "sample identifier": "sample_H2",
+                                "location identifier": "H2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.85,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
+                            "sample document": {
+                                "sample identifier": "sample_A3",
+                                "location identifier": "A3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.02,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
+                            "sample document": {
+                                "sample identifier": "sample_B3",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.03,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -210,34 +780,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                             "sample document": {
-                                "sample identifier": "sample_D1",
-                                "location identifier": "D1",
+                                "sample identifier": "sample_C3",
+                                "location identifier": "C3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.88,
+                                "value": 1.21,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
+                            "sample document": {
+                                "sample identifier": "sample_D3",
+                                "location identifier": "D3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.16,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                            "sample document": {
+                                "sample identifier": "sample_E3",
+                                "location identifier": "E3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.07,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
+                            "sample document": {
+                                "sample identifier": "sample_F3",
+                                "location identifier": "F3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.9,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
+                            "sample document": {
+                                "sample identifier": "sample_G3",
+                                "location identifier": "G3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.83,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                            "sample document": {
+                                "sample identifier": "sample_H3",
+                                "location identifier": "H3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.79,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -272,34 +1032,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                             "sample document": {
-                                "sample identifier": "sample_E1",
-                                "location identifier": "E1",
+                                "sample identifier": "sample_A4",
+                                "location identifier": "A4",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.92,
+                                "value": 0.84,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                            "sample document": {
+                                "sample identifier": "sample_B4",
+                                "location identifier": "B4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.39,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
+                            "sample document": {
+                                "sample identifier": "sample_C4",
+                                "location identifier": "C4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.12,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
+                            "sample document": {
+                                "sample identifier": "sample_D4",
+                                "location identifier": "D4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.19,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
+                            "sample document": {
+                                "sample identifier": "sample_E4",
+                                "location identifier": "E4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.96,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
+                            "sample document": {
+                                "sample identifier": "sample_F4",
+                                "location identifier": "F4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.79,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -334,34 +1284,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
                             "sample document": {
-                                "sample identifier": "sample_F1",
-                                "location identifier": "F1",
+                                "sample identifier": "sample_G4",
+                                "location identifier": "G4",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.91,
+                                "value": 0.76,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
+                            "sample document": {
+                                "sample identifier": "sample_H4",
+                                "location identifier": "H4",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.69,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
+                            "sample document": {
+                                "sample identifier": "sample_A5",
+                                "location identifier": "A5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.56,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
+                            "sample document": {
+                                "sample identifier": "sample_B5",
+                                "location identifier": "B5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.42,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
+                            "sample document": {
+                                "sample identifier": "sample_C5",
+                                "location identifier": "C5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.44,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                            "sample document": {
+                                "sample identifier": "sample_D5",
+                                "location identifier": "D5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.42,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -396,34 +1536,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
                             "sample document": {
-                                "sample identifier": "sample_G1",
-                                "location identifier": "G1",
+                                "sample identifier": "sample_E5",
+                                "location identifier": "E5",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.7,
+                                "value": 1.29,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
+                            "sample document": {
+                                "sample identifier": "sample_F5",
+                                "location identifier": "F5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.4,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                            "sample document": {
+                                "sample identifier": "sample_G5",
+                                "location identifier": "G5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.17,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
+                            "sample document": {
+                                "sample identifier": "sample_H5",
+                                "location identifier": "H5",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.11,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                            "sample document": {
+                                "sample identifier": "sample_A6",
+                                "location identifier": "A6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.94,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
+                            "sample document": {
+                                "sample identifier": "sample_B6",
+                                "location identifier": "B6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.22,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -458,34 +1788,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                             "sample document": {
-                                "sample identifier": "sample_H1",
-                                "location identifier": "H1",
+                                "sample identifier": "sample_C6",
+                                "location identifier": "C6",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.84,
+                                "value": 1.32,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                            "sample document": {
+                                "sample identifier": "sample_D6",
+                                "location identifier": "D6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.21,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
+                            "sample document": {
+                                "sample identifier": "sample_E6",
+                                "location identifier": "E6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.24,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                            "sample document": {
+                                "sample identifier": "sample_F6",
+                                "location identifier": "F6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.3,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                            "sample document": {
+                                "sample identifier": "sample_G6",
+                                "location identifier": "G6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.06,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                            "sample document": {
+                                "sample identifier": "sample_H6",
+                                "location identifier": "H6",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.95,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -520,34 +2040,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
                             "sample document": {
-                                "sample identifier": "sample_A2",
-                                "location identifier": "A2",
+                                "sample identifier": "sample_A7",
+                                "location identifier": "A7",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.25,
+                                "value": 1.13,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                            "sample document": {
+                                "sample identifier": "sample_B7",
+                                "location identifier": "B7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.27,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                            "sample document": {
+                                "sample identifier": "sample_C7",
+                                "location identifier": "C7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.84,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                            "sample document": {
+                                "sample identifier": "sample_D7",
+                                "location identifier": "D7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.65,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                            "sample document": {
+                                "sample identifier": "sample_E7",
+                                "location identifier": "E7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.06,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
+                            "sample document": {
+                                "sample identifier": "sample_F7",
+                                "location identifier": "F7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.36,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -582,34 +2292,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
                             "sample document": {
-                                "sample identifier": "sample_B2",
-                                "location identifier": "B2",
+                                "sample identifier": "sample_G7",
+                                "location identifier": "G7",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.17,
+                                "value": 1.07,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                            "sample document": {
+                                "sample identifier": "sample_H7",
+                                "location identifier": "H7",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.21,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                            "sample document": {
+                                "sample identifier": "sample_A8",
+                                "location identifier": "A8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.62,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
+                            "sample document": {
+                                "sample identifier": "sample_B8",
+                                "location identifier": "B8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.34,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
+                            "sample document": {
+                                "sample identifier": "sample_C8",
+                                "location identifier": "C8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.21,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
+                            "sample document": {
+                                "sample identifier": "sample_D8",
+                                "location identifier": "D8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.9,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -644,34 +2544,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
                             "sample document": {
-                                "sample identifier": "sample_C2",
-                                "location identifier": "C2",
+                                "sample identifier": "sample_E8",
+                                "location identifier": "E8",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.18,
+                                "value": 1.79,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                            "sample document": {
+                                "sample identifier": "sample_F8",
+                                "location identifier": "F8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.79,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
+                            "sample document": {
+                                "sample identifier": "sample_G8",
+                                "location identifier": "G8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.48,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
+                            "sample document": {
+                                "sample identifier": "sample_H8",
+                                "location identifier": "H8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.92,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
+                            "sample document": {
+                                "sample identifier": "sample_A9",
+                                "location identifier": "A9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.1,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                            "sample document": {
+                                "sample identifier": "sample_B9",
+                                "location identifier": "B9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.49,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -706,34 +2796,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
                             "sample document": {
-                                "sample identifier": "sample_D2",
-                                "location identifier": "D2",
+                                "sample identifier": "sample_C9",
+                                "location identifier": "C9",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.83,
+                                "value": 1.06,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
+                            "sample document": {
+                                "sample identifier": "sample_D9",
+                                "location identifier": "D9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.91,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                            "sample document": {
+                                "sample identifier": "sample_E9",
+                                "location identifier": "E9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.72,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
+                            "sample document": {
+                                "sample identifier": "sample_F9",
+                                "location identifier": "F9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.26,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                            "sample document": {
+                                "sample identifier": "sample_G9",
+                                "location identifier": "G9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.89,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                            "sample document": {
+                                "sample identifier": "sample_H9",
+                                "location identifier": "H9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.01,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -768,34 +3048,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
                             "sample document": {
-                                "sample identifier": "sample_E2",
-                                "location identifier": "E2",
+                                "sample identifier": "sample_A10",
+                                "location identifier": "A10",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.75,
+                                "value": 1.4,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
+                            "sample document": {
+                                "sample identifier": "sample_B10",
+                                "location identifier": "B10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.34,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
+                            "sample document": {
+                                "sample identifier": "sample_C10",
+                                "location identifier": "C10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.14,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                            "sample document": {
+                                "sample identifier": "sample_D10",
+                                "location identifier": "D10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.11,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                            "sample document": {
+                                "sample identifier": "sample_E10",
+                                "location identifier": "E10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.43,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
+                            "sample document": {
+                                "sample identifier": "sample_F10",
+                                "location identifier": "F10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.48,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -830,34 +3300,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                             "sample document": {
-                                "sample identifier": "sample_F2",
-                                "location identifier": "F2",
+                                "sample identifier": "sample_G10",
+                                "location identifier": "G10",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.79,
+                                "value": 1.27,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
+                            "sample document": {
+                                "sample identifier": "sample_H10",
+                                "location identifier": "H10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.2,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                            "sample document": {
+                                "sample identifier": "sample_A11",
+                                "location identifier": "A11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.21,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                            "sample document": {
+                                "sample identifier": "sample_B11",
+                                "location identifier": "B11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.04,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
+                            "sample document": {
+                                "sample identifier": "sample_C11",
+                                "location identifier": "C11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.28,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
+                            "sample document": {
+                                "sample identifier": "sample_D11",
+                                "location identifier": "D11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.19,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -892,34 +3552,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
                             "sample document": {
-                                "sample identifier": "sample_G2",
-                                "location identifier": "G2",
+                                "sample identifier": "sample_E11",
+                                "location identifier": "E11",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.7,
+                                "value": 1.19,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89"
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                            "sample document": {
+                                "sample identifier": "sample_F11",
+                                "location identifier": "F11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.62,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                            "sample document": {
+                                "sample identifier": "sample_G11",
+                                "location identifier": "G11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.09,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
+                            "sample document": {
+                                "sample identifier": "sample_H11",
+                                "location identifier": "H11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.04,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
+                            "sample document": {
+                                "sample identifier": "sample_A12",
+                                "location identifier": "A12",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.78,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89",
+                            "sample document": {
+                                "sample identifier": "sample_B12",
+                                "location identifier": "B12",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.77,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -954,4684 +3804,14 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
                             "sample document": {
-                                "sample identifier": "sample_H2",
-                                "location identifier": "H2",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.85,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                            "sample document": {
-                                "sample identifier": "sample_A3",
-                                "location identifier": "A3",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.02,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                            "sample document": {
-                                "sample identifier": "sample_B3",
-                                "location identifier": "B3",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.03,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                            "sample document": {
-                                "sample identifier": "sample_C3",
-                                "location identifier": "C3",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.21,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                            "sample document": {
-                                "sample identifier": "sample_D3",
-                                "location identifier": "D3",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.16,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                            "sample document": {
-                                "sample identifier": "sample_E3",
-                                "location identifier": "E3",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.07,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                            "sample document": {
-                                "sample identifier": "sample_F3",
-                                "location identifier": "F3",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.9,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                            "sample document": {
-                                "sample identifier": "sample_G3",
-                                "location identifier": "G3",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.83,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                            "sample document": {
-                                "sample identifier": "sample_H3",
-                                "location identifier": "H3",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.79,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                            "sample document": {
-                                "sample identifier": "sample_A4",
-                                "location identifier": "A4",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.84,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                            "sample document": {
-                                "sample identifier": "sample_B4",
-                                "location identifier": "B4",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.39,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                            "sample document": {
-                                "sample identifier": "sample_C4",
-                                "location identifier": "C4",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.12,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                            "sample document": {
-                                "sample identifier": "sample_D4",
-                                "location identifier": "D4",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.19,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                            "sample document": {
-                                "sample identifier": "sample_E4",
-                                "location identifier": "E4",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.96,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
-                            "sample document": {
-                                "sample identifier": "sample_F4",
-                                "location identifier": "F4",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.79,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
-                            "sample document": {
-                                "sample identifier": "sample_G4",
-                                "location identifier": "G4",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.76,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
-                            "sample document": {
-                                "sample identifier": "sample_H4",
-                                "location identifier": "H4",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.69,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_191"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
-                            "sample document": {
-                                "sample identifier": "sample_A5",
-                                "location identifier": "A5",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.56,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_197"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
-                            "sample document": {
-                                "sample identifier": "sample_B5",
-                                "location identifier": "B5",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.42,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_203"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
-                            "sample document": {
-                                "sample identifier": "sample_C5",
-                                "location identifier": "C5",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.44,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_209"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
-                            "sample document": {
-                                "sample identifier": "sample_D5",
-                                "location identifier": "D5",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.42,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
-                            "sample document": {
-                                "sample identifier": "sample_E5",
-                                "location identifier": "E5",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.29,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_221"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
-                            "sample document": {
-                                "sample identifier": "sample_F5",
-                                "location identifier": "F5",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.4,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_227"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
-                            "sample document": {
-                                "sample identifier": "sample_G5",
-                                "location identifier": "G5",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.17,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_233"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
-                            "sample document": {
-                                "sample identifier": "sample_H5",
-                                "location identifier": "H5",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.11,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_239"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
-                            "sample document": {
-                                "sample identifier": "sample_A6",
-                                "location identifier": "A6",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.94,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                            "sample document": {
-                                "sample identifier": "sample_B6",
-                                "location identifier": "B6",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.22,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_251"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
-                            "sample document": {
-                                "sample identifier": "sample_C6",
-                                "location identifier": "C6",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.32,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_257"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
-                            "sample document": {
-                                "sample identifier": "sample_D6",
-                                "location identifier": "D6",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.21,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_263"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
-                            "sample document": {
-                                "sample identifier": "sample_E6",
-                                "location identifier": "E6",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.24,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_269"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
-                            "sample document": {
-                                "sample identifier": "sample_F6",
-                                "location identifier": "F6",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.3,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
-                            "sample document": {
-                                "sample identifier": "sample_G6",
-                                "location identifier": "G6",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.06,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_281"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
-                            "sample document": {
-                                "sample identifier": "sample_H6",
-                                "location identifier": "H6",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.95,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_287"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
-                            "sample document": {
-                                "sample identifier": "sample_A7",
-                                "location identifier": "A7",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.13,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_293"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
-                            "sample document": {
-                                "sample identifier": "sample_B7",
-                                "location identifier": "B7",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.27,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_299"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
-                            "sample document": {
-                                "sample identifier": "sample_C7",
-                                "location identifier": "C7",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.84,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
-                            "sample document": {
-                                "sample identifier": "sample_D7",
-                                "location identifier": "D7",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.65,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_311"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
-                            "sample document": {
-                                "sample identifier": "sample_E7",
-                                "location identifier": "E7",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.06,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_317"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
-                            "sample document": {
-                                "sample identifier": "sample_F7",
-                                "location identifier": "F7",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.36,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_323"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
-                            "sample document": {
-                                "sample identifier": "sample_G7",
-                                "location identifier": "G7",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.07,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_329"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
-                            "sample document": {
-                                "sample identifier": "sample_H7",
-                                "location identifier": "H7",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.21,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
-                            "sample document": {
-                                "sample identifier": "sample_A8",
-                                "location identifier": "A8",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.62,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_341"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
-                            "sample document": {
-                                "sample identifier": "sample_B8",
-                                "location identifier": "B8",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.34,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_347"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
-                            "sample document": {
-                                "sample identifier": "sample_C8",
-                                "location identifier": "C8",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.21,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_353"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
-                            "sample document": {
-                                "sample identifier": "sample_D8",
-                                "location identifier": "D8",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.9,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_359"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
-                            "sample document": {
-                                "sample identifier": "sample_E8",
-                                "location identifier": "E8",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.79,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
-                            "sample document": {
-                                "sample identifier": "sample_F8",
-                                "location identifier": "F8",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.79,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_371"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
-                            "sample document": {
-                                "sample identifier": "sample_G8",
-                                "location identifier": "G8",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.48,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_377"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
-                            "sample document": {
-                                "sample identifier": "sample_H8",
-                                "location identifier": "H8",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.92,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_383"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
-                            "sample document": {
-                                "sample identifier": "sample_A9",
-                                "location identifier": "A9",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.1,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_389"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
-                            "sample document": {
-                                "sample identifier": "sample_B9",
-                                "location identifier": "B9",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.49,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
-                            "sample document": {
-                                "sample identifier": "sample_C9",
-                                "location identifier": "C9",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.06,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_401"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
-                            "sample document": {
-                                "sample identifier": "sample_D9",
-                                "location identifier": "D9",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.91,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_407"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
-                            "sample document": {
-                                "sample identifier": "sample_E9",
-                                "location identifier": "E9",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.72,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_413"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
-                            "sample document": {
-                                "sample identifier": "sample_F9",
-                                "location identifier": "F9",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.26,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_419"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
-                            "sample document": {
-                                "sample identifier": "sample_G9",
-                                "location identifier": "G9",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.89,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
-                            "sample document": {
-                                "sample identifier": "sample_H9",
-                                "location identifier": "H9",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.01,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_431"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_432",
-                            "sample document": {
-                                "sample identifier": "sample_A10",
-                                "location identifier": "A10",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.4,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_437"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_438",
-                            "sample document": {
-                                "sample identifier": "sample_B10",
-                                "location identifier": "B10",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.34,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_443"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_444",
-                            "sample document": {
-                                "sample identifier": "sample_C10",
-                                "location identifier": "C10",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.14,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_449"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_450",
-                            "sample document": {
-                                "sample identifier": "sample_D10",
-                                "location identifier": "D10",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.11,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_455"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_456",
-                            "sample document": {
-                                "sample identifier": "sample_E10",
-                                "location identifier": "E10",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.43,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_461"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_462",
-                            "sample document": {
-                                "sample identifier": "sample_F10",
-                                "location identifier": "F10",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.48,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_467"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_468",
-                            "sample document": {
-                                "sample identifier": "sample_G10",
-                                "location identifier": "G10",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.27,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_473"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_474",
-                            "sample document": {
-                                "sample identifier": "sample_H10",
-                                "location identifier": "H10",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.2,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_479"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_480",
-                            "sample document": {
-                                "sample identifier": "sample_A11",
-                                "location identifier": "A11",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.21,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_485"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_486",
-                            "sample document": {
-                                "sample identifier": "sample_B11",
-                                "location identifier": "B11",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.04,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_491"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_492",
-                            "sample document": {
-                                "sample identifier": "sample_C11",
-                                "location identifier": "C11",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.28,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_497"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_498",
-                            "sample document": {
-                                "sample identifier": "sample_D11",
-                                "location identifier": "D11",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.19,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_503"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_504",
-                            "sample document": {
-                                "sample identifier": "sample_E11",
-                                "location identifier": "E11",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.19,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_509"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_510",
-                            "sample document": {
-                                "sample identifier": "sample_F11",
-                                "location identifier": "F11",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.62,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_515"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_516",
-                            "sample document": {
-                                "sample identifier": "sample_G11",
-                                "location identifier": "G11",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.09,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_521"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_522",
-                            "sample document": {
-                                "sample identifier": "sample_H11",
-                                "location identifier": "H11",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.04,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_527"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_528",
-                            "sample document": {
-                                "sample identifier": "sample_A12",
-                                "location identifier": "A12",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.78,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_533"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_534",
-                            "sample document": {
-                                "sample identifier": "sample_B12",
-                                "location identifier": "B12",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.77,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_539"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_540",
-                            "sample document": {
                                 "sample identifier": "sample_C12",
                                 "location identifier": "C12",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
                                 "value": 1.46,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_545"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -5664,36 +3844,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_546",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
                             "sample document": {
                                 "sample identifier": "sample_D12",
                                 "location identifier": "D12",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
                                 "value": 0.96,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_551"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -5726,36 +3886,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_552",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
                             "sample document": {
                                 "sample identifier": "sample_E12",
                                 "location identifier": "E12",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
                                 "value": 1.0,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_557"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -5788,36 +3928,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_558",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
                             "sample document": {
                                 "sample identifier": "sample_F12",
                                 "location identifier": "F12",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
                                 "value": 0.93,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_563"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -5850,36 +3970,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_564",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
                             "sample document": {
                                 "sample identifier": "sample_G12",
                                 "location identifier": "G12",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
                                 "value": 1.04,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_569"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -5912,36 +4012,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_570",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
                             "sample document": {
                                 "sample identifier": "sample_H12",
                                 "location identifier": "H12",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
                                 "value": 0.95,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_575"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -5955,6161 +4035,13 @@
                 "analyst": "admin"
             }
         ],
-        "calculated data aggregate document": {
-            "calculated data document": [
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 61.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.15,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.76,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.88,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 48.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.46,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 35.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 2.0,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 44.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.25,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.63,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 46.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.22,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.53,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 45.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.46,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 34.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.15,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 41.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.05,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 62.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.25,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.53,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 58.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.61,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 58.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.34,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.96,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 41.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.97,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 37.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.25,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.73,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 39.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.12,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 34.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.49,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 42.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.75,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 51.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.48,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 51.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.3,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 60.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.14,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.32,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 57.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.2,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.31,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 53.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.63,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.98,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 44.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 41.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.12,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.75,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.98,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 39.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.27,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.75,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 42.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.28,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.57,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.88,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 69.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_152",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.47,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_153",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_154",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 56.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.17,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 59.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.12,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.7,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 47.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.54,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 39.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.21,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.77,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 38.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_181",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.22,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_182",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.74,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_183",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_184",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 34.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_187",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.26,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_188",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.61,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_189",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 77.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_193",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.13,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_194",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_196",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 70.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_199",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.37,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_201",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_202",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 71.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.09,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_206",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_207",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_208",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 71.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_211",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_212",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_213",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_214",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 64.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_217",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_218",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.37,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_219",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 70.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_223",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_224",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.58,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_226",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 58.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_229",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.23,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.63,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_231",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_232",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 55.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_236",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.64,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_237",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_238",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 46.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_241",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.22,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_242",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.53,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_243",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.87,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_244",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 61.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_247",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_248",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.49,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_249",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 66.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_253",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.2,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_254",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.49,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_256",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 60.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_259",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.57,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_261",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.96,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_262",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 62.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_266",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_267",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_268",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 64.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_271",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.09,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_272",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_273",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_274",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 53.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_277",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_278",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.51,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_279",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 47.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_283",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.22,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_284",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.53,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_286",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 56.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_289",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.25,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.51,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_291",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_292",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 63.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.05,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_296",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.59,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_297",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.96,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_298",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 42.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_301",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_302",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_303",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_304",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 82.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_307",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_308",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_309",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 53.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_313",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_314",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.69,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.97,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_316",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 68.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_319",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.66,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_321",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_322",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 53.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_326",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.72,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_327",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_328",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 60.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_331",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.12,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_332",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.65,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_333",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_334",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 80.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_337",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.03,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_338",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_339",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 66.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_343",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_344",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.77,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_346",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 60.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_349",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.02,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.5,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_351",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_352",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 94.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.28,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_356",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.58,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_357",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_358",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 89.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_361",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.22,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_362",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.66,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_363",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_364",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 89.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_367",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.25,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_368",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.56,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_369",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 74.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_373",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.26,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_374",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_376",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 45.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_379",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.76,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_381",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.96,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_382",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 55.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_386",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_387",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_388",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 74.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_391",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.14,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_392",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.54,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_393",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_394",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 53.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_397",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_398",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.39,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_399",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 45.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_403",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.01,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_404",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.65,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.97,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_406",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 35.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_409",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.59,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_411",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_412",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 62.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_416",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.45,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_417",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.97,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_418",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 44.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_421",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_422",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.5,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_423",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_424",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 50.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_427",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.23,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_428",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.61,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_429",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 69.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_433",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_432",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.23,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_434",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_432",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.49,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_435",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_432",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_436",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_432",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 66.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_439",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_438",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.22,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_440",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_438",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.5,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_441",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_438",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_442",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_438",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 57.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_445",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_444",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_446",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_444",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.45,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_447",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_444",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_448",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_444",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 55.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_451",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_450",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_452",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_450",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.59,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_453",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_450",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_454",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_450",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 71.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_457",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_456",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_458",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_456",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.49,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_459",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_456",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_460",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_456",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 74.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_463",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_462",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.27,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_464",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_462",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.62,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_465",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_462",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_466",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_462",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 63.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_469",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_468",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_470",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_468",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.63,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_471",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_468",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_472",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_468",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 60.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_475",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_474",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.17,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_476",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_474",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.72,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_477",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_474",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_478",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_474",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 60.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_481",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_480",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_482",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_480",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.48,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_483",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_480",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_484",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_480",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 51.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_487",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_486",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_488",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_486",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.34,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_489",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_486",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_490",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_486",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 63.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_493",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_492",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_494",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_492",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.73,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_495",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_492",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.88,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_496",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_492",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 59.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_499",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_498",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_500",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_498",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.53,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_501",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_498",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.96,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_502",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_498",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 59.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_505",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_504",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_506",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_504",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_507",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_504",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.97,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_508",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_504",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 81.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_511",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_510",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.23,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_512",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_510",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.57,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_513",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_510",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_514",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_510",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 54.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_517",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_516",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.02,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_518",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_516",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_519",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_516",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_520",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_516",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 51.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_523",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_522",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.27,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_524",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_522",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.69,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_525",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_522",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.88,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_526",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_522",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 39.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_529",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_528",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.24,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_530",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_528",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_531",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_528",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.86,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_532",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_528",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 38.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_535",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_534",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_536",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_534",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.61,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_537",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_534",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.88,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_538",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_534",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 72.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_541",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_540",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_542",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_540",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_543",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_540",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_544",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_540",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 48.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_547",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_546",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_548",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_546",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.7,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_549",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_546",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_550",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_546",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 49.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_553",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_552",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.23,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_554",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_552",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_555",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_552",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_556",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_552",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 46.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_559",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_558",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_560",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_558",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.49,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_561",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_558",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.98,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_562",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_558",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 52.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_565",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_564",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_566",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_564",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.99,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_567",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_564",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_568",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_564",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 47.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_571",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_570",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_572",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_570",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.64,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_573",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_570",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.96,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_574",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_570",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
         "data system document": {
             "ASM file identifier": "2024-07-16_CW288_Plate2.json",
             "data system instance identifier": "N/A",
             "file name": "2024-07-16_CW288_Plate2.xlsx",
             "UNC path": "tests/parsers/unchained_labs_lunatic/testdata/2024-07-16_CW288_Plate2.xlsx",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.69",
+            "ASM converter version": "0.1.74",
             "software name": "Lunatic and Stunner Analysis",
             "software version": "6.0.0.99"
         },

--- a/tests/parsers/unchained_labs_lunatic/testdata/2024-07-16_CW288_Plate2.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/2024-07-16_CW288_Plate2.json
@@ -40,6 +40,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -72,7 +85,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                             "sample document": {
                                 "sample identifier": "sample_B1",
                                 "location identifier": "B1",
@@ -90,6 +103,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -122,7 +148,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                             "sample document": {
                                 "sample identifier": "sample_C1",
                                 "location identifier": "C1",
@@ -140,6 +166,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -172,7 +211,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                             "sample document": {
                                 "sample identifier": "sample_D1",
                                 "location identifier": "D1",
@@ -190,6 +229,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -222,7 +274,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                             "sample document": {
                                 "sample identifier": "sample_E1",
                                 "location identifier": "E1",
@@ -240,54 +292,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                            "sample document": {
-                                "sample identifier": "sample_F1",
-                                "location identifier": "F1",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.91,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29"
                                     }
                                 ]
                             }
@@ -324,13 +339,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
                             "sample document": {
-                                "sample identifier": "sample_G1",
-                                "location identifier": "G1",
+                                "sample identifier": "sample_F1",
+                                "location identifier": "F1",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.7,
+                                "value": 0.91,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -338,6 +353,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35"
                                     }
                                 ]
                             }
@@ -372,7 +400,70 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
+                            "sample document": {
+                                "sample identifier": "sample_G1",
+                                "location identifier": "G1",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.7,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                             "sample document": {
                                 "sample identifier": "sample_H1",
                                 "location identifier": "H1",
@@ -390,6 +481,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -422,7 +526,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
                             "sample document": {
                                 "sample identifier": "sample_A2",
                                 "location identifier": "A2",
@@ -440,6 +544,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -472,7 +589,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
                             "sample document": {
                                 "sample identifier": "sample_B2",
                                 "location identifier": "B2",
@@ -490,104 +607,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                            "sample document": {
-                                "sample identifier": "sample_C2",
-                                "location identifier": "C2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.18,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                            "sample document": {
-                                "sample identifier": "sample_D2",
-                                "location identifier": "D2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.83,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59"
                                     }
                                 ]
                             }
@@ -624,13 +654,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
                             "sample document": {
-                                "sample identifier": "sample_E2",
-                                "location identifier": "E2",
+                                "sample identifier": "sample_C2",
+                                "location identifier": "C2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.75,
+                                "value": 1.18,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -638,6 +668,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65"
                                     }
                                 ]
                             }
@@ -672,7 +715,133 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                            "sample document": {
+                                "sample identifier": "sample_D2",
+                                "location identifier": "D2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.83,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                            "sample document": {
+                                "sample identifier": "sample_E2",
+                                "location identifier": "E2",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.75,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                             "sample document": {
                                 "sample identifier": "sample_F2",
                                 "location identifier": "F2",
@@ -690,6 +859,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -722,7 +904,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
                             "sample document": {
                                 "sample identifier": "sample_G2",
                                 "location identifier": "G2",
@@ -740,154 +922,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                            "sample document": {
-                                "sample identifier": "sample_H2",
-                                "location identifier": "H2",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.85,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                            "sample document": {
-                                "sample identifier": "sample_A3",
-                                "location identifier": "A3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.02,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
-                            "sample document": {
-                                "sample identifier": "sample_B3",
-                                "location identifier": "B3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.03,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89"
                                     }
                                 ]
                             }
@@ -924,13 +969,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
                             "sample document": {
-                                "sample identifier": "sample_C3",
-                                "location identifier": "C3",
+                                "sample identifier": "sample_H2",
+                                "location identifier": "H2",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.21,
+                                "value": 0.85,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -938,6 +983,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95"
                                     }
                                 ]
                             }
@@ -972,7 +1030,196 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
+                            "sample document": {
+                                "sample identifier": "sample_A3",
+                                "location identifier": "A3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.02,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                            "sample document": {
+                                "sample identifier": "sample_B3",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.03,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                            "sample document": {
+                                "sample identifier": "sample_C3",
+                                "location identifier": "C3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.21,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
                             "sample document": {
                                 "sample identifier": "sample_D3",
                                 "location identifier": "D3",
@@ -990,204 +1237,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                            "sample document": {
-                                "sample identifier": "sample_E3",
-                                "location identifier": "E3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.07,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
-                            "sample document": {
-                                "sample identifier": "sample_F3",
-                                "location identifier": "F3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.9,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                            "sample document": {
-                                "sample identifier": "sample_G3",
-                                "location identifier": "G3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.83,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
-                            "sample document": {
-                                "sample identifier": "sample_H3",
-                                "location identifier": "H3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.79,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119"
                                     }
                                 ]
                             }
@@ -1224,6 +1284,258 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
                             "sample document": {
+                                "sample identifier": "sample_E3",
+                                "location identifier": "E3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.07,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                            "sample document": {
+                                "sample identifier": "sample_F3",
+                                "location identifier": "F3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.9,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
+                            "sample document": {
+                                "sample identifier": "sample_G3",
+                                "location identifier": "G3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.83,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                            "sample document": {
+                                "sample identifier": "sample_H3",
+                                "location identifier": "H3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.79,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                            "sample document": {
                                 "sample identifier": "sample_A4",
                                 "location identifier": "A4",
                                 "batch identifier": "Sample Group",
@@ -1240,254 +1552,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
-                            "sample document": {
-                                "sample identifier": "sample_B4",
-                                "location identifier": "B4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.39,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
-                            "sample document": {
-                                "sample identifier": "sample_C4",
-                                "location identifier": "C4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.12,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
-                            "sample document": {
-                                "sample identifier": "sample_D4",
-                                "location identifier": "D4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.19,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
-                            "sample document": {
-                                "sample identifier": "sample_E4",
-                                "location identifier": "E4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.96,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
-                            "sample document": {
-                                "sample identifier": "sample_F4",
-                                "location identifier": "F4",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.79,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149"
                                     }
                                 ]
                             }
@@ -1524,13 +1599,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
                             "sample document": {
-                                "sample identifier": "sample_G4",
-                                "location identifier": "G4",
+                                "sample identifier": "sample_B4",
+                                "location identifier": "B4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.76,
+                                "value": 1.39,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1538,6 +1613,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155"
                                     }
                                 ]
                             }
@@ -1572,15 +1660,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
                             "sample document": {
-                                "sample identifier": "sample_H4",
-                                "location identifier": "H4",
+                                "sample identifier": "sample_C4",
+                                "location identifier": "C4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.69,
+                                "value": 1.12,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1588,6 +1676,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161"
                                     }
                                 ]
                             }
@@ -1622,15 +1723,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
                             "sample document": {
-                                "sample identifier": "sample_A5",
-                                "location identifier": "A5",
+                                "sample identifier": "sample_D4",
+                                "location identifier": "D4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.56,
+                                "value": 1.19,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1638,6 +1739,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167"
                                     }
                                 ]
                             }
@@ -1672,15 +1786,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
                             "sample document": {
-                                "sample identifier": "sample_B5",
-                                "location identifier": "B5",
+                                "sample identifier": "sample_E4",
+                                "location identifier": "E4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.42,
+                                "value": 0.96,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1688,6 +1802,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173"
                                     }
                                 ]
                             }
@@ -1722,15 +1849,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
                             "sample document": {
-                                "sample identifier": "sample_C5",
-                                "location identifier": "C5",
+                                "sample identifier": "sample_F4",
+                                "location identifier": "F4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.44,
+                                "value": 0.79,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1740,54 +1867,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
-                            "sample document": {
-                                "sample identifier": "sample_D5",
-                                "location identifier": "D5",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.42,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179"
                                     }
                                 ]
                             }
@@ -1824,13 +1914,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
                             "sample document": {
-                                "sample identifier": "sample_E5",
-                                "location identifier": "E5",
+                                "sample identifier": "sample_G4",
+                                "location identifier": "G4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.29,
+                                "value": 0.76,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1838,6 +1928,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185"
                                     }
                                 ]
                             }
@@ -1872,15 +1975,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
                             "sample document": {
-                                "sample identifier": "sample_F5",
-                                "location identifier": "F5",
+                                "sample identifier": "sample_H4",
+                                "location identifier": "H4",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.4,
+                                "value": 0.69,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1888,6 +1991,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_191"
                                     }
                                 ]
                             }
@@ -1922,15 +2038,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
                             "sample document": {
-                                "sample identifier": "sample_G5",
-                                "location identifier": "G5",
+                                "sample identifier": "sample_A5",
+                                "location identifier": "A5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.17,
+                                "value": 1.56,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1938,6 +2054,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_197"
                                     }
                                 ]
                             }
@@ -1972,15 +2101,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
                             "sample document": {
-                                "sample identifier": "sample_H5",
-                                "location identifier": "H5",
+                                "sample identifier": "sample_B5",
+                                "location identifier": "B5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.11,
+                                "value": 1.42,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1988,6 +2117,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_203"
                                     }
                                 ]
                             }
@@ -2022,15 +2164,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
                             "sample document": {
-                                "sample identifier": "sample_A6",
-                                "location identifier": "A6",
+                                "sample identifier": "sample_C5",
+                                "location identifier": "C5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.94,
+                                "value": 1.44,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2040,54 +2182,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
-                            "sample document": {
-                                "sample identifier": "sample_B6",
-                                "location identifier": "B6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.22,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_209"
                                     }
                                 ]
                             }
@@ -2124,13 +2229,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
                             "sample document": {
-                                "sample identifier": "sample_C6",
-                                "location identifier": "C6",
+                                "sample identifier": "sample_D5",
+                                "location identifier": "D5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.32,
+                                "value": 1.42,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2138,6 +2243,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215"
                                     }
                                 ]
                             }
@@ -2172,15 +2290,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
                             "sample document": {
-                                "sample identifier": "sample_D6",
-                                "location identifier": "D6",
+                                "sample identifier": "sample_E5",
+                                "location identifier": "E5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.21,
+                                "value": 1.29,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2188,6 +2306,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_221"
                                     }
                                 ]
                             }
@@ -2222,15 +2353,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
                             "sample document": {
-                                "sample identifier": "sample_E6",
-                                "location identifier": "E6",
+                                "sample identifier": "sample_F5",
+                                "location identifier": "F5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.24,
+                                "value": 1.4,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2238,6 +2369,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_227"
                                     }
                                 ]
                             }
@@ -2272,15 +2416,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
                             "sample document": {
-                                "sample identifier": "sample_F6",
-                                "location identifier": "F6",
+                                "sample identifier": "sample_G5",
+                                "location identifier": "G5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.3,
+                                "value": 1.17,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2288,6 +2432,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_233"
                                     }
                                 ]
                             }
@@ -2322,15 +2479,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
                             "sample document": {
-                                "sample identifier": "sample_G6",
-                                "location identifier": "G6",
+                                "sample identifier": "sample_H5",
+                                "location identifier": "H5",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.06,
+                                "value": 1.11,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2340,54 +2497,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
-                            "sample document": {
-                                "sample identifier": "sample_H6",
-                                "location identifier": "H6",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.95,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_239"
                                     }
                                 ]
                             }
@@ -2424,13 +2544,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
                             "sample document": {
-                                "sample identifier": "sample_A7",
-                                "location identifier": "A7",
+                                "sample identifier": "sample_A6",
+                                "location identifier": "A6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.13,
+                                "value": 0.94,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2438,6 +2558,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245"
                                     }
                                 ]
                             }
@@ -2472,15 +2605,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
                             "sample document": {
-                                "sample identifier": "sample_B7",
-                                "location identifier": "B7",
+                                "sample identifier": "sample_B6",
+                                "location identifier": "B6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.27,
+                                "value": 1.22,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2488,6 +2621,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_251"
                                     }
                                 ]
                             }
@@ -2522,15 +2668,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
                             "sample document": {
-                                "sample identifier": "sample_C7",
-                                "location identifier": "C7",
+                                "sample identifier": "sample_C6",
+                                "location identifier": "C6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.84,
+                                "value": 1.32,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2538,6 +2684,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_257"
                                     }
                                 ]
                             }
@@ -2572,15 +2731,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
                             "sample document": {
-                                "sample identifier": "sample_D7",
-                                "location identifier": "D7",
+                                "sample identifier": "sample_D6",
+                                "location identifier": "D6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.65,
+                                "value": 1.21,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2588,6 +2747,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_263"
                                     }
                                 ]
                             }
@@ -2622,15 +2794,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
                             "sample document": {
-                                "sample identifier": "sample_E7",
-                                "location identifier": "E7",
+                                "sample identifier": "sample_E6",
+                                "location identifier": "E6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.06,
+                                "value": 1.24,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2640,54 +2812,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
-                            "sample document": {
-                                "sample identifier": "sample_F7",
-                                "location identifier": "F7",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.36,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_269"
                                     }
                                 ]
                             }
@@ -2724,13 +2859,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
                             "sample document": {
-                                "sample identifier": "sample_G7",
-                                "location identifier": "G7",
+                                "sample identifier": "sample_F6",
+                                "location identifier": "F6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.07,
+                                "value": 1.3,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2738,6 +2873,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275"
                                     }
                                 ]
                             }
@@ -2772,15 +2920,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
                             "sample document": {
-                                "sample identifier": "sample_H7",
-                                "location identifier": "H7",
+                                "sample identifier": "sample_G6",
+                                "location identifier": "G6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.21,
+                                "value": 1.06,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2788,6 +2936,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_281"
                                     }
                                 ]
                             }
@@ -2822,15 +2983,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
                             "sample document": {
-                                "sample identifier": "sample_A8",
-                                "location identifier": "A8",
+                                "sample identifier": "sample_H6",
+                                "location identifier": "H6",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.62,
+                                "value": 0.95,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2838,6 +2999,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_287"
                                     }
                                 ]
                             }
@@ -2872,15 +3046,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
                             "sample document": {
-                                "sample identifier": "sample_B8",
-                                "location identifier": "B8",
+                                "sample identifier": "sample_A7",
+                                "location identifier": "A7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.34,
+                                "value": 1.13,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2888,6 +3062,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_293"
                                     }
                                 ]
                             }
@@ -2922,15 +3109,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
                             "sample document": {
-                                "sample identifier": "sample_C8",
-                                "location identifier": "C8",
+                                "sample identifier": "sample_B7",
+                                "location identifier": "B7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.21,
+                                "value": 1.27,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -2940,54 +3127,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
-                            "sample document": {
-                                "sample identifier": "sample_D8",
-                                "location identifier": "D8",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.9,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_299"
                                     }
                                 ]
                             }
@@ -3024,13 +3174,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
                             "sample document": {
-                                "sample identifier": "sample_E8",
-                                "location identifier": "E8",
+                                "sample identifier": "sample_C7",
+                                "location identifier": "C7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.79,
+                                "value": 0.84,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3038,6 +3188,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305"
                                     }
                                 ]
                             }
@@ -3072,15 +3235,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
                             "sample document": {
-                                "sample identifier": "sample_F8",
-                                "location identifier": "F8",
+                                "sample identifier": "sample_D7",
+                                "location identifier": "D7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.79,
+                                "value": 1.65,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3088,6 +3251,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_311"
                                     }
                                 ]
                             }
@@ -3122,15 +3298,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
                             "sample document": {
-                                "sample identifier": "sample_G8",
-                                "location identifier": "G8",
+                                "sample identifier": "sample_E7",
+                                "location identifier": "E7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.48,
+                                "value": 1.06,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3138,6 +3314,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_317"
                                     }
                                 ]
                             }
@@ -3172,15 +3361,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
                             "sample document": {
-                                "sample identifier": "sample_H8",
-                                "location identifier": "H8",
+                                "sample identifier": "sample_F7",
+                                "location identifier": "F7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.92,
+                                "value": 1.36,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3188,6 +3377,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_323"
                                     }
                                 ]
                             }
@@ -3222,15 +3424,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
                             "sample document": {
-                                "sample identifier": "sample_A9",
-                                "location identifier": "A9",
+                                "sample identifier": "sample_G7",
+                                "location identifier": "G7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.1,
+                                "value": 1.07,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3240,54 +3442,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
-                            "sample document": {
-                                "sample identifier": "sample_B9",
-                                "location identifier": "B9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.49,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_329"
                                     }
                                 ]
                             }
@@ -3324,13 +3489,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
                             "sample document": {
-                                "sample identifier": "sample_C9",
-                                "location identifier": "C9",
+                                "sample identifier": "sample_H7",
+                                "location identifier": "H7",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.06,
+                                "value": 1.21,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3338,6 +3503,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335"
                                     }
                                 ]
                             }
@@ -3372,15 +3550,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
                             "sample document": {
-                                "sample identifier": "sample_D9",
-                                "location identifier": "D9",
+                                "sample identifier": "sample_A8",
+                                "location identifier": "A8",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.91,
+                                "value": 1.62,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3388,6 +3566,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_341"
                                     }
                                 ]
                             }
@@ -3422,15 +3613,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
                             "sample document": {
-                                "sample identifier": "sample_E9",
-                                "location identifier": "E9",
+                                "sample identifier": "sample_B8",
+                                "location identifier": "B8",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.72,
+                                "value": 1.34,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3438,6 +3629,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_347"
                                     }
                                 ]
                             }
@@ -3472,15 +3676,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
                             "sample document": {
-                                "sample identifier": "sample_F9",
-                                "location identifier": "F9",
+                                "sample identifier": "sample_C8",
+                                "location identifier": "C8",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.26,
+                                "value": 1.21,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3488,6 +3692,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_353"
                                     }
                                 ]
                             }
@@ -3522,15 +3739,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
                             "sample document": {
-                                "sample identifier": "sample_G9",
-                                "location identifier": "G9",
+                                "sample identifier": "sample_D8",
+                                "location identifier": "D8",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.89,
+                                "value": 1.9,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3540,54 +3757,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
-                            "sample document": {
-                                "sample identifier": "sample_H9",
-                                "location identifier": "H9",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.01,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_359"
                                     }
                                 ]
                             }
@@ -3624,13 +3804,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
                             "sample document": {
-                                "sample identifier": "sample_A10",
-                                "location identifier": "A10",
+                                "sample identifier": "sample_E8",
+                                "location identifier": "E8",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.4,
+                                "value": 1.79,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3638,6 +3818,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365"
                                     }
                                 ]
                             }
@@ -3672,15 +3865,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
                             "sample document": {
-                                "sample identifier": "sample_B10",
-                                "location identifier": "B10",
+                                "sample identifier": "sample_F8",
+                                "location identifier": "F8",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.34,
+                                "value": 1.79,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3688,6 +3881,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_371"
                                     }
                                 ]
                             }
@@ -3722,160 +3928,10 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
                             "sample document": {
-                                "sample identifier": "sample_C10",
-                                "location identifier": "C10",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.14,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
-                            "sample document": {
-                                "sample identifier": "sample_D10",
-                                "location identifier": "D10",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.11,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
-                            "sample document": {
-                                "sample identifier": "sample_E10",
-                                "location identifier": "E10",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.43,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
-                            "sample document": {
-                                "sample identifier": "sample_F10",
-                                "location identifier": "F10",
+                                "sample identifier": "sample_G8",
+                                "location identifier": "G8",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
@@ -3888,6 +3944,145 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_377"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
+                            "sample document": {
+                                "sample identifier": "sample_H8",
+                                "location identifier": "H8",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.92,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_383"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
+                            "sample document": {
+                                "sample identifier": "sample_A9",
+                                "location identifier": "A9",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.1,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_389"
                                     }
                                 ]
                             }
@@ -3924,13 +4119,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_390",
                             "sample document": {
-                                "sample identifier": "sample_G10",
-                                "location identifier": "G10",
+                                "sample identifier": "sample_B9",
+                                "location identifier": "B9",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.27,
+                                "value": 1.49,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3938,6 +4133,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395"
                                     }
                                 ]
                             }
@@ -3972,15 +4180,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
                             "sample document": {
-                                "sample identifier": "sample_H10",
-                                "location identifier": "H10",
+                                "sample identifier": "sample_C9",
+                                "location identifier": "C9",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.2,
+                                "value": 1.06,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -3988,6 +4196,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_401"
                                     }
                                 ]
                             }
@@ -4022,15 +4243,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
                             "sample document": {
-                                "sample identifier": "sample_A11",
-                                "location identifier": "A11",
+                                "sample identifier": "sample_D9",
+                                "location identifier": "D9",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.21,
+                                "value": 0.91,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -4038,6 +4259,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_407"
                                     }
                                 ]
                             }
@@ -4072,15 +4306,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
                             "sample document": {
-                                "sample identifier": "sample_B11",
-                                "location identifier": "B11",
+                                "sample identifier": "sample_E9",
+                                "location identifier": "E9",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.04,
+                                "value": 0.72,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -4088,6 +4322,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_413"
                                     }
                                 ]
                             }
@@ -4122,15 +4369,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
                             "sample document": {
-                                "sample identifier": "sample_C11",
-                                "location identifier": "C11",
+                                "sample identifier": "sample_F9",
+                                "location identifier": "F9",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.28,
+                                "value": 1.26,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -4140,54 +4387,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
-                            "sample document": {
-                                "sample identifier": "sample_D11",
-                                "location identifier": "D11",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 1.19,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_419"
                                     }
                                 ]
                             }
@@ -4224,13 +4434,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_420",
                             "sample document": {
-                                "sample identifier": "sample_E11",
-                                "location identifier": "E11",
+                                "sample identifier": "sample_G9",
+                                "location identifier": "G9",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.19,
+                                "value": 0.89,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -4238,6 +4448,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425"
                                     }
                                 ]
                             }
@@ -4272,15 +4495,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
                             "sample document": {
-                                "sample identifier": "sample_F11",
-                                "location identifier": "F11",
+                                "sample identifier": "sample_H9",
+                                "location identifier": "H9",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.62,
+                                "value": 1.01,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -4288,6 +4511,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_431"
                                     }
                                 ]
                             }
@@ -4322,15 +4558,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_432",
                             "sample document": {
-                                "sample identifier": "sample_G11",
-                                "location identifier": "G11",
+                                "sample identifier": "sample_A10",
+                                "location identifier": "A10",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.09,
+                                "value": 1.4,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -4338,6 +4574,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_437"
                                     }
                                 ]
                             }
@@ -4372,15 +4621,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_435",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_438",
                             "sample document": {
-                                "sample identifier": "sample_H11",
-                                "location identifier": "H11",
+                                "sample identifier": "sample_B10",
+                                "location identifier": "B10",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.04,
+                                "value": 1.34,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -4388,6 +4637,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_443"
                                     }
                                 ]
                             }
@@ -4422,15 +4684,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_440",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_444",
                             "sample document": {
-                                "sample identifier": "sample_A12",
-                                "location identifier": "A12",
+                                "sample identifier": "sample_C10",
+                                "location identifier": "C10",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 0.78,
+                                "value": 1.14,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -4440,54 +4702,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2024-07-16T10:50:49+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "container type": "well plate"
-                },
-                "analyst": "admin"
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "firmware version": "6.0.0.85",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_445",
-                            "sample document": {
-                                "sample identifier": "sample_B12",
-                                "location identifier": "B12",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "96DWP7117"
-                            },
-                            "absorbance": {
-                                "value": 0.77,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_449"
                                     }
                                 ]
                             }
@@ -4524,13 +4749,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_450",
                             "sample document": {
-                                "sample identifier": "sample_C12",
-                                "location identifier": "C12",
+                                "sample identifier": "sample_D10",
+                                "location identifier": "D10",
                                 "batch identifier": "Sample Group",
                                 "well plate identifier": "96DWP7117"
                             },
                             "absorbance": {
-                                "value": 1.46,
+                                "value": 1.11,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -4538,6 +4763,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_455"
                                     }
                                 ]
                             }
@@ -4572,7 +4810,952 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_455",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_456",
+                            "sample document": {
+                                "sample identifier": "sample_E10",
+                                "location identifier": "E10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.43,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_461"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_462",
+                            "sample document": {
+                                "sample identifier": "sample_F10",
+                                "location identifier": "F10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.48,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_467"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_468",
+                            "sample document": {
+                                "sample identifier": "sample_G10",
+                                "location identifier": "G10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.27,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_473"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_474",
+                            "sample document": {
+                                "sample identifier": "sample_H10",
+                                "location identifier": "H10",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.2,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_479"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_480",
+                            "sample document": {
+                                "sample identifier": "sample_A11",
+                                "location identifier": "A11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.21,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_485"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_486",
+                            "sample document": {
+                                "sample identifier": "sample_B11",
+                                "location identifier": "B11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.04,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_491"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_492",
+                            "sample document": {
+                                "sample identifier": "sample_C11",
+                                "location identifier": "C11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.28,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_497"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_498",
+                            "sample document": {
+                                "sample identifier": "sample_D11",
+                                "location identifier": "D11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.19,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_503"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_504",
+                            "sample document": {
+                                "sample identifier": "sample_E11",
+                                "location identifier": "E11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.19,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_509"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_510",
+                            "sample document": {
+                                "sample identifier": "sample_F11",
+                                "location identifier": "F11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.62,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_515"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_516",
+                            "sample document": {
+                                "sample identifier": "sample_G11",
+                                "location identifier": "G11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.09,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_521"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_522",
+                            "sample document": {
+                                "sample identifier": "sample_H11",
+                                "location identifier": "H11",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.04,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_527"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_528",
+                            "sample document": {
+                                "sample identifier": "sample_A12",
+                                "location identifier": "A12",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.78,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_533"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_534",
+                            "sample document": {
+                                "sample identifier": "sample_B12",
+                                "location identifier": "B12",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 0.77,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_539"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_540",
+                            "sample document": {
+                                "sample identifier": "sample_C12",
+                                "location identifier": "C12",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "96DWP7117"
+                            },
+                            "absorbance": {
+                                "value": 1.46,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_545"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2024-07-16T10:50:49+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "container type": "well plate"
+                },
+                "analyst": "admin"
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "firmware version": "6.0.0.85",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_546",
                             "sample document": {
                                 "sample identifier": "sample_D12",
                                 "location identifier": "D12",
@@ -4590,6 +5773,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_551"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -4622,7 +5818,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_460",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_552",
                             "sample document": {
                                 "sample identifier": "sample_E12",
                                 "location identifier": "E12",
@@ -4640,6 +5836,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_557"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -4672,7 +5881,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_465",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_558",
                             "sample document": {
                                 "sample identifier": "sample_F12",
                                 "location identifier": "F12",
@@ -4690,6 +5899,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_563"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -4722,7 +5944,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_470",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_564",
                             "sample document": {
                                 "sample identifier": "sample_G12",
                                 "location identifier": "G12",
@@ -4740,6 +5962,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_569"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -4772,7 +6007,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_475",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_570",
                             "sample document": {
                                 "sample identifier": "sample_H12",
                                 "location identifier": "H12",
@@ -4788,6 +6023,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_575"
                                     }
                                 ]
                             }
@@ -4875,11 +6123,11 @@
                         "value": 48.2,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4891,11 +6139,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4907,11 +6155,11 @@
                         "value": 2.46,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4923,11 +6171,11 @@
                         "value": 1.95,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4939,11 +6187,11 @@
                         "value": 35.0,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4955,11 +6203,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4971,11 +6219,11 @@
                         "value": 2.9,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -4987,11 +6235,11 @@
                         "value": 2.0,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5003,11 +6251,11 @@
                         "value": 44.0,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5019,11 +6267,11 @@
                         "value": 0.25,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5035,11 +6283,11 @@
                         "value": 2.63,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5051,11 +6299,11 @@
                         "value": 1.9,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5067,11 +6315,11 @@
                         "value": 46.0,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5083,11 +6331,11 @@
                         "value": 0.22,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5099,11 +6347,11 @@
                         "value": 2.53,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5115,11 +6363,11 @@
                         "value": 1.91,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5129,70 +6377,6 @@
                     "calculated data name": "Concentration",
                     "calculated result": {
                         "value": 45.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.46,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 34.8,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
@@ -5208,7 +6392,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.15,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
@@ -5224,7 +6408,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.4,
+                        "value": 2.46,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
@@ -5240,7 +6424,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.91,
+                        "value": 1.94,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
@@ -5256,14 +6440,78 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 41.9,
+                        "value": 34.8,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 41.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5275,11 +6523,11 @@
                         "value": 0.05,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5291,11 +6539,11 @@
                         "value": 2.43,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5307,11 +6555,11 @@
                         "value": 1.92,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5323,11 +6571,11 @@
                         "value": 62.6,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5339,11 +6587,11 @@
                         "value": 0.25,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5355,11 +6603,11 @@
                         "value": 2.53,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5371,11 +6619,11 @@
                         "value": 1.9,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5387,11 +6635,11 @@
                         "value": 58.5,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5403,11 +6651,11 @@
                         "value": 0.16,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5419,11 +6667,11 @@
                         "value": 2.61,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5435,11 +6683,11 @@
                         "value": 1.93,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5449,134 +6697,6 @@
                     "calculated data name": "Concentration",
                     "calculated result": {
                         "value": 58.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.34,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.96,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 41.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.97,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 37.7,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
@@ -5592,7 +6712,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.25,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
@@ -5608,7 +6728,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.73,
+                        "value": 2.34,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
@@ -5624,7 +6744,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.93,
+                        "value": 1.96,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
@@ -5640,14 +6760,142 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 39.3,
+                        "value": 41.4,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.97,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 37.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.25,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.73,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 39.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5659,11 +6907,11 @@
                         "value": 0.12,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5675,11 +6923,11 @@
                         "value": 2.42,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5691,11 +6939,11 @@
                         "value": 1.9,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5707,11 +6955,11 @@
                         "value": 34.9,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5723,11 +6971,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5739,11 +6987,11 @@
                         "value": 2.49,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5755,11 +7003,11 @@
                         "value": 1.94,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -5769,198 +7017,6 @@
                     "calculated data name": "Concentration",
                     "calculated result": {
                         "value": 42.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.75,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 51.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.48,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 51.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.3,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 60.7,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
@@ -5976,7 +7032,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.14,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
@@ -5992,7 +7048,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.32,
+                        "value": 2.75,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
@@ -6008,7 +7064,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.93,
+                        "value": 1.94,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
@@ -6024,142 +7080,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 57.9,
+                        "value": 51.0,
                         "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.2,
-                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.31,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 53.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.63,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.98,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 44.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6171,11 +7099,11 @@
                         "value": 0.19,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6184,14 +7112,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.42,
+                        "value": 2.48,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6203,11 +7131,11 @@
                         "value": 1.91,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6216,14 +7144,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 41.5,
+                        "value": 51.6,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6232,14 +7160,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.12,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6248,78 +7176,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.75,
+                        "value": 2.3,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.98,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 39.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.27,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.75,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6331,11 +7195,11 @@
                         "value": 1.94,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6344,7 +7208,135 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 42.2,
+                        "value": 60.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.14,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.32,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 57.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.2,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.31,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 53.4,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
@@ -6360,7 +7352,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.28,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
@@ -6376,7 +7368,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.57,
+                        "value": 2.63,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
@@ -6392,7 +7384,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.88,
+                        "value": 1.98,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
@@ -6408,14 +7400,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 69.4,
+                        "value": 44.9,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6424,14 +7416,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.18,
+                        "value": 0.19,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6440,78 +7432,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.47,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
+                        "value": 2.42,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 56.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.17,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.4,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6520,14 +7448,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.89,
+                        "value": 1.91,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6536,14 +7464,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 59.5,
+                        "value": 41.5,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6555,11 +7483,11 @@
                         "value": 0.12,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6568,14 +7496,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.7,
+                        "value": 2.75,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6584,78 +7512,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.92,
+                        "value": 1.98,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 47.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.54,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6667,11 +7531,11 @@
                         "value": 39.4,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6680,14 +7544,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.21,
+                        "value": 0.27,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6696,14 +7560,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.77,
+                        "value": 2.75,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6712,14 +7576,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.89,
+                        "value": 1.94,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6728,7 +7592,71 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 38.2,
+                        "value": 42.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.28,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.57,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 69.4,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
@@ -6744,7 +7672,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.22,
+                        "value": 0.18,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_152",
@@ -6760,7 +7688,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.74,
+                        "value": 2.47,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_153",
@@ -6776,7 +7704,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.91,
+                        "value": 1.9,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_154",
@@ -6792,14 +7720,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 34.4,
+                        "value": 56.0,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6808,14 +7736,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.26,
+                        "value": 0.17,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -6824,206 +7752,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.61,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
+                        "value": 2.4,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 77.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.13,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 70.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.37,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 71.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.09,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7035,11 +7771,11 @@
                         "value": 1.89,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7048,14 +7784,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 71.1,
+                        "value": 59.5,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7064,14 +7800,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.12,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7080,14 +7816,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.52,
+                        "value": 2.7,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7096,14 +7832,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.94,
+                        "value": 1.92,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7112,7 +7848,135 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 64.6,
+                        "value": 47.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.54,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 39.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.21,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.77,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 38.2,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_181",
@@ -7128,7 +7992,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.22,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_182",
@@ -7144,7 +8008,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.37,
+                        "value": 2.74,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_183",
@@ -7160,7 +8024,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.94,
+                        "value": 1.91,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_184",
@@ -7176,14 +8040,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 70.1,
+                        "value": 34.4,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_187",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7192,14 +8056,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.26,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_187",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_188",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7208,30 +8072,30 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.58,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_188",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
+                        "value": 2.61,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_189",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7240,94 +8104,30 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 58.5,
+                        "value": 77.8,
                         "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_191",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.23,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.63,
-                        "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_193",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
                                 "data source feature": "absorbance"
                             }
                         ]
                     }
                 },
                 {
-                    "calculated data name": "A260/A280",
+                    "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
+                        "value": 0.13,
+                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_194",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 55.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_196",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_197",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7336,14 +8136,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.64,
+                        "value": 2.44,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7355,91 +8155,27 @@
                         "value": 1.9,
                         "unit": "(unitless)"
                     },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_196",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 70.8,
+                        "unit": "ng/µL"
+                    },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_199",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 46.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_201",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.22,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_202",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.53,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_203",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.87,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 61.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_206",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7451,11 +8187,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_207",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7464,14 +8200,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.49,
+                        "value": 2.37,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_208",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_201",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7480,14 +8216,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.92,
+                        "value": 1.95,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_209",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_202",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7496,7 +8232,71 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 66.2,
+                        "value": 71.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.09,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_206",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_207",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_208",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 71.1,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_211",
@@ -7512,7 +8312,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.2,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_212",
@@ -7528,7 +8328,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.49,
+                        "value": 2.52,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_213",
@@ -7544,7 +8344,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.92,
+                        "value": 1.94,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_214",
@@ -7560,14 +8360,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 60.7,
+                        "value": 64.6,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_217",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7579,11 +8379,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_217",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_218",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7592,206 +8392,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.57,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_218",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.96,
+                        "value": 2.37,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_219",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 62.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_221",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_223",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_224",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 64.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_226",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.09,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_227",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_229",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 53.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_231",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_232",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.51,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_233",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7803,11 +8411,11 @@
                         "value": 1.94,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7816,14 +8424,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 47.4,
+                        "value": 70.1,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_236",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_223",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7832,14 +8440,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.22,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_237",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_224",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7848,14 +8456,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.53,
+                        "value": 2.58,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_238",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7864,14 +8472,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.89,
+                        "value": 1.92,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_239",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_226",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7880,7 +8488,135 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 56.4,
+                        "value": 58.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_229",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.23,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.63,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_231",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_232",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 55.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_236",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.64,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_237",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_238",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 46.8,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_241",
@@ -7896,7 +8632,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.25,
+                        "value": 0.22,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_242",
@@ -7912,7 +8648,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.51,
+                        "value": 2.53,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_243",
@@ -7928,7 +8664,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.9,
+                        "value": 1.87,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_244",
@@ -7944,14 +8680,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 63.3,
+                        "value": 61.0,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_247",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7960,14 +8696,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.05,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_247",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_248",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7976,14 +8712,142 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.59,
+                        "value": 2.49,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_248",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_249",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 66.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_253",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.2,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_254",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.49,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_256",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 60.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_259",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.57,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_261",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -7995,203 +8859,11 @@
                         "value": 1.96,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_249",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 42.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_251",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_253",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_254",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 82.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_256",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_257",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.41,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_259",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 53.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_261",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_262",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.69,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_263",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.97,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8200,30 +8872,30 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 68.0,
+                        "value": 62.2,
                         "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_266",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_267",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8232,30 +8904,30 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.66,
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_267",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_268",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_269",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8264,7 +8936,7 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 53.3,
+                        "value": 64.9,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_271",
@@ -8280,7 +8952,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.09,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_272",
@@ -8296,7 +8968,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.72,
+                        "value": 2.52,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_273",
@@ -8312,7 +8984,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.95,
+                        "value": 1.9,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_274",
@@ -8328,14 +9000,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 60.4,
+                        "value": 53.1,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_277",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8344,14 +9016,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.12,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_277",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_278",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8360,206 +9032,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.65,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_278",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
+                        "value": 2.51,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_279",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 80.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_281",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.03,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_283",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_284",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 66.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_286",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_287",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.77,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_289",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 60.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_291",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.02,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_292",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.5,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_293",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8571,11 +9051,11 @@
                         "value": 1.94,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8584,14 +9064,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 94.8,
+                        "value": 47.4,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_296",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_283",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8600,14 +9080,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.28,
+                        "value": 0.22,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_297",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_284",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8616,14 +9096,78 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.58,
+                        "value": 2.53,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_298",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_286",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 56.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_289",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.25,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.51,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_291",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8635,11 +9179,11 @@
                         "value": 1.9,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_299",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_292",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8648,7 +9192,71 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 89.6,
+                        "value": 63.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.05,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_296",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.59,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_297",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.96,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_298",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 42.2,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_301",
@@ -8664,7 +9272,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.22,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_302",
@@ -8680,7 +9288,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.66,
+                        "value": 2.52,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_303",
@@ -8696,7 +9304,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.92,
+                        "value": 1.94,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_304",
@@ -8712,14 +9320,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 89.6,
+                        "value": 82.3,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_307",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8728,14 +9336,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.25,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_307",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_308",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8744,78 +9352,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.56,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_308",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
+                        "value": 2.41,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_309",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 74.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_311",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.26,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_313",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -8824,206 +9368,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.91,
+                        "value": 1.93,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_314",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 45.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_316",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_317",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.76,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.96,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_319",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 55.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_321",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_322",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_323",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 74.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_326",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.14,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_327",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.54,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_328",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_329",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9033,6 +9385,198 @@
                     "calculated data name": "Concentration",
                     "calculated result": {
                         "value": 53.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_313",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_314",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.69,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.97,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_316",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 68.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_319",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.66,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_321",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.95,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_322",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 53.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_326",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.72,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_327",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.95,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_328",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 60.4,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_331",
@@ -9048,7 +9592,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.12,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_332",
@@ -9064,7 +9608,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.39,
+                        "value": 2.65,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_333",
@@ -9080,7 +9624,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.92,
+                        "value": 1.93,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_334",
@@ -9096,14 +9640,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 45.7,
+                        "value": 80.9,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_337",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9112,14 +9656,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.01,
+                        "value": 0.03,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_337",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_338",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9128,270 +9672,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.65,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_338",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.97,
+                        "value": 2.52,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_339",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 35.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_341",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.59,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_343",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_344",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 62.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_346",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_347",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.45,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.97,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_349",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 44.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_351",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_352",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.5,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_353",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.93,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 50.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_356",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.23,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_357",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.61,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_358",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9403,11 +9691,11 @@
                         "value": 1.92,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_359",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9416,7 +9704,199 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 69.9,
+                        "value": 66.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_343",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_344",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.77,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_346",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 60.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_349",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.02,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.5,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_351",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_352",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 94.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.28,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_356",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.58,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_357",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_358",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 89.6,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_361",
@@ -9432,7 +9912,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.23,
+                        "value": 0.22,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_362",
@@ -9448,7 +9928,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.49,
+                        "value": 2.66,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_363",
@@ -9464,7 +9944,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.9,
+                        "value": 1.92,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_364",
@@ -9480,14 +9960,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 66.9,
+                        "value": 89.6,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_367",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9496,14 +9976,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.22,
+                        "value": 0.25,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_367",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_368",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9512,206 +9992,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.5,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_368",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.9,
+                        "value": 2.56,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_369",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 57.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_371",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.45,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_373",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_374",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 55.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_376",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_377",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.59,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_379",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 71.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_381",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_382",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.49,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_383",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9723,11 +10011,11 @@
                         "value": 1.91,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9736,14 +10024,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 74.0,
+                        "value": 74.2,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_386",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_373",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9752,14 +10040,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.27,
+                        "value": 0.26,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_387",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_374",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9768,30 +10056,158 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.62,
+                        "value": 2.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_375",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_376",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 45.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_379",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_380",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.76,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_381",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.96,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_382",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_378",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 55.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_386",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_387",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_388",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.91,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_389",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_385",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_384",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9800,7 +10216,7 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 63.4,
+                        "value": 74.7,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_391",
@@ -9816,7 +10232,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.16,
+                        "value": 0.14,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_392",
@@ -9832,7 +10248,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.63,
+                        "value": 2.54,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_393",
@@ -9848,7 +10264,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.9,
+                        "value": 1.91,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_394",
@@ -9864,14 +10280,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 60.1,
+                        "value": 53.2,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_397",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9880,14 +10296,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.17,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_397",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_398",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9896,30 +10312,30 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.72,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_398",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
+                        "value": 2.39,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_399",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_395",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_396",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9928,62 +10344,62 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 60.5,
+                        "value": 45.7,
                         "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_401",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.48,
-                        "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_403",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
                                 "data source feature": "absorbance"
                             }
                         ]
                     }
                 },
                 {
-                    "calculated data name": "A260/A280",
+                    "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 1.95,
-                        "unit": "(unitless)"
+                        "value": 0.01,
+                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_404",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_400",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.65,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.97,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_406",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_402",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -9992,14 +10408,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 51.9,
+                        "value": 35.9,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_406",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_409",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10011,11 +10427,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_407",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10024,14 +10440,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.34,
+                        "value": 2.59,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_411",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10043,75 +10459,11 @@
                         "value": 1.95,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_409",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_405",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 63.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_411",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_412",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.73,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_413",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.88,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_410",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_408",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10120,14 +10472,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 59.3,
+                        "value": 62.8,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_416",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10139,11 +10491,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_417",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_416",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10152,30 +10504,30 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.53,
+                        "value": 2.45,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_417",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.97,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_418",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.96,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_419",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_415",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_414",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10184,7 +10536,7 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 59.4,
+                        "value": 44.5,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_421",
@@ -10200,7 +10552,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.18,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_422",
@@ -10216,7 +10568,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.43,
+                        "value": 2.5,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_423",
@@ -10232,7 +10584,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.97,
+                        "value": 1.93,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_424",
@@ -10248,14 +10600,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 81.0,
+                        "value": 50.4,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_427",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10267,267 +10619,11 @@
                         "value": 0.23,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_427",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.57,
-                        "unit": "(unitless)"
-                    },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_428",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_429",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_425",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 54.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_431",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.02,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_432",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_433",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_434",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 51.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_436",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_435",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.27,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_437",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_435",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.69,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_438",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_435",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.88,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_439",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_435",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 39.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_441",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_440",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.24,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_442",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_440",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_443",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_440",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.86,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_444",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_440",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 38.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_446",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_445",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_447",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_445",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10539,11 +10635,11 @@
                         "value": 2.61,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_448",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_429",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_445",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10552,14 +10648,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.88,
+                        "value": 1.92,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_449",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_430",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_445",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_426",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10568,7 +10664,199 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 72.8,
+                        "value": 69.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_433",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_432",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.23,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_434",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_432",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.49,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_435",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_432",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_436",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_432",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 66.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_439",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_438",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.22,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_440",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_438",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.5,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_441",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_438",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_442",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_438",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 57.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_445",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_444",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_446",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_444",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.45,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_447",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_444",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_448",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_444",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 55.5,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_451",
@@ -10600,7 +10888,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.4,
+                        "value": 2.59,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_453",
@@ -10616,7 +10904,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.93,
+                        "value": 1.95,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_454",
@@ -10632,206 +10920,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 48.2,
+                        "value": 71.4,
                         "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_456",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_455",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.16,
-                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_457",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_455",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.7,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_458",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_455",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_459",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_455",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 49.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_461",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_460",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.23,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_462",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_460",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_463",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_460",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.92,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_464",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_460",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 46.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_466",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_465",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_467",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_465",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.49,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_468",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_465",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.98,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_469",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_465",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 52.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_471",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_470",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_456",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10843,11 +10939,11 @@
                         "value": 0.19,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_472",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_458",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_470",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_456",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10856,14 +10952,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.99,
+                        "value": 2.49,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_473",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_459",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_470",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_456",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10872,14 +10968,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.92,
+                        "value": 1.91,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_474",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_460",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_470",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_456",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10888,14 +10984,206 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 47.7,
+                        "value": 74.0,
                         "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_463",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_462",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.27,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_464",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_462",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.62,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_465",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_462",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.91,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_466",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_462",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 63.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_469",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_468",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_470",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_468",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.63,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_471",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_468",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.9,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_472",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_468",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 60.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_475",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_474",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.17,
+                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_476",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_475",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_474",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.72,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_477",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_474",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_478",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_474",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 60.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_481",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_480",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10907,11 +11195,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_477",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_482",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_475",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_480",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10920,14 +11208,206 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.64,
+                        "value": 2.48,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_478",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_483",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_475",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_480",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.95,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_484",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_480",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 51.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_487",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_486",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_488",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_486",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.34,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_489",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_486",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.95,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_490",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_486",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 63.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_493",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_492",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_494",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_492",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.73,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_495",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_492",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_496",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_492",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 59.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_499",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_498",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_500",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_498",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.53,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_501",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_498",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -10939,11 +11419,779 @@
                         "value": 1.96,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_479",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_502",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_475",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_498",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 59.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_505",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_504",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_506",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_504",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.43,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_507",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_504",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.97,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_508",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_504",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 81.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_511",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_510",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.23,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_512",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_510",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.57,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_513",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_510",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_514",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_510",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 54.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_517",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_516",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.02,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_518",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_516",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_519",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_516",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_520",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_516",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 51.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_523",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_522",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.27,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_524",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_522",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.69,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_525",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_522",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_526",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_522",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 39.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_529",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_528",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.24,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_530",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_528",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_531",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_528",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.86,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_532",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_528",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 38.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_535",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_534",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_536",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_534",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.61,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_537",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_534",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.88,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_538",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_534",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 72.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_541",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_540",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_542",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_540",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.4,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_543",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_540",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.93,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_544",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_540",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 48.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_547",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_546",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.16,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_548",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_546",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.7,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_549",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_546",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_550",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_546",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 49.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_553",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_552",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.23,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_554",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_552",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_555",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_552",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_556",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_552",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 46.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_559",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_558",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_560",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_558",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.49,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_561",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_558",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.98,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_562",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_558",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 52.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_565",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_564",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_566",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_564",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.99,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_567",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_564",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.92,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_568",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_564",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 47.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_571",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_570",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_572",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_570",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.64,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_573",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_570",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.96,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_574",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_570",
                                 "data source feature": "absorbance"
                             }
                         ]

--- a/tests/parsers/unchained_labs_lunatic/testdata/Demo_A260_dsDNA_Data.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Demo_A260_dsDNA_Data.json
@@ -32,6 +32,22 @@
                             "absorbance": {
                                 "value": -0.0,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A230"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A280"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -64,7 +80,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "B1",
@@ -77,6 +93,10 @@
                             },
                             "error aggregate document": {
                                 "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
                                     {
                                         "error": "N/A",
                                         "error feature": "absorbance"
@@ -114,7 +134,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
                             "sample document": {
                                 "sample identifier": "Sample 3",
                                 "location identifier": "C1",
@@ -124,426 +144,14 @@
                             "absorbance": {
                                 "value": 2.03,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
-                            "sample document": {
-                                "sample identifier": "Sample 7",
-                                "location identifier": "D1",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.49,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                            "sample document": {
-                                "sample identifier": "Sample 2",
-                                "location identifier": "E1",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 5.01,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
-                            "sample document": {
-                                "sample identifier": "Sample 6",
-                                "location identifier": "F1",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.6,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                            "sample document": {
-                                "sample identifier": "Sample 1",
-                                "location identifier": "G1",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 10.04,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
-                            "sample document": {
-                                "sample identifier": "Sample 5",
-                                "location identifier": "H1",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.79,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
-                            "sample document": {
-                                "sample identifier": "Sample 1",
-                                "location identifier": "A2",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 10.19,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
-                            "sample document": {
-                                "sample identifier": "Sample 5",
-                                "location identifier": "B2",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.77,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
-                            "sample document": {
-                                "sample identifier": "H2O",
-                                "location identifier": "C2",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": -0.0,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
-                            "sample document": {
-                                "sample identifier": "Sample 4",
-                                "location identifier": "D2",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.99,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                            "sample document": {
-                                "sample identifier": "Sample 3",
-                                "location identifier": "E2",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 2.02,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -579,181 +187,21 @@
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
                             "sample document": {
                                 "sample identifier": "Sample 7",
-                                "location identifier": "F2",
+                                "location identifier": "D1",
                                 "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": 0.49,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
-                            "sample document": {
-                                "sample identifier": "Sample 2",
-                                "location identifier": "G2",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 5.01,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
-                            "sample document": {
-                                "sample identifier": "Sample 6",
-                                "location identifier": "H2",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.6,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
-                            "sample document": {
-                                "sample identifier": "Sample 2",
-                                "location identifier": "A3",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 5.03,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
-                            "sample document": {
-                                "sample identifier": "Sample 6",
-                                "location identifier": "B3",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.59,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -788,182 +236,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                             "sample document": {
-                                "sample identifier": "Sample 1",
-                                "location identifier": "C3",
+                                "sample identifier": "Sample 2",
+                                "location identifier": "E1",
                                 "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
-                                "value": 10.09,
+                                "value": 5.01,
                                 "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "error aggregate document": {
+                                "error document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
                                     }
                                 ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
-                            "sample document": {
-                                "sample identifier": "Sample 5",
-                                "location identifier": "D3",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.81,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
-                            "sample document": {
-                                "sample identifier": "H2O",
-                                "location identifier": "E3",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": -0.0,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
-                            "sample document": {
-                                "sample identifier": "Sample 4",
-                                "location identifier": "F3",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.98,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                            "sample document": {
-                                "sample identifier": "Sample 3",
-                                "location identifier": "G3",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 1.98,
-                                "unit": "mAU"
                             }
                         }
                     ],
@@ -998,182 +286,22 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
                             "sample document": {
-                                "sample identifier": "Sample 7",
-                                "location identifier": "H3",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.49,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                            "sample document": {
-                                "sample identifier": "Sample 3",
-                                "location identifier": "A4",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 2.02,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                            "sample document": {
-                                "sample identifier": "Sample 7",
-                                "location identifier": "B4",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.49,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                            "sample document": {
-                                "sample identifier": "Sample 2",
-                                "location identifier": "C4",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 5.02,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
-                            "sample document": {
                                 "sample identifier": "Sample 6",
-                                "location identifier": "D4",
+                                "location identifier": "F1",
                                 "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": 0.6,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -1209,13 +337,21 @@
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
                             "sample document": {
                                 "sample identifier": "Sample 1",
-                                "location identifier": "E4",
+                                "location identifier": "G1",
                                 "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
-                                "value": 10.05,
+                                "value": 10.04,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -1248,7 +384,1123 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
+                            "sample document": {
+                                "sample identifier": "Sample 5",
+                                "location identifier": "H1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.79,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                            "sample document": {
+                                "sample identifier": "Sample 1",
+                                "location identifier": "A2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 10.19,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                            "sample document": {
+                                "sample identifier": "Sample 5",
+                                "location identifier": "B2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.77,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                            "sample document": {
+                                "sample identifier": "H2O",
+                                "location identifier": "C2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": -0.0,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A230"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A280"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                            "sample document": {
+                                "sample identifier": "Sample 4",
+                                "location identifier": "D2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.99,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                            "sample document": {
+                                "sample identifier": "Sample 3",
+                                "location identifier": "E2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 2.02,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                            "sample document": {
+                                "sample identifier": "Sample 7",
+                                "location identifier": "F2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.49,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                            "sample document": {
+                                "sample identifier": "Sample 2",
+                                "location identifier": "G2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 5.01,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                            "sample document": {
+                                "sample identifier": "Sample 6",
+                                "location identifier": "H2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.6,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                            "sample document": {
+                                "sample identifier": "Sample 2",
+                                "location identifier": "A3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 5.03,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                            "sample document": {
+                                "sample identifier": "Sample 6",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.59,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                            "sample document": {
+                                "sample identifier": "Sample 1",
+                                "location identifier": "C3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 10.09,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                            "sample document": {
+                                "sample identifier": "Sample 5",
+                                "location identifier": "D3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.81,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
+                            "sample document": {
+                                "sample identifier": "H2O",
+                                "location identifier": "E3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": -0.0,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A230"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A280"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
+                            "sample document": {
+                                "sample identifier": "Sample 4",
+                                "location identifier": "F3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.98,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
+                            "sample document": {
+                                "sample identifier": "Sample 3",
+                                "location identifier": "G3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 1.98,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                            "sample document": {
+                                "sample identifier": "Sample 7",
+                                "location identifier": "H3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.49,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                            "sample document": {
+                                "sample identifier": "Sample 3",
+                                "location identifier": "A4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 2.02,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
+                            "sample document": {
+                                "sample identifier": "Sample 7",
+                                "location identifier": "B4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.49,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
+                            "sample document": {
+                                "sample identifier": "Sample 2",
+                                "location identifier": "C4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 5.02,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
+                            "sample document": {
+                                "sample identifier": "Sample 6",
+                                "location identifier": "D4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.6,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
+                            "sample document": {
+                                "sample identifier": "Sample 1",
+                                "location identifier": "E4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 10.05,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
                             "sample document": {
                                 "sample identifier": "Sample 5",
                                 "location identifier": "F4",
@@ -1258,6 +1510,14 @@
                             "absorbance": {
                                 "value": 0.78,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -1290,7 +1550,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
                             "sample document": {
                                 "sample identifier": "H2O",
                                 "location identifier": "G4",
@@ -1300,6 +1560,22 @@
                             "absorbance": {
                                 "value": -0.01,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A230"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A280"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -1332,7 +1608,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "H4",
@@ -1342,6 +1618,14 @@
                             "absorbance": {
                                 "value": 0.98,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -1355,6 +1639,1930 @@
                 }
             }
         ],
+        "calculated data aggregate document": {
+            "calculated data document": [
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": -0.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.05,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 49.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.51,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.84,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 101.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.07,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.46,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 24.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.03,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.74,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.84,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 250.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.45,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 29.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.56,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 501.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.02,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.43,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 39.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.64,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.84,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 509.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 38.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.06,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.72,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.86,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": -0.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 49.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.52,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.84,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 100.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.49,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 24.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 3.13,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 250.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 29.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.02,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.56,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.81,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 251.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.43,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 29.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.74,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.87,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 504.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.43,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 40.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.51,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.87,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": -0.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 49.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.12,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.74,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.84,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 99.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.6,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.86,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 24.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.72,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.83,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 100.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.01,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.47,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.84,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 24.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.07,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.86,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 250.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.43,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 30.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.02,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.71,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.84,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 502.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 39.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.66,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.83,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": -0.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 49.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.63,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.87,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
         "data system document": {
             "ASM file identifier": "Demo_A260_dsDNA_Data.json",
             "data system instance identifier": "N/A",

--- a/tests/parsers/unchained_labs_lunatic/testdata/Demo_A260_dsDNA_Data.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Demo_A260_dsDNA_Data.json
@@ -48,6 +48,19 @@
                                         "error feature": "A260/A280"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -80,7 +93,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "B1",
@@ -102,6 +115,19 @@
                                         "error feature": "absorbance"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -134,7 +160,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
                             "sample document": {
                                 "sample identifier": "Sample 3",
                                 "location identifier": "C1",
@@ -152,6 +178,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -184,7 +223,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
                             "sample document": {
                                 "sample identifier": "Sample 7",
                                 "location identifier": "D1",
@@ -202,6 +241,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -234,7 +286,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
                             "sample document": {
                                 "sample identifier": "Sample 2",
                                 "location identifier": "E1",
@@ -252,54 +304,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
-                            "sample document": {
-                                "sample identifier": "Sample 6",
-                                "location identifier": "F1",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.6,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27"
                                     }
                                 ]
                             }
@@ -336,13 +351,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
                             "sample document": {
-                                "sample identifier": "Sample 1",
-                                "location identifier": "G1",
+                                "sample identifier": "Sample 6",
+                                "location identifier": "F1",
                                 "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
-                                "value": 10.04,
+                                "value": 0.6,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -350,6 +365,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33"
                                     }
                                 ]
                             }
@@ -384,7 +412,70 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
+                            "sample document": {
+                                "sample identifier": "Sample 1",
+                                "location identifier": "G1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 10.04,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
                             "sample document": {
                                 "sample identifier": "Sample 5",
                                 "location identifier": "H1",
@@ -402,6 +493,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -434,7 +538,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
                             "sample document": {
                                 "sample identifier": "Sample 1",
                                 "location identifier": "A2",
@@ -452,6 +556,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -484,7 +601,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
                             "sample document": {
                                 "sample identifier": "Sample 5",
                                 "location identifier": "B2",
@@ -502,6 +619,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -534,7 +664,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
                             "sample document": {
                                 "sample identifier": "H2O",
                                 "location identifier": "C2",
@@ -560,6 +690,19 @@
                                         "error feature": "A260/A280"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -592,7 +735,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "D2",
@@ -610,6 +753,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -642,7 +798,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
                             "sample document": {
                                 "sample identifier": "Sample 3",
                                 "location identifier": "E2",
@@ -660,6 +816,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -692,7 +861,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
                             "sample document": {
                                 "sample identifier": "Sample 7",
                                 "location identifier": "F2",
@@ -710,6 +879,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -742,7 +924,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
                             "sample document": {
                                 "sample identifier": "Sample 2",
                                 "location identifier": "G2",
@@ -760,154 +942,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
-                            "sample document": {
-                                "sample identifier": "Sample 6",
-                                "location identifier": "H2",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.6,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
-                            "sample document": {
-                                "sample identifier": "Sample 2",
-                                "location identifier": "A3",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 5.03,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
-                            "sample document": {
-                                "sample identifier": "Sample 6",
-                                "location identifier": "B3",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.59,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85"
                                     }
                                 ]
                             }
@@ -944,13 +989,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
                             "sample document": {
-                                "sample identifier": "Sample 1",
-                                "location identifier": "C3",
+                                "sample identifier": "Sample 6",
+                                "location identifier": "H2",
                                 "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
-                                "value": 10.09,
+                                "value": 0.6,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -958,6 +1003,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91"
                                     }
                                 ]
                             }
@@ -992,15 +1050,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
                             "sample document": {
-                                "sample identifier": "Sample 5",
-                                "location identifier": "D3",
+                                "sample identifier": "Sample 2",
+                                "location identifier": "A3",
                                 "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
-                                "value": 0.81,
+                                "value": 5.03,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1008,6 +1066,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97"
                                     }
                                 ]
                             }
@@ -1042,15 +1113,15 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
                             "sample document": {
-                                "sample identifier": "H2O",
-                                "location identifier": "E3",
+                                "sample identifier": "Sample 6",
+                                "location identifier": "B3",
                                 "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
-                                "value": -0.0,
+                                "value": 0.59,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1058,64 +1129,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A230"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A280"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
-                            "sample document": {
-                                "sample identifier": "Sample 4",
-                                "location identifier": "F3",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.98,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103"
                                     }
                                 ]
                             }
@@ -1152,13 +1178,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
                             "sample document": {
-                                "sample identifier": "Sample 3",
-                                "location identifier": "G3",
+                                "sample identifier": "Sample 1",
+                                "location identifier": "C3",
                                 "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
-                                "value": 1.98,
+                                "value": 10.09,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1166,6 +1192,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109"
                                     }
                                 ]
                             }
@@ -1200,7 +1239,267 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                            "sample document": {
+                                "sample identifier": "Sample 5",
+                                "location identifier": "D3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.81,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
+                            "sample document": {
+                                "sample identifier": "H2O",
+                                "location identifier": "E3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": -0.0,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A230"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A280"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                            "sample document": {
+                                "sample identifier": "Sample 4",
+                                "location identifier": "F3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.98,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                            "sample document": {
+                                "sample identifier": "Sample 3",
+                                "location identifier": "G3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 1.98,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
                             "sample document": {
                                 "sample identifier": "Sample 7",
                                 "location identifier": "H3",
@@ -1218,6 +1517,19 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -1250,7 +1562,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
                             "sample document": {
                                 "sample identifier": "Sample 3",
                                 "location identifier": "A4",
@@ -1268,254 +1580,17 @@
                                         "error feature": "Concentration"
                                     }
                                 ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
                                         },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
-                            "sample document": {
-                                "sample identifier": "Sample 7",
-                                "location identifier": "B4",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.49,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
-                            "sample document": {
-                                "sample identifier": "Sample 2",
-                                "location identifier": "C4",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 5.02,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
-                            "sample document": {
-                                "sample identifier": "Sample 6",
-                                "location identifier": "D4",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.6,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
-                            "sample document": {
-                                "sample identifier": "Sample 1",
-                                "location identifier": "E4",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 10.05,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
-                            "sample document": {
-                                "sample identifier": "Sample 5",
-                                "location identifier": "F4",
-                                "batch identifier": "Sample Group 1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.78,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143"
                                     }
                                 ]
                             }
@@ -1552,13 +1627,13 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
                             "sample document": {
-                                "sample identifier": "H2O",
-                                "location identifier": "G4",
+                                "sample identifier": "Sample 7",
+                                "location identifier": "B4",
                                 "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
-                                "value": -0.01,
+                                "value": 0.49,
                                 "unit": "mAU"
                             },
                             "error aggregate document": {
@@ -1566,14 +1641,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
-                                    },
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "A260/A230"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A280"
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149"
                                     }
                                 ]
                             }
@@ -1608,7 +1688,330 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                            "sample document": {
+                                "sample identifier": "Sample 2",
+                                "location identifier": "C4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 5.02,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
+                            "sample document": {
+                                "sample identifier": "Sample 6",
+                                "location identifier": "D4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.6,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
+                            "sample document": {
+                                "sample identifier": "Sample 1",
+                                "location identifier": "E4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 10.05,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                            "sample document": {
+                                "sample identifier": "Sample 5",
+                                "location identifier": "F4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.78,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                            "sample document": {
+                                "sample identifier": "H2O",
+                                "location identifier": "G4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": -0.01,
+                                "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A230"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A280"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "H4",
@@ -1624,6 +2027,19 @@
                                     {
                                         "error": "N/A",
                                         "error feature": "Concentration"
+                                    }
+                                ]
+                            },
+                            "processed data aggregate document": {
+                                "processed data document": [
+                                    {
+                                        "data processing document": {
+                                            "concentration factor": {
+                                                "value": 50.0,
+                                                "unit": "ng/µL"
+                                            }
+                                        },
+                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_183"
                                     }
                                 ]
                             }
@@ -1679,11 +2095,11 @@
                         "value": 49.8,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1695,11 +2111,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1711,11 +2127,11 @@
                         "value": 2.51,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1727,11 +2143,11 @@
                         "value": 1.84,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1743,11 +2159,11 @@
                         "value": 101.3,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1759,11 +2175,11 @@
                         "value": 0.07,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1775,11 +2191,11 @@
                         "value": 2.46,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1791,11 +2207,11 @@
                         "value": 1.85,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1807,11 +2223,11 @@
                         "value": 24.7,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1823,11 +2239,11 @@
                         "value": 0.03,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1839,11 +2255,11 @@
                         "value": 2.74,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1855,11 +2271,11 @@
                         "value": 1.84,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1871,11 +2287,11 @@
                         "value": 250.7,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1887,11 +2303,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1903,11 +2319,11 @@
                         "value": 2.45,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1919,11 +2335,11 @@
                         "value": 1.85,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -1933,70 +2349,6 @@
                     "calculated data name": "Concentration",
                     "calculated result": {
                         "value": 29.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.56,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 501.8,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
@@ -2012,7 +2364,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.02,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
@@ -2028,7 +2380,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.43,
+                        "value": 2.56,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
@@ -2060,494 +2412,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 39.5,
+                        "value": 501.8,
                         "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.64,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.84,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 509.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 38.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.06,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.72,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.86,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": -0.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 49.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.84,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 100.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.15,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.49,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 24.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 3.13,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 250.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 29.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2559,75 +2431,11 @@
                         "value": 0.02,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.56,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.81,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 251.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2639,11 +2447,11 @@
                         "value": 2.43,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2655,11 +2463,11 @@
                         "value": 1.85,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2668,14 +2476,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 29.7,
+                        "value": 39.5,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2687,11 +2495,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2700,14 +2508,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.74,
+                        "value": 2.64,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2716,14 +2524,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.87,
+                        "value": 1.84,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2732,7 +2540,423 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 504.3,
+                        "value": 509.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 38.5,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.06,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.72,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.86,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": -0.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 49.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.52,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.84,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 100.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.15,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.49,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 24.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 3.13,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 250.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.44,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 29.9,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
@@ -2748,7 +2972,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.02,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
@@ -2764,7 +2988,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.43,
+                        "value": 2.56,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89",
@@ -2780,7 +3004,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.85,
+                        "value": 1.81,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
@@ -2796,14 +3020,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 40.3,
+                        "value": 251.6,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2815,11 +3039,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2828,14 +3052,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.51,
+                        "value": 2.43,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2844,14 +3068,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.87,
+                        "value": 1.85,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2860,14 +3084,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": -0.2,
+                        "value": 29.7,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2879,43 +3103,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 49.1,
-                        "unit": "ng/µL"
-                    },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.12,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2927,11 +3119,11 @@
                         "value": 2.74,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2940,14 +3132,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.84,
+                        "value": 1.87,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -2956,7 +3148,7 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 99.2,
+                        "value": 504.3,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
@@ -2988,7 +3180,7 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.6,
+                        "value": 2.43,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107",
@@ -3004,7 +3196,7 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.86,
+                        "value": 1.85,
                         "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
@@ -3020,14 +3212,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 24.4,
+                        "value": 40.3,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3039,11 +3231,11 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3052,14 +3244,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.72,
+                        "value": 2.51,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3068,14 +3260,14 @@
                 {
                     "calculated data name": "A260/A280",
                     "calculated result": {
-                        "value": 1.83,
+                        "value": 1.87,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3084,14 +3276,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 100.8,
+                        "value": -0.2,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3100,14 +3292,46 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.01,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 49.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.12,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3116,14 +3340,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.47,
+                        "value": 2.74,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3135,11 +3359,11 @@
                         "value": 1.84,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3148,14 +3372,14 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 24.5,
+                        "value": 99.2,
                         "unit": "ng/µL"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3164,14 +3388,14 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.07,
+                        "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3180,14 +3404,14 @@
                 {
                     "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 2.89,
+                        "value": 2.6,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3199,251 +3423,59 @@
                         "value": 1.86,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 250.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 30.0,
-                        "unit": "ng/µL"
-                    },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
                                 "data source feature": "absorbance"
                             }
                         ]
                     }
                 },
                 {
-                    "calculated data name": "Background (A260)",
+                    "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": 0.02,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.71,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.84,
-                        "unit": "(unitless)"
+                        "value": 24.4,
+                        "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
                                 "data source feature": "absorbance"
                             }
                         ]
                     }
                 },
                 {
-                    "calculated data name": "Concentration",
+                    "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 502.3,
-                        "unit": "ng/µL"
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.72,
+                        "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 39.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.66,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3455,11 +3487,11 @@
                         "value": 1.83,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3468,7 +3500,71 @@
                 {
                     "calculated data name": "Concentration",
                     "calculated result": {
-                        "value": -0.4,
+                        "value": 100.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.01,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.47,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.84,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 24.5,
                         "unit": "ng/µL"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
@@ -3484,7 +3580,7 @@
                 {
                     "calculated data name": "Background (A260)",
                     "calculated result": {
-                        "value": 0.0,
+                        "value": 0.07,
                         "unit": "mAU"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
@@ -3498,16 +3594,48 @@
                     }
                 },
                 {
-                    "calculated data name": "Concentration",
+                    "calculated data name": "A260/A230",
                     "calculated result": {
-                        "value": 49.2,
-                        "unit": "ng/µL"
+                        "value": 2.89,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.86,
+                        "unit": "(unitless)"
                     },
                     "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 250.9,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3519,11 +3647,299 @@
                         "value": 0.0,
                         "unit": "mAU"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_152",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.43,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_153",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_154",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 30.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.02,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.71,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.84,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 502.3,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.42,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.85,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 39.1,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.66,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.83,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": -0.4,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 49.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A260)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3535,11 +3951,11 @@
                         "value": 2.63,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_181",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
                                 "data source feature": "absorbance"
                             }
                         ]
@@ -3551,11 +3967,11 @@
                         "value": 1.87,
                         "unit": "(unitless)"
                     },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_182",
                     "data source aggregate document": {
                         "data source document": [
                             {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
                                 "data source feature": "absorbance"
                             }
                         ]

--- a/tests/parsers/unchained_labs_lunatic/testdata/Demo_A260_dsDNA_Data.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Demo_A260_dsDNA_Data.json
@@ -26,6 +26,49 @@
                             "sample document": {
                                 "sample identifier": "H2O",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": -0.0,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                            "sample document": {
+                                "sample identifier": "Sample 4",
+                                "location identifier": "B1",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -36,30 +79,93 @@
                                 "error document": [
                                     {
                                         "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
+                                        "error feature": "absorbance"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "A260/A230"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A280"
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
                             },
-                            "processed data aggregate document": {
-                                "processed data document": [
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                            "sample document": {
+                                "sample identifier": "Sample 3",
+                                "location identifier": "C1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 2.03,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3"
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                            "sample document": {
+                                "sample identifier": "Sample 7",
+                                "location identifier": "D1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.49,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -94,38 +200,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
                             "sample document": {
-                                "sample identifier": "Sample 4",
-                                "location identifier": "B1",
+                                "sample identifier": "Sample 2",
+                                "location identifier": "E1",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
-                                "value": -0.0,
+                                "value": 5.01,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "absorbance"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9"
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                            "sample document": {
+                                "sample identifier": "Sample 6",
+                                "location identifier": "F1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.6,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                            "sample document": {
+                                "sample identifier": "Sample 1",
+                                "location identifier": "G1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 10.04,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                            "sample document": {
+                                "sample identifier": "Sample 5",
+                                "location identifier": "H1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.79,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                            "sample document": {
+                                "sample identifier": "Sample 1",
+                                "location identifier": "A2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 10.19,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
+                            "sample document": {
+                                "sample identifier": "Sample 5",
+                                "location identifier": "B2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.77,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -160,34 +452,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
                             "sample document": {
-                                "sample identifier": "Sample 3",
-                                "location identifier": "C1",
+                                "sample identifier": "H2O",
+                                "location identifier": "C2",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
-                                "value": 2.03,
+                                "value": -0.0,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15"
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
+                            "sample document": {
+                                "sample identifier": "Sample 4",
+                                "location identifier": "D2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.99,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
+                            "sample document": {
+                                "sample identifier": "Sample 3",
+                                "location identifier": "E2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 2.02,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                            "sample document": {
+                                "sample identifier": "Sample 7",
+                                "location identifier": "F2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.49,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                            "sample document": {
+                                "sample identifier": "Sample 2",
+                                "location identifier": "G2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 5.01,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                            "sample document": {
+                                "sample identifier": "Sample 6",
+                                "location identifier": "H2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.6,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -222,34 +704,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
                             "sample document": {
-                                "sample identifier": "Sample 7",
-                                "location identifier": "D1",
+                                "sample identifier": "Sample 2",
+                                "location identifier": "A3",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
-                                "value": 0.49,
+                                "value": 5.03,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21"
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
+                            "sample document": {
+                                "sample identifier": "Sample 6",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.59,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                            "sample document": {
+                                "sample identifier": "Sample 1",
+                                "location identifier": "C3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 10.09,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
+                            "sample document": {
+                                "sample identifier": "Sample 5",
+                                "location identifier": "D3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.81,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                            "sample document": {
+                                "sample identifier": "H2O",
+                                "location identifier": "E3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": -0.0,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
+                            "sample document": {
+                                "sample identifier": "Sample 4",
+                                "location identifier": "F3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.98,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -284,34 +956,224 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
                             "sample document": {
-                                "sample identifier": "Sample 2",
-                                "location identifier": "E1",
+                                "sample identifier": "Sample 3",
+                                "location identifier": "G3",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
-                                "value": 5.01,
+                                "value": 1.98,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
                                     {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
                                         },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27"
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
                                     }
                                 ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                            "sample document": {
+                                "sample identifier": "Sample 7",
+                                "location identifier": "H3",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.49,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
+                            "sample document": {
+                                "sample identifier": "Sample 3",
+                                "location identifier": "A4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 2.02,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                            "sample document": {
+                                "sample identifier": "Sample 7",
+                                "location identifier": "B4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.49,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
+                            "sample document": {
+                                "sample identifier": "Sample 2",
+                                "location identifier": "C4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 5.02,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:19:18+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "A260 dsDNA",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
+                            "sample document": {
+                                "sample identifier": "Sample 6",
+                                "location identifier": "D4",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.6,
+                                "unit": "mAU"
                             }
                         }
                     ],
@@ -346,1476 +1208,14 @@
                             },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
                             "sample document": {
-                                "sample identifier": "Sample 6",
-                                "location identifier": "F1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.6,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                            "sample document": {
-                                "sample identifier": "Sample 1",
-                                "location identifier": "G1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 10.04,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                            "sample document": {
-                                "sample identifier": "Sample 5",
-                                "location identifier": "H1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.79,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
-                            "sample document": {
-                                "sample identifier": "Sample 1",
-                                "location identifier": "A2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 10.19,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                            "sample document": {
-                                "sample identifier": "Sample 5",
-                                "location identifier": "B2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.77,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
-                            "sample document": {
-                                "sample identifier": "H2O",
-                                "location identifier": "C2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": -0.0,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A230"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A280"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
-                            "sample document": {
-                                "sample identifier": "Sample 4",
-                                "location identifier": "D2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.99,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                            "sample document": {
-                                "sample identifier": "Sample 3",
-                                "location identifier": "E2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 2.02,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
-                            "sample document": {
-                                "sample identifier": "Sample 7",
-                                "location identifier": "F2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.49,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                            "sample document": {
-                                "sample identifier": "Sample 2",
-                                "location identifier": "G2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 5.01,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
-                            "sample document": {
-                                "sample identifier": "Sample 6",
-                                "location identifier": "H2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.6,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
-                            "sample document": {
-                                "sample identifier": "Sample 2",
-                                "location identifier": "A3",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 5.03,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
-                            "sample document": {
-                                "sample identifier": "Sample 6",
-                                "location identifier": "B3",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.59,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
-                            "sample document": {
-                                "sample identifier": "Sample 1",
-                                "location identifier": "C3",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 10.09,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                            "sample document": {
-                                "sample identifier": "Sample 5",
-                                "location identifier": "D3",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.81,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
-                            "sample document": {
-                                "sample identifier": "H2O",
-                                "location identifier": "E3",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": -0.0,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A230"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A280"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                            "sample document": {
-                                "sample identifier": "Sample 4",
-                                "location identifier": "F3",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.98,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                            "sample document": {
-                                "sample identifier": "Sample 3",
-                                "location identifier": "G3",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 1.98,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                            "sample document": {
-                                "sample identifier": "Sample 7",
-                                "location identifier": "H3",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.49,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                            "sample document": {
-                                "sample identifier": "Sample 3",
-                                "location identifier": "A4",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 2.02,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                            "sample document": {
-                                "sample identifier": "Sample 7",
-                                "location identifier": "B4",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.49,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                            "sample document": {
-                                "sample identifier": "Sample 2",
-                                "location identifier": "C4",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 5.02,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                            "sample document": {
-                                "sample identifier": "Sample 6",
-                                "location identifier": "D4",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.6,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:19:18+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "A260 dsDNA",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                            "sample document": {
                                 "sample identifier": "Sample 1",
                                 "location identifier": "E4",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": 10.05,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -1848,36 +1248,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
                             "sample document": {
                                 "sample identifier": "Sample 5",
                                 "location identifier": "F4",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": 0.78,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -1910,44 +1290,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
                             "sample document": {
                                 "sample identifier": "H2O",
                                 "location identifier": "G4",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": -0.01,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A230"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A280"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -1980,36 +1332,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "H4",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": 0.98,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    }
-                                ]
-                            },
-                            "processed data aggregate document": {
-                                "processed data document": [
-                                    {
-                                        "data processing document": {
-                                            "concentration factor": {
-                                                "value": 50.0,
-                                                "unit": "ng/µL"
-                                            }
-                                        },
-                                        "processed data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_183"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -2023,1937 +1355,13 @@
                 }
             }
         ],
-        "calculated data aggregate document": {
-            "calculated data document": [
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": -0.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.05,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 49.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.51,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.84,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 101.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.07,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.46,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 24.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.03,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.74,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.84,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 250.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.45,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 29.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.56,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 501.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.02,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 39.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.64,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.84,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 509.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 38.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.06,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.72,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.86,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": -0.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 49.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.84,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 100.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.15,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.49,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 24.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 3.13,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 250.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.44,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 29.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.02,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.56,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.81,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 251.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 29.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.74,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.87,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 504.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 40.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.51,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.87,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": -0.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 49.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.12,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.74,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.84,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_120",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 99.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.6,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.86,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 24.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.72,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.83,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 100.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.01,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.47,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.84,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 24.5,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.07,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.89,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.86,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 250.9,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_152",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.43,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_153",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_154",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 30.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.02,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.71,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.84,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 502.3,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.42,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.85,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 39.1,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.66,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.83,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": -0.4,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 49.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A260)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.63,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_181",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.87,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_182",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
         "data system document": {
             "ASM file identifier": "Demo_A260_dsDNA_Data.json",
             "data system instance identifier": "N/A",
             "file name": "Demo_A260_dsDNA_Data.csv",
             "UNC path": "tests/parsers/unchained_labs_lunatic/testdata/Demo_A260_dsDNA_Data.csv",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.69",
+            "ASM converter version": "0.1.74",
             "software name": "Lunatic and Stunner Analysis"
         },
         "device system document": {

--- a/tests/parsers/unchained_labs_lunatic/testdata/Demo_A280_Protein.csv
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Demo_A280_Protein.csv
@@ -1,4 +1,4 @@
-Plate ID,Plate Position,Sample name,Application,Column,Row,Source Plate ID,Source Position,Sample group,Pump,Concentration (mg/ml),E1%,Date,Time,Instrument ID,Background (A280),A280,A260/A280,Plate type
+Plate ID,Plate Position,Sample Name,Application,Column,Row,Source Plate ID,Source Position,Sample group,Pump,Concentration (mg/ml),E1%,Date,Time,Instrument ID,Background (A280),A280,A260/A280,Plate type
 Plate 1,A1,H2O,Protein (Turbidity),1,A,,,Sample Group 1,0,N/A,N/A,17/10/2016,07:28:30,15,0.02,-0.00,N/A,Lunatic Plate
 Plate 1,B1,Sample 4,Protein (Turbidity),1,B,,,Sample Group 1,0,0.84,10.00,17/10/2016,07:28:30,15,0.00,0.84,0.56,Lunatic Plate
 Plate 1,C1,Sample 3,Protein (Turbidity),1,C,,,Sample Group 1,0,1.04,10.00,17/10/2016,07:28:30,15,0.14,1.04,0.55,Lunatic Plate

--- a/tests/parsers/unchained_labs_lunatic/testdata/Demo_A280_Protein.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Demo_A280_Protein.json
@@ -25,23 +25,12 @@
                             "sample document": {
                                 "sample identifier": "H2O",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": -0.0,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A280"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -73,10 +62,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "B1",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -113,10 +103,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
                             "sample document": {
                                 "sample identifier": "Sample 3",
                                 "location identifier": "C1",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -153,10 +144,421 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
                             "sample document": {
                                 "sample identifier": "Sample 7",
                                 "location identifier": "D1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.18,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:28:30+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "Protein (Turbidity)",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 280.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                            "sample document": {
+                                "sample identifier": "Sample 2",
+                                "location identifier": "E1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 2.07,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:28:30+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "Protein (Turbidity)",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 280.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                            "sample document": {
+                                "sample identifier": "Sample 6",
+                                "location identifier": "F1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.39,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:28:30+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "Protein (Turbidity)",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 280.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                            "sample document": {
+                                "sample identifier": "Sample 1",
+                                "location identifier": "G1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 4.22,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:28:30+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "Protein (Turbidity)",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 280.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                            "sample document": {
+                                "sample identifier": "Sample 5",
+                                "location identifier": "H1",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.61,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:28:30+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "Protein (Turbidity)",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 280.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                            "sample document": {
+                                "sample identifier": "Sample 1",
+                                "location identifier": "A2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 4.22,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:28:30+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "Protein (Turbidity)",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 280.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
+                            "sample document": {
+                                "sample identifier": "Sample 5",
+                                "location identifier": "B2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.61,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:28:30+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "Protein (Turbidity)",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 280.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                            "sample document": {
+                                "sample identifier": "H2O",
+                                "location identifier": "C2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.0,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:28:30+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "Protein (Turbidity)",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 280.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
+                            "sample document": {
+                                "sample identifier": "Sample 4",
+                                "location identifier": "D2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 0.82,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:28:30+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "Protein (Turbidity)",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 280.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
+                            "sample document": {
+                                "sample identifier": "Sample 3",
+                                "location identifier": "E2",
+                                "batch identifier": "Sample Group 1",
+                                "well plate identifier": "Plate 1"
+                            },
+                            "absorbance": {
+                                "value": 1.03,
+                                "unit": "mAU"
+                            }
+                        }
+                    ],
+                    "measurement time": "2016-10-17T07:28:30+00:00",
+                    "plate well count": {
+                        "value": 96,
+                        "unit": "#"
+                    },
+                    "analytical method identifier": "Protein (Turbidity)",
+                    "container type": "well plate"
+                }
+            },
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 280.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                            "sample document": {
+                                "sample identifier": "Sample 7",
+                                "location identifier": "F2",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -196,419 +598,8 @@
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
                             "sample document": {
                                 "sample identifier": "Sample 2",
-                                "location identifier": "E1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 2.07,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:28:30+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "Protein (Turbidity)",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 280.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                            "sample document": {
-                                "sample identifier": "Sample 6",
-                                "location identifier": "F1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.39,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:28:30+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "Protein (Turbidity)",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 280.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                            "sample document": {
-                                "sample identifier": "Sample 1",
-                                "location identifier": "G1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 4.22,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:28:30+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "Protein (Turbidity)",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 280.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                            "sample document": {
-                                "sample identifier": "Sample 5",
-                                "location identifier": "H1",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.61,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:28:30+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "Protein (Turbidity)",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 280.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                            "sample document": {
-                                "sample identifier": "Sample 1",
-                                "location identifier": "A2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 4.22,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:28:30+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "Protein (Turbidity)",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 280.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                            "sample document": {
-                                "sample identifier": "Sample 5",
-                                "location identifier": "B2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.61,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:28:30+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "Protein (Turbidity)",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 280.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                            "sample document": {
-                                "sample identifier": "H2O",
-                                "location identifier": "C2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.0,
-                                "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A280"
-                                    }
-                                ]
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:28:30+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "Protein (Turbidity)",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 280.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                            "sample document": {
-                                "sample identifier": "Sample 4",
-                                "location identifier": "D2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.82,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:28:30+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "Protein (Turbidity)",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 280.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
-                            "sample document": {
-                                "sample identifier": "Sample 3",
-                                "location identifier": "E2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 1.03,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:28:30+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "Protein (Turbidity)",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 280.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                            "sample document": {
-                                "sample identifier": "Sample 7",
-                                "location identifier": "F2",
-                                "well plate identifier": "Plate 1"
-                            },
-                            "absorbance": {
-                                "value": 0.18,
-                                "unit": "mAU"
-                            }
-                        }
-                    ],
-                    "measurement time": "2016-10-17T07:28:30+00:00",
-                    "plate well count": {
-                        "value": 96,
-                        "unit": "#"
-                    },
-                    "analytical method identifier": "Protein (Turbidity)",
-                    "container type": "well plate"
-                }
-            },
-            {
-                "measurement aggregate document": {
-                    "measurement document": [
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 280.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                            "sample document": {
-                                "sample identifier": "Sample 2",
                                 "location identifier": "G2",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -645,10 +636,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
                             "sample document": {
                                 "sample identifier": "Sample 6",
                                 "location identifier": "H2",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -685,10 +677,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
                             "sample document": {
                                 "sample identifier": "Sample 2",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -725,10 +718,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
                             "sample document": {
                                 "sample identifier": "Sample 6",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -765,10 +759,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                             "sample document": {
                                 "sample identifier": "Sample 1",
                                 "location identifier": "C3",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -805,10 +800,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
                             "sample document": {
                                 "sample identifier": "Sample 5",
                                 "location identifier": "D3",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -845,27 +841,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
                             "sample document": {
                                 "sample identifier": "H2O",
                                 "location identifier": "E3",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": -0.0,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A280"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -897,10 +882,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "F3",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -937,10 +923,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
                             "sample document": {
                                 "sample identifier": "Sample 3",
                                 "location identifier": "G3",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -977,10 +964,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
                             "sample document": {
                                 "sample identifier": "Sample 7",
                                 "location identifier": "H3",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -1017,10 +1005,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
                             "sample document": {
                                 "sample identifier": "Sample 3",
                                 "location identifier": "A4",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -1057,10 +1046,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
                             "sample document": {
                                 "sample identifier": "Sample 7",
                                 "location identifier": "B4",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -1097,10 +1087,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
                             "sample document": {
                                 "sample identifier": "Sample 2",
                                 "location identifier": "C4",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -1137,10 +1128,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
                             "sample document": {
                                 "sample identifier": "Sample 6",
                                 "location identifier": "D4",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -1177,10 +1169,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
                             "sample document": {
                                 "sample identifier": "Sample 1",
                                 "location identifier": "E4",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -1217,10 +1210,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
                             "sample document": {
                                 "sample identifier": "Sample 5",
                                 "location identifier": "F4",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -1257,27 +1251,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
                             "sample document": {
                                 "sample identifier": "H2O",
                                 "location identifier": "G4",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": -0.01,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A280"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -1309,10 +1292,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "H4",
+                                "batch identifier": "Sample Group 1",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
@@ -1331,1425 +1315,13 @@
                 }
             }
         ],
-        "calculated data aggregate document": {
-            "calculated data document": [
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.02,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.84,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.56,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 1.04,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.14,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.14,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.46,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 2.07,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.22,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.39,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.09,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.51,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 4.22,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.31,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.61,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.04,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.53,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 4.22,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.61,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.82,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.01,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 1.03,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.1,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.47,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 2.05,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.4,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.09,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.53,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 2.08,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.21,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.4,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.06,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 4.23,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.3,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.6,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.53,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.83,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.12,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 1.03,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.14,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.54,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.19,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 1.04,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.12,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.56,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.18,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.01,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.54,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 2.07,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.21,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.38,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.12,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.49,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 4.22,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.27,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.62,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.56,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.83,
-                        "unit": "mg/mL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Background (A280)",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "mAU"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 0.56,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
         "data system document": {
             "ASM file identifier": "Demo_A280_Protein.json",
             "data system instance identifier": "N/A",
             "file name": "Demo_A280_Protein.csv",
             "UNC path": "tests/parsers/unchained_labs_lunatic/testdata/Demo_A280_Protein.csv",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.65",
+            "ASM converter version": "0.1.74",
             "software name": "Lunatic and Stunner Analysis"
         },
         "device system document": {

--- a/tests/parsers/unchained_labs_lunatic/testdata/Demo_A280_Protein.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Demo_A280_Protein.json
@@ -31,6 +31,18 @@
                             "absorbance": {
                                 "value": -0.0,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A280"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -62,7 +74,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "B1",
@@ -103,7 +115,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
                             "sample document": {
                                 "sample identifier": "Sample 3",
                                 "location identifier": "C1",
@@ -144,7 +156,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
                             "sample document": {
                                 "sample identifier": "Sample 7",
                                 "location identifier": "D1",
@@ -185,7 +197,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
                             "sample document": {
                                 "sample identifier": "Sample 2",
                                 "location identifier": "E1",
@@ -226,7 +238,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
                             "sample document": {
                                 "sample identifier": "Sample 6",
                                 "location identifier": "F1",
@@ -267,7 +279,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
                             "sample document": {
                                 "sample identifier": "Sample 1",
                                 "location identifier": "G1",
@@ -308,7 +320,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
                             "sample document": {
                                 "sample identifier": "Sample 5",
                                 "location identifier": "H1",
@@ -349,7 +361,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
                             "sample document": {
                                 "sample identifier": "Sample 1",
                                 "location identifier": "A2",
@@ -390,7 +402,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
                             "sample document": {
                                 "sample identifier": "Sample 5",
                                 "location identifier": "B2",
@@ -431,7 +443,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
                             "sample document": {
                                 "sample identifier": "H2O",
                                 "location identifier": "C2",
@@ -441,6 +453,18 @@
                             "absorbance": {
                                 "value": 0.0,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A280"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -472,7 +496,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "D2",
@@ -513,7 +537,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
                             "sample document": {
                                 "sample identifier": "Sample 3",
                                 "location identifier": "E2",
@@ -554,7 +578,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
                             "sample document": {
                                 "sample identifier": "Sample 7",
                                 "location identifier": "F2",
@@ -595,7 +619,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
                             "sample document": {
                                 "sample identifier": "Sample 2",
                                 "location identifier": "G2",
@@ -636,7 +660,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
                             "sample document": {
                                 "sample identifier": "Sample 6",
                                 "location identifier": "H2",
@@ -677,7 +701,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
                             "sample document": {
                                 "sample identifier": "Sample 2",
                                 "location identifier": "A3",
@@ -718,7 +742,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
                             "sample document": {
                                 "sample identifier": "Sample 6",
                                 "location identifier": "B3",
@@ -759,7 +783,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
                             "sample document": {
                                 "sample identifier": "Sample 1",
                                 "location identifier": "C3",
@@ -800,7 +824,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
                             "sample document": {
                                 "sample identifier": "Sample 5",
                                 "location identifier": "D3",
@@ -841,7 +865,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
                             "sample document": {
                                 "sample identifier": "H2O",
                                 "location identifier": "E3",
@@ -851,6 +875,18 @@
                             "absorbance": {
                                 "value": -0.0,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A280"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -882,7 +918,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "F3",
@@ -923,7 +959,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
                             "sample document": {
                                 "sample identifier": "Sample 3",
                                 "location identifier": "G3",
@@ -964,7 +1000,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
                             "sample document": {
                                 "sample identifier": "Sample 7",
                                 "location identifier": "H3",
@@ -1005,7 +1041,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
                             "sample document": {
                                 "sample identifier": "Sample 3",
                                 "location identifier": "A4",
@@ -1046,7 +1082,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
                             "sample document": {
                                 "sample identifier": "Sample 7",
                                 "location identifier": "B4",
@@ -1087,7 +1123,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
                             "sample document": {
                                 "sample identifier": "Sample 2",
                                 "location identifier": "C4",
@@ -1128,7 +1164,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
                             "sample document": {
                                 "sample identifier": "Sample 6",
                                 "location identifier": "D4",
@@ -1169,7 +1205,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
                             "sample document": {
                                 "sample identifier": "Sample 1",
                                 "location identifier": "E4",
@@ -1210,7 +1246,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
                             "sample document": {
                                 "sample identifier": "Sample 5",
                                 "location identifier": "F4",
@@ -1251,7 +1287,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
                             "sample document": {
                                 "sample identifier": "H2O",
                                 "location identifier": "G4",
@@ -1261,6 +1297,18 @@
                             "absorbance": {
                                 "value": -0.01,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A280"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -1292,7 +1340,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
                             "sample document": {
                                 "sample identifier": "Sample 4",
                                 "location identifier": "H4",
@@ -1315,6 +1363,1418 @@
                 }
             }
         ],
+        "calculated data aggregate document": {
+            "calculated data document": [
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.02,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.84,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.56,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 1.04,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.14,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_8",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_9",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_11",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.14,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_12",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.46,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_13",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_10",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 2.07,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_15",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.22,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_16",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_17",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_14",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.39,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_19",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.09,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_20",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.51,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_21",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_18",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 4.22,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_23",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.31,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_24",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_25",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_22",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.61,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_27",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.04,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_28",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.53,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_29",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_26",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 4.22,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_31",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_32",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_33",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_30",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.61,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_35",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_36",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_37",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_34",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_39",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_38",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.82,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_41",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.01,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_42",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_43",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_40",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 1.03,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_45",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_46",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_47",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_44",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_49",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.1,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_50",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.47,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_51",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_48",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 2.05,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_53",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_54",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_55",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_52",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.4,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_57",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.09,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_58",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.53,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_59",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_56",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 2.08,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_61",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.21,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_62",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_63",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_60",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.4,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_65",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.06,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_66",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_67",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_64",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 4.23,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_69",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.3,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_70",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_71",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_68",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.6,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_73",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_74",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.53,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_75",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_72",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_77",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_76",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.83,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_79",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.12,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_80",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_81",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_78",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 1.03,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_83",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.14,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_84",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.54,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_85",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_82",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.19,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_87",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_88",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_89",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_86",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 1.04,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_91",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.12,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_92",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.56,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_93",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_90",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.18,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_95",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.01,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_96",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.54,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_97",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_94",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 2.07,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_99",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.21,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_100",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_101",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_98",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.38,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_103",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.12,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_104",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.49,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_105",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_102",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 4.22,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_107",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.27,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_108",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_109",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_106",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.62,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_111",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_112",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.56,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_113",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_110",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_115",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_114",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.83,
+                        "unit": "mg/mL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_117",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Background (A280)",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "mAU"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_118",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 0.56,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_119",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_116",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
         "data system document": {
             "ASM file identifier": "Demo_A280_Protein.json",
             "data system instance identifier": "N/A",

--- a/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_no_header.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_no_header.json
@@ -28,6 +28,18 @@
                             "absorbance": {
                                 "value": 3.65,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Background (A260)"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -56,7 +68,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
                             "sample document": {
                                 "sample identifier": "SAMPLE_2",
                                 "location identifier": "B1",
@@ -66,6 +78,18 @@
                             "absorbance": {
                                 "value": 3.66,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Background (A260)"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -79,6 +103,106 @@
                 }
             }
         ],
+        "calculated data aggregate document": {
+            "calculated data document": [
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 182.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 182.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.52,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
         "data system document": {
             "ASM file identifier": "Example_Lunatic_Plate_Reader_csv_no_header.json",
             "data system instance identifier": "N/A",

--- a/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_no_header.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_no_header.json
@@ -22,23 +22,12 @@
                             "sample document": {
                                 "sample identifier": "SAMPLE_1",
                                 "location identifier": "A1",
+                                "batch identifier": "GROUP_1",
                                 "well plate identifier": "PLATE_1"
                             },
                             "absorbance": {
                                 "value": 3.65,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Background (A260)"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -67,27 +56,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
                             "sample document": {
                                 "sample identifier": "SAMPLE_2",
                                 "location identifier": "B1",
+                                "batch identifier": "GROUP_1",
                                 "well plate identifier": "PLATE_2"
                             },
                             "absorbance": {
                                 "value": 3.66,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Background (A260)"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -101,113 +79,13 @@
                 }
             }
         ],
-        "calculated data aggregate document": {
-            "calculated data document": [
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 182.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 182.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
         "data system document": {
             "ASM file identifier": "Example_Lunatic_Plate_Reader_csv_no_header.json",
             "data system instance identifier": "N/A",
             "file name": "Example_Lunatic_Plate_Reader_csv_no_header.csv",
             "UNC path": "tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_no_header.csv",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.65",
+            "ASM converter version": "0.1.74",
             "software name": "Lunatic and Stunner Analysis"
         },
         "device system document": {

--- a/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_with_header.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_with_header.json
@@ -29,6 +29,18 @@
                             "absorbance": {
                                 "value": 3.65,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Background (A260)"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -44,6 +56,58 @@
                 "analyst": "ImmuneMed"
             }
         ],
+        "calculated data aggregate document": {
+            "calculated data document": [
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 182.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
         "data system document": {
             "ASM file identifier": "Example_Lunatic_Plate_Reader_csv_with_header.json",
             "data system instance identifier": "N/A",

--- a/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_with_header.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_with_header.json
@@ -23,23 +23,12 @@
                             "sample document": {
                                 "sample identifier": "SAMPLE_1",
                                 "location identifier": "A1",
+                                "batch identifier": "GROUP_1",
                                 "well plate identifier": "PLATE_1"
                             },
                             "absorbance": {
                                 "value": 3.65,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Background (A260)"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -55,65 +44,13 @@
                 "analyst": "ImmuneMed"
             }
         ],
-        "calculated data aggregate document": {
-            "calculated data document": [
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 182.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
         "data system document": {
             "ASM file identifier": "Example_Lunatic_Plate_Reader_csv_with_header.json",
             "data system instance identifier": "N/A",
             "file name": "Example_Lunatic_Plate_Reader_csv_with_header.csv",
             "UNC path": "tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_csv_with_header.csv",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.65",
+            "ASM converter version": "0.1.74",
             "software name": "Lunatic and Stunner Analysis",
             "software version": "8.2.0.259"
         },

--- a/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_no_header.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_no_header.json
@@ -22,23 +22,12 @@
                             "sample document": {
                                 "sample identifier": "SAMPLE_1",
                                 "location identifier": "A1",
+                                "batch identifier": "GROUP_1",
                                 "well plate identifier": "PLATE_1"
                             },
                             "absorbance": {
                                 "value": 3.65,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Background (A260)"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -67,27 +56,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
                             "sample document": {
                                 "sample identifier": "SAMPLE_2",
                                 "location identifier": "B1",
+                                "batch identifier": "GROUP_1",
                                 "well plate identifier": "PLATE_1"
                             },
                             "absorbance": {
                                 "value": 3.66,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Background (A260)"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -101,113 +79,13 @@
                 }
             }
         ],
-        "calculated data aggregate document": {
-            "calculated data document": [
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 182.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 182.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
         "data system document": {
             "ASM file identifier": "Example_Lunatic_Plate_Reader_xlsx_no_header.json",
             "data system instance identifier": "N/A",
             "file name": "Example_Lunatic_Plate_Reader_xlsx_no_header.xlsx",
             "UNC path": "tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_no_header.xlsx",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.65",
+            "ASM converter version": "0.1.74",
             "software name": "Lunatic and Stunner Analysis"
         },
         "device system document": {

--- a/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_no_header.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_no_header.json
@@ -28,6 +28,18 @@
                             "absorbance": {
                                 "value": 3.65,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Background (A260)"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -56,7 +68,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
                             "sample document": {
                                 "sample identifier": "SAMPLE_2",
                                 "location identifier": "B1",
@@ -66,6 +78,18 @@
                             "absorbance": {
                                 "value": 3.66,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Background (A260)"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -79,6 +103,106 @@
                 }
             }
         ],
+        "calculated data aggregate document": {
+            "calculated data document": [
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 182.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 182.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.52,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
         "data system document": {
             "ASM file identifier": "Example_Lunatic_Plate_Reader_xlsx_no_header.json",
             "data system instance identifier": "N/A",

--- a/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_with_header.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_with_header.json
@@ -23,23 +23,12 @@
                             "sample document": {
                                 "sample identifier": "SAMPLE_1",
                                 "location identifier": "A1",
+                                "batch identifier": "GROUP_1",
                                 "well plate identifier": "PLATE_1"
                             },
                             "absorbance": {
                                 "value": 3.65,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Background (A260)"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -71,27 +60,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
                             "sample document": {
                                 "sample identifier": "SAMPLE_2",
                                 "location identifier": "B1",
+                                "batch identifier": "GROUP_1",
                                 "well plate identifier": "PLATE_1"
                             },
                             "absorbance": {
                                 "value": 3.66,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Background (A260)"
-                                    }
-                                ]
                             }
                         }
                     ],
@@ -107,113 +85,13 @@
                 "analyst": "ImmuneMed"
             }
         ],
-        "calculated data aggregate document": {
-            "calculated data document": [
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 182.6,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.55,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 182.8,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.52,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.94,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
         "data system document": {
             "ASM file identifier": "Example_Lunatic_Plate_Reader_xlsx_with_header.json",
             "data system instance identifier": "N/A",
             "file name": "Example_Lunatic_Plate_Reader_xlsx_with_header.xlsx",
             "UNC path": "tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_with_header.xlsx",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.65",
+            "ASM converter version": "0.1.74",
             "software name": "Lunatic and Stunner Analysis",
             "software version": "8.2.0.259"
         },

--- a/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_with_header.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/Example_Lunatic_Plate_Reader_xlsx_with_header.json
@@ -29,6 +29,18 @@
                             "absorbance": {
                                 "value": 3.65,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Background (A260)"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -60,7 +72,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
                             "sample document": {
                                 "sample identifier": "SAMPLE_2",
                                 "location identifier": "B1",
@@ -70,6 +82,18 @@
                             "absorbance": {
                                 "value": 3.66,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Background (A260)"
+                                    }
+                                ]
                             }
                         }
                     ],
@@ -85,6 +109,106 @@
                 "analyst": "ImmuneMed"
             }
         ],
+        "calculated data aggregate document": {
+            "calculated data document": [
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 182.6,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_1",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.55,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_2",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_3",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_0",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 182.8,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_5",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.52,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_6",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.94,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_7",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_4",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
         "data system document": {
             "ASM file identifier": "Example_Lunatic_Plate_Reader_xlsx_with_header.json",
             "data system instance identifier": "N/A",

--- a/tests/parsers/unchained_labs_lunatic/testdata/spectrum_measurement.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/spectrum_measurement.json
@@ -30,6 +30,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -68,6 +69,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -106,6 +108,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -144,6 +147,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -182,6 +186,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -220,6 +225,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -258,6 +264,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -296,6 +303,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -334,6 +342,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -372,6 +381,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -410,6 +420,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -448,6 +459,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -486,6 +498,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -524,6 +537,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -562,6 +576,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -600,6 +615,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -638,6 +654,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -676,6 +693,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -714,6 +732,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -752,6 +771,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -790,6 +810,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -828,6 +849,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -866,6 +888,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -904,6 +927,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -942,6 +966,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -980,6 +1005,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1018,6 +1044,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1056,6 +1083,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1094,6 +1122,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1132,6 +1161,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1170,6 +1200,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1208,6 +1239,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1246,6 +1278,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1284,6 +1317,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1322,6 +1356,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1360,6 +1395,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1398,6 +1434,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1436,6 +1473,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1474,6 +1512,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1512,6 +1551,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1550,6 +1590,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1588,6 +1629,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1626,6 +1668,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1664,6 +1707,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1702,6 +1746,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1740,6 +1785,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1778,6 +1824,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1816,6 +1863,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1854,6 +1902,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1892,6 +1941,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1930,6 +1980,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -1968,6 +2019,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2006,6 +2058,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2044,6 +2097,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2082,6 +2136,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2120,6 +2175,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2158,6 +2214,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2196,6 +2253,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2234,6 +2292,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2272,6 +2331,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2310,6 +2370,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2348,6 +2409,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2386,6 +2448,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2424,6 +2487,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2462,6 +2526,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2500,6 +2565,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2538,6 +2604,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2576,6 +2643,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2614,6 +2682,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2652,6 +2721,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2690,6 +2760,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2728,6 +2799,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2766,6 +2838,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2804,6 +2877,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2842,6 +2916,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2880,6 +2955,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2918,6 +2994,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2956,6 +3033,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -2994,6 +3072,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3032,6 +3111,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3070,6 +3150,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3108,6 +3189,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3146,6 +3228,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3184,6 +3267,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3222,6 +3306,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3260,6 +3345,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3298,6 +3384,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3336,6 +3423,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3374,6 +3462,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3412,6 +3501,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3450,6 +3540,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3488,6 +3579,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3526,6 +3618,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3564,6 +3657,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3602,6 +3696,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3640,6 +3735,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3678,6 +3774,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3716,6 +3813,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3754,6 +3852,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3792,6 +3891,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3830,6 +3930,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3868,6 +3969,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3906,6 +4008,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3944,6 +4047,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -3982,6 +4086,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4020,6 +4125,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4058,6 +4164,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4096,6 +4203,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4134,6 +4242,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4172,6 +4281,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4210,6 +4320,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4248,6 +4359,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4286,6 +4398,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4324,6 +4437,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4362,6 +4476,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4400,6 +4515,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4438,6 +4554,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4476,6 +4593,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4514,6 +4632,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4552,6 +4671,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4590,6 +4710,7 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4628,23 +4749,12 @@
                             "sample document": {
                                 "sample identifier": "sample_A1",
                                 "location identifier": "A1",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": 0.58,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Background (A260)"
-                                    }
-                                ]
                             },
                             "custom information document": {
                                 "electronic absorbance reference absorbance": 0.16
@@ -4684,10 +4794,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4722,10 +4833,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4760,10 +4872,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4798,10 +4911,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4836,10 +4950,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4874,10 +4989,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4912,10 +5028,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4950,10 +5067,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -4988,10 +5106,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5026,10 +5145,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5064,10 +5184,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5102,10 +5223,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5140,10 +5262,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5178,10 +5301,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5216,10 +5340,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5254,10 +5379,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5292,10 +5418,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5330,10 +5457,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5368,10 +5496,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5406,10 +5535,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5444,10 +5574,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5482,10 +5613,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5520,10 +5652,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5558,10 +5691,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5596,10 +5730,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5634,10 +5769,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5672,10 +5808,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5710,10 +5847,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_152",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5748,10 +5886,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_153",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5786,10 +5925,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_154",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5824,10 +5964,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_152",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5862,10 +6003,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_153",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5900,10 +6042,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_154",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5938,10 +6081,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -5976,10 +6120,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6014,10 +6159,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6052,10 +6198,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6090,10 +6237,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6128,10 +6276,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6166,10 +6315,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6204,10 +6354,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6242,10 +6393,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6280,10 +6432,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6318,10 +6471,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6356,10 +6510,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6394,10 +6549,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6432,10 +6588,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6470,10 +6627,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6508,10 +6666,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6546,10 +6705,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6584,10 +6744,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6622,10 +6783,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6660,10 +6822,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6698,10 +6861,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6736,10 +6900,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6774,10 +6939,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6812,10 +6978,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_181",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6850,10 +7017,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_182",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6888,10 +7056,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_183",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6926,10 +7095,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_184",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_181",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -6964,10 +7134,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_182",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7002,10 +7173,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_183",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7040,10 +7212,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_187",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_184",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7078,10 +7251,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_188",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7116,10 +7290,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_189",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7154,10 +7329,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_187",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7192,10 +7368,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_191",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_188",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7230,10 +7407,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_189",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7268,10 +7446,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_193",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7306,10 +7485,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_194",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_191",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7344,10 +7524,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7382,10 +7563,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_196",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_193",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7420,10 +7602,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_197",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_194",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7458,10 +7641,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7496,10 +7680,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_199",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_196",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7534,10 +7719,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_197",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7572,10 +7758,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_201",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7610,10 +7797,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_202",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_199",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7648,10 +7836,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_203",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7686,10 +7875,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_201",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7724,10 +7914,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_202",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7762,10 +7953,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_206",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_203",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7800,10 +7992,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_207",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7838,10 +8031,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_208",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7876,10 +8070,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_209",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_206",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7914,10 +8109,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_207",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7952,10 +8148,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_211",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_208",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -7990,10 +8187,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_212",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_209",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8028,10 +8226,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_213",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8066,10 +8265,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_214",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_211",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8104,10 +8304,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_212",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8142,10 +8343,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_213",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8180,10 +8382,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_217",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_214",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8218,10 +8421,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_218",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8256,10 +8460,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_219",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8294,10 +8499,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_217",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8332,10 +8538,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_221",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_218",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8370,10 +8577,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_219",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8408,10 +8616,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_223",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8446,10 +8655,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_224",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_221",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8484,10 +8694,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8522,10 +8733,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_226",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_223",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8560,10 +8772,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_227",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_224",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8598,10 +8811,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8636,10 +8850,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_229",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_226",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8674,10 +8889,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_227",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8712,10 +8928,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_231",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8750,10 +8967,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_232",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_229",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8788,10 +9006,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_233",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8826,10 +9045,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_231",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8864,10 +9084,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_232",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8902,10 +9123,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_236",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_233",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8940,10 +9162,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_237",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -8978,10 +9201,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_238",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9016,10 +9240,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_239",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_236",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9054,10 +9279,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_237",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9092,10 +9318,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_241",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_238",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9130,10 +9357,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_242",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_239",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9168,10 +9396,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_243",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9206,10 +9435,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_244",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_241",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9244,10 +9474,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_242",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9282,27 +9513,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_243",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": 0.01,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Background (A260)"
-                                    }
-                                ]
                             },
                             "custom information document": {
                                 "electronic absorbance reference absorbance": 0.0
@@ -9342,10 +9562,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_244",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9380,10 +9601,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_251",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9418,10 +9640,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9456,10 +9679,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_253",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_247",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9494,10 +9718,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_254",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_248",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9532,10 +9757,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_249",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9570,10 +9796,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_256",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9608,10 +9835,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_257",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_251",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9646,10 +9874,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9684,10 +9913,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_259",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_253",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9722,10 +9952,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_254",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9760,10 +9991,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_261",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9798,10 +10030,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_262",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_256",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9836,10 +10069,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_263",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_257",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9874,10 +10108,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9912,10 +10147,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_259",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9950,10 +10186,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_266",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -9988,10 +10225,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_267",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_261",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10026,10 +10264,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_268",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_262",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10064,10 +10303,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_269",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_263",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10102,10 +10342,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10140,10 +10381,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_271",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10178,10 +10420,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_272",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_266",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10216,10 +10459,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_273",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_267",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10254,10 +10498,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_274",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_268",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10292,10 +10537,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_269",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10330,10 +10576,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10368,10 +10615,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_277",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_271",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10406,10 +10654,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_278",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_272",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10444,10 +10693,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_279",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_273",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10482,10 +10732,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_274",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10520,10 +10771,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_281",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10558,10 +10810,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10596,10 +10849,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_283",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_277",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10634,10 +10888,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_284",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_278",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10672,10 +10927,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_279",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10710,10 +10966,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_286",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_280",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10748,10 +11005,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_287",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_281",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10786,10 +11044,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_282",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10824,10 +11083,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_289",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_283",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10862,10 +11122,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_284",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10900,10 +11161,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_291",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_285",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10938,10 +11200,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_292",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_286",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -10976,10 +11239,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_293",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_287",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11014,10 +11278,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_288",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11052,10 +11317,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_289",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11090,10 +11356,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_296",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_290",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11128,10 +11395,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_297",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_291",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11166,10 +11434,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_298",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_292",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11204,10 +11473,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_299",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_293",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11242,10 +11512,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_294",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11280,10 +11551,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_301",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_295",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11318,10 +11590,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_302",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_296",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11356,10 +11629,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_303",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_297",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11394,10 +11668,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_304",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_298",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11432,10 +11707,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_299",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11470,10 +11746,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_300",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11508,10 +11785,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_307",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_301",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11546,10 +11824,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_308",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_302",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11584,10 +11863,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_309",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_303",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11622,10 +11902,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_304",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11660,10 +11941,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_311",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_305",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11698,10 +11980,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_306",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11736,10 +12019,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_313",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_307",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11774,10 +12058,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_314",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_308",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11812,10 +12097,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_309",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11850,10 +12136,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_316",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_310",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11888,10 +12175,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_317",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_311",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11926,10 +12214,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_312",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -11964,10 +12253,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_319",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_313",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12002,10 +12292,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_314",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12040,10 +12331,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_321",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_315",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12078,10 +12370,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_322",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_316",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12116,10 +12409,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_323",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_317",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12154,10 +12448,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_318",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12192,10 +12487,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_319",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12230,10 +12526,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_326",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_320",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12268,10 +12565,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_327",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_321",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12306,10 +12604,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_328",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_322",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12344,10 +12643,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_329",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_323",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12382,10 +12682,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_324",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12420,10 +12721,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_331",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_325",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12458,10 +12760,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_332",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_326",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12496,10 +12799,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_333",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_327",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12534,10 +12838,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_334",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_328",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12572,10 +12877,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_329",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12610,10 +12916,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_330",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12648,10 +12955,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_337",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_331",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12686,10 +12994,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_338",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_332",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12724,10 +13033,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_339",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_333",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12762,10 +13072,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_334",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12800,10 +13111,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_341",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_335",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12838,10 +13150,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_336",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12876,10 +13189,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_343",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_337",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12914,10 +13228,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_344",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_338",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12952,10 +13267,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_339",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -12990,10 +13306,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_346",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_340",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13028,10 +13345,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_347",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_341",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13066,10 +13384,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_342",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13104,10 +13423,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_349",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_343",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13142,10 +13462,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_344",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13180,10 +13501,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_351",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_345",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13218,10 +13540,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_352",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_346",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13256,10 +13579,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_353",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_347",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13294,10 +13618,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_348",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13332,10 +13657,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_349",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13370,10 +13696,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_356",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_350",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13408,10 +13735,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_357",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_351",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13446,10 +13774,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_358",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_352",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13484,10 +13813,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_359",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_353",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13522,10 +13852,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_354",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13560,10 +13891,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_361",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_355",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13598,10 +13930,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_362",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_356",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13636,10 +13969,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_363",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_357",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13674,10 +14008,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_364",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_358",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13712,10 +14047,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_359",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13750,10 +14086,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_360",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13788,10 +14125,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_367",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_361",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13826,10 +14164,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_368",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_362",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13864,10 +14203,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_369",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_363",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13902,10 +14242,11 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_364",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1",
                                 "custom information document": {
                                     "path length": 10.0
@@ -13940,35 +14281,16 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_371",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_365",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": 0.0,
                                 "unit": "mAU"
-                            },
-                            "error aggregate document": {
-                                "error document": [
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Concentration"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "Background (A260)"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A230"
-                                    },
-                                    {
-                                        "error": "N/A",
-                                        "error feature": "A260/A280"
-                                    }
-                                ]
                             },
                             "custom information document": {
                                 "electronic absorbance reference absorbance": 0.0
@@ -13985,129 +14307,13 @@
                 }
             }
         ],
-        "calculated data aggregate document": {
-            "calculated data document": [
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 29.2,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 0.8,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.65,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.7,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_247",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A230",
-                    "calculated result": {
-                        "value": 2.63,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_248",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "A260/A280",
-                    "calculated result": {
-                        "value": 1.28,
-                        "unit": "(unitless)"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_249",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "calculated data name": "Concentration",
-                    "calculated result": {
-                        "value": 0.0,
-                        "unit": "ng/µL"
-                    },
-                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
-                    "data source aggregate document": {
-                        "data source document": [
-                            {
-                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_371",
-                                "data source feature": "absorbance"
-                            }
-                        ]
-                    }
-                }
-            ]
-        },
         "data system document": {
             "ASM file identifier": "spectrum_measurement.json",
             "data system instance identifier": "N/A",
             "file name": "spectrum_measurement.csv",
             "UNC path": "tests/parsers/unchained_labs_lunatic/testdata/spectrum_measurement.csv",
             "ASM converter name": "allotropy_unchained_labs_lunatic",
-            "ASM converter version": "0.1.65",
+            "ASM converter version": "0.1.74",
             "software name": "Lunatic and Stunner Analysis"
         },
         "device system document": {

--- a/tests/parsers/unchained_labs_lunatic/testdata/spectrum_measurement.json
+++ b/tests/parsers/unchained_labs_lunatic/testdata/spectrum_measurement.json
@@ -4756,6 +4756,18 @@
                                 "value": 0.58,
                                 "unit": "mAU"
                             },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Background (A260)"
+                                    }
+                                ]
+                            },
                             "custom information document": {
                                 "electronic absorbance reference absorbance": 0.16
                             }
@@ -4794,7 +4806,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -4833,7 +4845,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -4872,7 +4884,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -4911,7 +4923,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_125",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -4950,7 +4962,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_126",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -4989,7 +5001,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_127",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5028,7 +5040,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_128",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5067,7 +5079,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_129",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5106,7 +5118,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_130",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5145,7 +5157,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_131",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5184,7 +5196,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_132",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5223,7 +5235,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_133",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5262,7 +5274,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_134",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5301,7 +5313,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_135",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5340,7 +5352,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_136",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5379,7 +5391,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_137",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5418,7 +5430,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_138",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5457,7 +5469,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_139",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5496,7 +5508,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_140",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5535,7 +5547,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_141",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5574,7 +5586,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_142",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5613,7 +5625,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_143",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5652,7 +5664,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_144",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5691,7 +5703,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_145",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5730,7 +5742,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_146",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5769,7 +5781,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_147",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5808,7 +5820,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_148",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5847,7 +5859,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_149",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_152",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5886,7 +5898,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_150",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_153",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5925,7 +5937,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_151",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_154",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -5964,7 +5976,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_152",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6003,7 +6015,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_153",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6042,7 +6054,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_154",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6081,7 +6093,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_155",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6120,7 +6132,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_156",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6159,7 +6171,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_157",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6198,7 +6210,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_158",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6237,7 +6249,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_159",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6276,7 +6288,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_160",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6315,7 +6327,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_161",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6354,7 +6366,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_162",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6393,7 +6405,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_163",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6432,7 +6444,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_164",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6471,7 +6483,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_165",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6510,7 +6522,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_166",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6549,7 +6561,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_167",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6588,7 +6600,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_168",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6627,7 +6639,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_169",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6666,7 +6678,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_170",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6705,7 +6717,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_171",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6744,7 +6756,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_172",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6783,7 +6795,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_173",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6822,7 +6834,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_174",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6861,7 +6873,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_175",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6900,7 +6912,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_176",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6939,7 +6951,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_177",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -6978,7 +6990,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_178",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_181",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7017,7 +7029,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_179",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_182",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7056,7 +7068,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_180",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_183",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7095,7 +7107,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_181",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_184",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7134,7 +7146,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_182",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7173,7 +7185,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_183",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7212,7 +7224,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_184",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_187",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7251,7 +7263,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_185",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_188",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7290,7 +7302,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_186",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_189",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7329,7 +7341,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_187",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7368,7 +7380,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_188",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_191",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7407,7 +7419,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_189",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7446,7 +7458,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_190",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_193",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7485,7 +7497,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_191",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_194",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7524,7 +7536,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_192",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7563,7 +7575,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_193",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_196",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7602,7 +7614,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_194",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_197",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7641,7 +7653,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_195",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7680,7 +7692,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_196",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_199",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7719,7 +7731,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_197",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7758,7 +7770,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_198",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_201",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7797,7 +7809,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_199",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_202",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7836,7 +7848,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_200",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_203",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7875,7 +7887,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_201",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7914,7 +7926,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_202",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7953,7 +7965,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_203",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_206",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -7992,7 +8004,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_204",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_207",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8031,7 +8043,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_205",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_208",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8070,7 +8082,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_206",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_209",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8109,7 +8121,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_207",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8148,7 +8160,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_208",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_211",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8187,7 +8199,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_209",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_212",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8226,7 +8238,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_210",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_213",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8265,7 +8277,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_211",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_214",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8304,7 +8316,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_212",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8343,7 +8355,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_213",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8382,7 +8394,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_214",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_217",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8421,7 +8433,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_215",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_218",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8460,7 +8472,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_216",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_219",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8499,7 +8511,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_217",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8538,7 +8550,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_218",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_221",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8577,7 +8589,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_219",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8616,7 +8628,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_220",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_223",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8655,7 +8667,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_221",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_224",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8694,7 +8706,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_222",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8733,7 +8745,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_223",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_226",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8772,7 +8784,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_224",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_227",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8811,7 +8823,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_225",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8850,7 +8862,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_226",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_229",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8889,7 +8901,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_227",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8928,7 +8940,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_228",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_231",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -8967,7 +8979,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_229",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_232",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9006,7 +9018,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_230",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_233",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9045,7 +9057,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_231",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9084,7 +9096,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_232",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9123,7 +9135,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_233",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_236",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9162,7 +9174,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_234",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_237",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9201,7 +9213,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_235",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_238",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9240,7 +9252,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_236",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_239",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9279,7 +9291,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_237",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9318,7 +9330,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_238",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_241",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9357,7 +9369,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_239",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_242",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9396,7 +9408,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_240",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_243",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9435,7 +9447,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_241",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_244",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9474,7 +9486,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_242",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9513,7 +9525,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_243",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
                             "sample document": {
                                 "sample identifier": "reference_A3",
                                 "location identifier": "A3",
@@ -9523,6 +9535,18 @@
                             "absorbance": {
                                 "value": 0.01,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Background (A260)"
+                                    }
+                                ]
                             },
                             "custom information document": {
                                 "electronic absorbance reference absorbance": 0.0
@@ -9562,7 +9586,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_244",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -9601,7 +9625,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_245",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_251",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -9640,7 +9664,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -9679,7 +9703,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_247",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_253",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -9718,7 +9742,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_248",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_254",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -9757,7 +9781,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_249",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -9796,7 +9820,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_250",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_256",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -9835,7 +9859,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_251",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_257",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -9874,7 +9898,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_252",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -9913,7 +9937,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_253",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_259",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -9952,7 +9976,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_254",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -9991,7 +10015,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_255",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_261",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10030,7 +10054,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_256",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_262",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10069,7 +10093,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_257",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_263",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10108,7 +10132,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_258",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10147,7 +10171,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_259",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10186,7 +10210,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_260",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_266",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10225,7 +10249,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_261",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_267",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10264,7 +10288,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_262",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_268",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10303,7 +10327,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_263",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_269",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10342,7 +10366,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_264",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10381,7 +10405,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_265",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_271",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10420,7 +10444,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_266",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_272",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10459,7 +10483,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_267",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_273",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10498,7 +10522,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_268",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_274",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10537,7 +10561,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_269",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10576,7 +10600,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_270",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10615,7 +10639,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_271",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_277",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10654,7 +10678,7 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_272",
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_278",
                             "sample document": {
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
@@ -10693,240 +10717,6 @@
                                     }
                                 ]
                             },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_273",
-                            "sample document": {
-                                "sample identifier": "blank_B3",
-                                "location identifier": "B3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "Plate 1",
-                                "custom information document": {
-                                    "path length": 10.0
-                                }
-                            },
-                            "absorbance": {
-                                "value": 0.0,
-                                "unit": "mAU"
-                            },
-                            "custom information document": {
-                                "electronic absorbance reference absorbance": 0.0
-                            }
-                        },
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 260.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 340.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_274",
-                            "sample document": {
-                                "sample identifier": "blank_B3",
-                                "location identifier": "B3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "Plate 1",
-                                "custom information document": {
-                                    "path length": 10.0
-                                }
-                            },
-                            "absorbance": {
-                                "value": 0.0,
-                                "unit": "mAU"
-                            },
-                            "custom information document": {
-                                "electronic absorbance reference absorbance": 0.0
-                            }
-                        },
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 261.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 340.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_275",
-                            "sample document": {
-                                "sample identifier": "blank_B3",
-                                "location identifier": "B3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "Plate 1",
-                                "custom information document": {
-                                    "path length": 10.0
-                                }
-                            },
-                            "absorbance": {
-                                "value": 0.0,
-                                "unit": "mAU"
-                            },
-                            "custom information document": {
-                                "electronic absorbance reference absorbance": 0.0
-                            }
-                        },
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 262.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 340.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_276",
-                            "sample document": {
-                                "sample identifier": "blank_B3",
-                                "location identifier": "B3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "Plate 1",
-                                "custom information document": {
-                                    "path length": 10.0
-                                }
-                            },
-                            "absorbance": {
-                                "value": 0.0,
-                                "unit": "mAU"
-                            },
-                            "custom information document": {
-                                "electronic absorbance reference absorbance": 0.0
-                            }
-                        },
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 263.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 340.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_277",
-                            "sample document": {
-                                "sample identifier": "blank_B3",
-                                "location identifier": "B3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "Plate 1",
-                                "custom information document": {
-                                    "path length": 10.0
-                                }
-                            },
-                            "absorbance": {
-                                "value": 0.0,
-                                "unit": "mAU"
-                            },
-                            "custom information document": {
-                                "electronic absorbance reference absorbance": 0.0
-                            }
-                        },
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 264.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 340.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
-                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_278",
-                            "sample document": {
-                                "sample identifier": "blank_B3",
-                                "location identifier": "B3",
-                                "batch identifier": "Sample Group",
-                                "well plate identifier": "Plate 1",
-                                "custom information document": {
-                                    "path length": 10.0
-                                }
-                            },
-                            "absorbance": {
-                                "value": 0.0,
-                                "unit": "mAU"
-                            },
-                            "custom information document": {
-                                "electronic absorbance reference absorbance": 0.0
-                            }
-                        },
-                        {
-                            "device control aggregate document": {
-                                "device control document": [
-                                    {
-                                        "device type": "plate reader",
-                                        "detection type": "Absorbance",
-                                        "detector wavelength setting": {
-                                            "value": 265.0,
-                                            "unit": "nm"
-                                        },
-                                        "electronic absorbance reference wavelength setting": {
-                                            "value": 340.0,
-                                            "unit": "nm"
-                                        },
-                                        "custom information document": {
-                                            "path length mode": "single",
-                                            "pump": "0"
-                                        }
-                                    }
-                                ]
-                            },
                             "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_279",
                             "sample document": {
                                 "sample identifier": "blank_B3",
@@ -10952,7 +10742,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 266.0,
+                                            "value": 260.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -10991,7 +10781,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 267.0,
+                                            "value": 261.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11030,7 +10820,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 268.0,
+                                            "value": 262.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11069,7 +10859,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 269.0,
+                                            "value": 263.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11108,7 +10898,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 270.0,
+                                            "value": 264.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11147,7 +10937,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 271.0,
+                                            "value": 265.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11186,7 +10976,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 272.0,
+                                            "value": 266.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11225,7 +11015,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 273.0,
+                                            "value": 267.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11264,7 +11054,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 274.0,
+                                            "value": 268.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11303,7 +11093,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 275.0,
+                                            "value": 269.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11342,7 +11132,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 276.0,
+                                            "value": 270.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11381,7 +11171,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 277.0,
+                                            "value": 271.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11420,7 +11210,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 278.0,
+                                            "value": 272.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11459,7 +11249,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 279.0,
+                                            "value": 273.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11498,7 +11288,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 280.0,
+                                            "value": 274.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11537,7 +11327,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 281.0,
+                                            "value": 275.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11576,7 +11366,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 282.0,
+                                            "value": 276.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11615,7 +11405,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 283.0,
+                                            "value": 277.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11654,7 +11444,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 284.0,
+                                            "value": 278.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11693,7 +11483,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 285.0,
+                                            "value": 279.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11732,7 +11522,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 286.0,
+                                            "value": 280.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11771,7 +11561,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 287.0,
+                                            "value": 281.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11810,7 +11600,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 288.0,
+                                            "value": 282.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11849,7 +11639,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 289.0,
+                                            "value": 283.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11888,7 +11678,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 290.0,
+                                            "value": 284.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11927,7 +11717,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 291.0,
+                                            "value": 285.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -11966,7 +11756,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 292.0,
+                                            "value": 286.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12005,7 +11795,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 293.0,
+                                            "value": 287.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12044,7 +11834,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 294.0,
+                                            "value": 288.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12083,7 +11873,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 295.0,
+                                            "value": 289.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12122,7 +11912,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 296.0,
+                                            "value": 290.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12161,7 +11951,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 297.0,
+                                            "value": 291.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12200,7 +11990,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 298.0,
+                                            "value": 292.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12239,7 +12029,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 299.0,
+                                            "value": 293.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12278,7 +12068,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 300.0,
+                                            "value": 294.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12317,7 +12107,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 301.0,
+                                            "value": 295.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12356,7 +12146,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 302.0,
+                                            "value": 296.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12395,7 +12185,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 303.0,
+                                            "value": 297.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12434,7 +12224,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 304.0,
+                                            "value": 298.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12473,7 +12263,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 305.0,
+                                            "value": 299.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12512,7 +12302,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 306.0,
+                                            "value": 300.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12551,7 +12341,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 307.0,
+                                            "value": 301.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12590,7 +12380,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 308.0,
+                                            "value": 302.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12629,7 +12419,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 309.0,
+                                            "value": 303.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12668,7 +12458,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 310.0,
+                                            "value": 304.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12707,7 +12497,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 311.0,
+                                            "value": 305.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12746,7 +12536,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 312.0,
+                                            "value": 306.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12785,7 +12575,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 313.0,
+                                            "value": 307.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12824,7 +12614,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 314.0,
+                                            "value": 308.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12863,7 +12653,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 315.0,
+                                            "value": 309.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12902,7 +12692,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 316.0,
+                                            "value": 310.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12941,7 +12731,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 317.0,
+                                            "value": 311.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -12980,7 +12770,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 318.0,
+                                            "value": 312.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13019,7 +12809,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 319.0,
+                                            "value": 313.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13058,7 +12848,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 320.0,
+                                            "value": 314.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13097,7 +12887,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 321.0,
+                                            "value": 315.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13136,7 +12926,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 322.0,
+                                            "value": 316.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13175,7 +12965,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 323.0,
+                                            "value": 317.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13214,7 +13004,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 324.0,
+                                            "value": 318.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13253,7 +13043,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 325.0,
+                                            "value": 319.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13292,7 +13082,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 326.0,
+                                            "value": 320.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13331,7 +13121,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 327.0,
+                                            "value": 321.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13370,7 +13160,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 328.0,
+                                            "value": 322.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13409,7 +13199,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 329.0,
+                                            "value": 323.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13448,7 +13238,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 330.0,
+                                            "value": 324.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13487,7 +13277,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 331.0,
+                                            "value": 325.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13526,7 +13316,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 332.0,
+                                            "value": 326.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13565,7 +13355,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 333.0,
+                                            "value": 327.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13604,7 +13394,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 334.0,
+                                            "value": 328.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13643,7 +13433,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 335.0,
+                                            "value": 329.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13682,7 +13472,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 336.0,
+                                            "value": 330.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13721,7 +13511,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 337.0,
+                                            "value": 331.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13760,7 +13550,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 338.0,
+                                            "value": 332.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13799,7 +13589,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 339.0,
+                                            "value": 333.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13838,7 +13628,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 340.0,
+                                            "value": 334.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13877,7 +13667,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 341.0,
+                                            "value": 335.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13916,7 +13706,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 342.0,
+                                            "value": 336.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13955,7 +13745,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 343.0,
+                                            "value": 337.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -13994,7 +13784,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 344.0,
+                                            "value": 338.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -14033,7 +13823,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 345.0,
+                                            "value": 339.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -14072,7 +13862,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 346.0,
+                                            "value": 340.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -14111,7 +13901,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 347.0,
+                                            "value": 341.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -14150,7 +13940,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 348.0,
+                                            "value": 342.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -14189,7 +13979,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 349.0,
+                                            "value": 343.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -14228,7 +14018,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 350.0,
+                                            "value": 344.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -14267,7 +14057,7 @@
                                         "device type": "plate reader",
                                         "detection type": "Absorbance",
                                         "detector wavelength setting": {
-                                            "value": 260.0,
+                                            "value": 345.0,
                                             "unit": "nm"
                                         },
                                         "electronic absorbance reference wavelength setting": {
@@ -14286,11 +14076,265 @@
                                 "sample identifier": "blank_B3",
                                 "location identifier": "B3",
                                 "batch identifier": "Sample Group",
+                                "well plate identifier": "Plate 1",
+                                "custom information document": {
+                                    "path length": 10.0
+                                }
+                            },
+                            "absorbance": {
+                                "value": 0.0,
+                                "unit": "mAU"
+                            },
+                            "custom information document": {
+                                "electronic absorbance reference absorbance": 0.0
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 346.0,
+                                            "unit": "nm"
+                                        },
+                                        "electronic absorbance reference wavelength setting": {
+                                            "value": 340.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_366",
+                            "sample document": {
+                                "sample identifier": "blank_B3",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "Plate 1",
+                                "custom information document": {
+                                    "path length": 10.0
+                                }
+                            },
+                            "absorbance": {
+                                "value": 0.0,
+                                "unit": "mAU"
+                            },
+                            "custom information document": {
+                                "electronic absorbance reference absorbance": 0.0
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 347.0,
+                                            "unit": "nm"
+                                        },
+                                        "electronic absorbance reference wavelength setting": {
+                                            "value": 340.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_367",
+                            "sample document": {
+                                "sample identifier": "blank_B3",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "Plate 1",
+                                "custom information document": {
+                                    "path length": 10.0
+                                }
+                            },
+                            "absorbance": {
+                                "value": 0.0,
+                                "unit": "mAU"
+                            },
+                            "custom information document": {
+                                "electronic absorbance reference absorbance": 0.0
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 348.0,
+                                            "unit": "nm"
+                                        },
+                                        "electronic absorbance reference wavelength setting": {
+                                            "value": 340.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_368",
+                            "sample document": {
+                                "sample identifier": "blank_B3",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "Plate 1",
+                                "custom information document": {
+                                    "path length": 10.0
+                                }
+                            },
+                            "absorbance": {
+                                "value": 0.0,
+                                "unit": "mAU"
+                            },
+                            "custom information document": {
+                                "electronic absorbance reference absorbance": 0.0
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 349.0,
+                                            "unit": "nm"
+                                        },
+                                        "electronic absorbance reference wavelength setting": {
+                                            "value": 340.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_369",
+                            "sample document": {
+                                "sample identifier": "blank_B3",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "Plate 1",
+                                "custom information document": {
+                                    "path length": 10.0
+                                }
+                            },
+                            "absorbance": {
+                                "value": 0.0,
+                                "unit": "mAU"
+                            },
+                            "custom information document": {
+                                "electronic absorbance reference absorbance": 0.0
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 350.0,
+                                            "unit": "nm"
+                                        },
+                                        "electronic absorbance reference wavelength setting": {
+                                            "value": 340.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_370",
+                            "sample document": {
+                                "sample identifier": "blank_B3",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group",
+                                "well plate identifier": "Plate 1",
+                                "custom information document": {
+                                    "path length": 10.0
+                                }
+                            },
+                            "absorbance": {
+                                "value": 0.0,
+                                "unit": "mAU"
+                            },
+                            "custom information document": {
+                                "electronic absorbance reference absorbance": 0.0
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "plate reader",
+                                        "detection type": "Absorbance",
+                                        "detector wavelength setting": {
+                                            "value": 260.0,
+                                            "unit": "nm"
+                                        },
+                                        "electronic absorbance reference wavelength setting": {
+                                            "value": 340.0,
+                                            "unit": "nm"
+                                        },
+                                        "custom information document": {
+                                            "path length mode": "single",
+                                            "pump": "0"
+                                        }
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_371",
+                            "sample document": {
+                                "sample identifier": "blank_B3",
+                                "location identifier": "B3",
+                                "batch identifier": "Sample Group",
                                 "well plate identifier": "Plate 1"
                             },
                             "absorbance": {
                                 "value": 0.0,
                                 "unit": "mAU"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Concentration"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "Background (A260)"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A230"
+                                    },
+                                    {
+                                        "error": "N/A",
+                                        "error feature": "A260/A280"
+                                    }
+                                ]
                             },
                             "custom information document": {
                                 "electronic absorbance reference absorbance": 0.0
@@ -14307,6 +14351,122 @@
                 }
             }
         ],
+        "calculated data aggregate document": {
+            "calculated data document": [
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 29.2,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_122",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 0.8,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_123",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.65,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_124",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_121",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.7,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_247",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A230",
+                    "calculated result": {
+                        "value": 2.63,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_248",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "A260/A280",
+                    "calculated result": {
+                        "value": 1.28,
+                        "unit": "(unitless)"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_249",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_246",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "calculated data name": "Concentration",
+                    "calculated result": {
+                        "value": 0.0,
+                        "unit": "ng/µL"
+                    },
+                    "calculated data identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_372",
+                    "data source aggregate document": {
+                        "data source document": [
+                            {
+                                "data source identifier": "UNCHAINED_LABS_LUNATIC_TEST_ID_371",
+                                "data source feature": "absorbance"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
         "data system document": {
             "ASM file identifier": "spectrum_measurement.json",
             "data system instance identifier": "N/A",

--- a/tests/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure_test.py
+++ b/tests/parsers/unchained_labs_lunatic/unchained_labs_lunatic_structure_test.py
@@ -45,9 +45,9 @@ def test__create_measurement(
     wavelength_column = f"A{wavelength}"
     well_plate_data = {
         wavelength_column: absorbance_value,
-        "Sample name": sample_identifier,
-        "Plate ID": well_plate_identifier,
-        "Plate Position": location_identifier,
+        "sample name": sample_identifier,
+        "plate id": well_plate_identifier,
+        "plate position": location_identifier,
     }
     header = SeriesData(pd.Series())
     measurement = _create_measurement(
@@ -65,14 +65,14 @@ def test__create_measurement_with_no_wavelength_column() -> None:
     well_plate_data = SeriesData(
         pd.Series(
             {
-                "Sample name": "dummy name",
-                "Plate ID": "some plate",
-                "Plate Position": "B3",
+                "sample name": "dummy name",
+                "plate id": "some plate",
+                "plate position": "B3",
             }
         )
     )
     header = SeriesData(pd.Series())
-    wavelength_column = "A250"
+    wavelength_column = "a250"
     msg = NO_MEASUREMENT_IN_PLATE_ERROR_MSG.format(wavelength_column)
     with pytest.raises(AllotropeConversionError, match=msg):
         _create_measurement(well_plate_data, header, wavelength_column, [])
@@ -80,26 +80,26 @@ def test__create_measurement_with_no_wavelength_column() -> None:
 
 def test__create_measurement_with_incorrect_wavelength_column_format() -> None:
     msg = INCORRECT_WAVELENGTH_COLUMN_FORMAT_ERROR_MSG
-    well_plate_data = SeriesData(pd.Series({"Sample name": "dummy name"}))
+    well_plate_data = SeriesData(pd.Series({"sample name": "dummy name"}))
     header = SeriesData(pd.Series())
     with pytest.raises(AllotropeConversionError, match=re.escape(msg)):
-        _create_measurement(well_plate_data, header, "Sample name", [])
+        _create_measurement(well_plate_data, header, "sample name", [])
 
 
 def test__get_calculated_data_from_measurement_for_unknown_wavelength() -> None:
     calculated_data: list[CalculatedDataItem] = []
     well_plate_data = {
-        "Sample name": "dummy name",
-        "Plate ID": "some plate",
-        "Plate Position": "B3",
-        "A240": 0.5,
-        "A260": 0,
-        "A260 Concentration (ng/ul)": 4.5,
-        "Background (A260)": 0.523,
+        "sample name": "dummy name",
+        "plate id": "some plate",
+        "plate position": "B3",
+        "a240": 0.5,
+        "a260": 0,
+        "a260 concentration (ng/ul)": 4.5,
+        "background (a260)": 0.523,
     }
     header = SeriesData(pd.Series())
     _create_measurement(
-        SeriesData(pd.Series(well_plate_data)), header, "A240", calculated_data
+        SeriesData(pd.Series(well_plate_data)), header, "a240", calculated_data
     )
 
     assert not calculated_data
@@ -108,17 +108,17 @@ def test__get_calculated_data_from_measurement_for_unknown_wavelength() -> None:
 def test__get_calculated_data_from_measurement_for_A260() -> None:  # noqa: N802
     calculated_data: list[CalculatedDataItem] = []
     well_plate_data = {
-        "Sample name": "dummy name",
-        "Plate ID": "some plate",
-        "Plate Position": "B3",
-        "A260": 34.5,
-        "A260 Concentration (ng/ul)": 4.5,
-        "Background (A260)": 0.523,
-        "A260/A230": 2.5,
-        "A260/A280": 24.9,
+        "sample name": "dummy name",
+        "plate id": "some plate",
+        "plate position": "B3",
+        "a260": 34.5,
+        "a260 concentration (ng/ul)": 4.5,
+        "background (a260)": 0.523,
+        "a260/a230": 2.5,
+        "a260/a280": 24.9,
     }
     header = SeriesData(pd.Series())
-    wavelength = "A260"
+    wavelength = "a260"
     _create_measurement(
         SeriesData(pd.Series(well_plate_data)), header, wavelength, calculated_data
     )
@@ -136,15 +136,15 @@ def test_create_well_plate() -> None:
     date = "17/10/2016"
     time = "7:19:18"
     plate_data = {
-        "A250": 23.45,
-        "Sample name": "dummy name",
-        "Plate Position": "some plate",
-        "Application": analytical_method_identifier,
-        "Date": date,
-        "Time": time,
+        "a250": 23.45,
+        "sample name": "dummy name",
+        "plate position": "some plate",
+        "application": analytical_method_identifier,
+        "date": date,
+        "time": time,
     }
     well_plate = _create_measurement_group(
-        SeriesData(pd.Series(plate_data)), ["A250"], [], SeriesData(pd.Series())
+        SeriesData(pd.Series(plate_data)), ["a250"], [], SeriesData(pd.Series())
     )
     assert well_plate.analytical_method_identifier == analytical_method_identifier
     assert well_plate.measurement_time == f"{date} {time}"
@@ -153,15 +153,15 @@ def test_create_well_plate() -> None:
 
 def test_create_well_plate_with_two_measurements() -> None:
     plate_data = {
-        "A452": 23.45,
-        "A280": 23.45,
-        "Sample name": "dummy name",
-        "Plate Position": "some plate",
-        "Date": "17/10/2016",
-        "Time": "7:19:18",
+        "a452": 23.45,
+        "a280": 23.45,
+        "sample name": "dummy name",
+        "plate position": "some plate",
+        "date": "17/10/2016",
+        "time": "7:19:18",
     }
     well_plate = _create_measurement_group(
-        SeriesData(pd.Series(plate_data)), ["A452", "A280"], [], SeriesData(pd.Series())
+        SeriesData(pd.Series(plate_data)), ["a452", "a280"], [], SeriesData(pd.Series())
     )
 
     assert len(well_plate.measurements) == 2
@@ -174,14 +174,14 @@ def test_create_well_plate_use_datetime_from_data_over_header() -> None:
     plate_data = SeriesData(
         pd.Series(
             {
-                "Sample name": "dummy name",
-                "Plate Position": "some plate",
-                "Date": date,
-                "Time": time,
+                "sample name": "dummy name",
+                "plate position": "some plate",
+                "date": date,
+                "time": time,
             }
         )
     )
-    header = SeriesData(pd.Series({"Date": header_datetime}))
+    header = SeriesData(pd.Series({"date": header_datetime}))
     well_plate = _create_measurement_group(plate_data, [], [], header)
 
     assert well_plate.measurement_time == f"{date} {time}"
@@ -191,14 +191,14 @@ def test_create_well_plate_with_date_from_header() -> None:
     plate_data = SeriesData(
         pd.Series(
             {
-                "Sample name": "dummy name",
-                "Plate Position": "some plate",
-                "Time": "7:19:18",
+                "sample name": "dummy name",
+                "plate position": "some plate",
+                "time": "7:19:18",
             }
         )
     )
     header_datetime = "01/08/2024 10:15:59"
-    header = SeriesData(pd.Series({"Date": header_datetime}))
+    header = SeriesData(pd.Series({"date": header_datetime}))
     well_plate = _create_measurement_group(plate_data, [], [], header)
 
     assert well_plate.measurement_time == "01/08/2024 10:15:59"
@@ -208,9 +208,9 @@ def test_create_well_plate_without_date_column_then_raise() -> None:
     plate_data = SeriesData(
         pd.Series(
             {
-                "Sample name": "dummy name",
-                "Plate Position": "some plate",
-                "Time": "7:19:18",
+                "sample name": "dummy name",
+                "plate position": "some plate",
+                "time": "7:19:18",
             }
         )
     )


### PR DESCRIPTION
We've seen recent failures in Unchained Labs parser because column names can have different case (e.g. "Sample Name" vs "Sample name")

To fix this, force everything to lowercase.