### PR TITLE
fix: Beckman Echo Plate Reformat -  remove accidental volume conversion of survey volume results

### DIFF
--- a/src/allotropy/parsers/beckman_echo_plate_reformat/beckman_echo_plate_reformat_structure.py
+++ b/src/allotropy/parsers/beckman_echo_plate_reformat/beckman_echo_plate_reformat_structure.py
@@ -40,7 +40,7 @@ def _create_measurement(row_data: SeriesData) -> Measurement:
     def convert_echo_nl_to_ul(value: float | None) -> float | None:
         return (
             (value * constants.PLATE_REFORMAT_REPORT_VOLUME_CONVERSION_TO_UL)
-            if value
+            if value is not None
             else None
         )
 

--- a/src/allotropy/parsers/beckman_echo_plate_reformat/beckman_echo_plate_reformat_structure.py
+++ b/src/allotropy/parsers/beckman_echo_plate_reformat/beckman_echo_plate_reformat_structure.py
@@ -61,12 +61,12 @@ def _create_measurement(row_data: SeriesData) -> Measurement:
         ),
         device_control_custom_info={
             "sample name": row_data.get(str, "Sample Name"),
-            "survey fluid volume":
-                row_data.get(float, "Survey Fluid Volume") # This is already in uL, so don't convert to nL
-            ,
-            "current fluid volume":
-                row_data.get(float, "Current Fluid Volume") # This is already in uL, so don't convert to nL
-            ,
+            "survey fluid volume": row_data.get(
+                float, "Survey Fluid Volume"
+            ),  # This is already in uL, so don't convert to nL
+            "current fluid volume": row_data.get(
+                float, "Current Fluid Volume"
+            ),  # This is already in uL, so don't convert to nL
             "intended transfer volume": convert_echo_nl_to_ul(
                 row_data.get(float, "Transfer Volume")
             ),

--- a/src/allotropy/parsers/beckman_echo_plate_reformat/beckman_echo_plate_reformat_structure.py
+++ b/src/allotropy/parsers/beckman_echo_plate_reformat/beckman_echo_plate_reformat_structure.py
@@ -61,12 +61,12 @@ def _create_measurement(row_data: SeriesData) -> Measurement:
         ),
         device_control_custom_info={
             "sample name": row_data.get(str, "Sample Name"),
-            "survey fluid volume": convert_echo_nl_to_ul(
-                row_data.get(float, "Survey Fluid Volume")
-            ),
-            "current fluid volume": convert_echo_nl_to_ul(
-                row_data.get(float, "Current Fluid Volume")
-            ),
+            "survey fluid volume":
+                row_data.get(float, "Survey Fluid Volume") # This is already in uL, so don't convert to nL
+            ,
+            "current fluid volume":
+                row_data.get(float, "Current Fluid Volume") # This is already in uL, so don't convert to nL
+            ,
             "intended transfer volume": convert_echo_nl_to_ul(
                 row_data.get(float, "Transfer Volume")
             ),

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/ExceptionsOnly.json
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/ExceptionsOnly.json
@@ -45,7 +45,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_0",
-                            "measurement time": "2024-12-09T13:29:31.401000+00:00"
+                            "measurement time": "2024-12-09T13:29:31.401000+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -87,7 +95,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_1",
-                            "measurement time": "2024-12-09T13:29:31.426000+00:00"
+                            "measurement time": "2024-12-09T13:29:31.426000+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -129,7 +145,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_2",
-                            "measurement time": "2024-12-09T13:29:34.520000+00:00"
+                            "measurement time": "2024-12-09T13:29:34.520000+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -171,7 +195,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_3",
-                            "measurement time": "2024-12-09T13:29:34.520000+00:00"
+                            "measurement time": "2024-12-09T13:29:34.520000+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         }
                     ],
                     "analytical method identifier": "connect_test_protocol.epr",

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/ExceptionsOnly.json
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/ExceptionsOnly.json
@@ -15,6 +15,8 @@
                                             "unit": "μL"
                                         },
                                         "custom information document": {
+                                            "survey fluid volume": 0.0,
+                                            "current fluid volume": 0.0,
                                             "intended transfer volume": 0.1,
                                             "source labware name": "384PP_AQ_BP",
                                             "destination labware name": "Eppendorf_PCR_384",
@@ -55,6 +57,8 @@
                                             "unit": "μL"
                                         },
                                         "custom information document": {
+                                            "survey fluid volume": 0.0,
+                                            "current fluid volume": 0.0,
                                             "intended transfer volume": 0.1,
                                             "source labware name": "384PP_AQ_BP",
                                             "destination labware name": "Eppendorf_PCR_384",
@@ -95,6 +99,8 @@
                                             "unit": "μL"
                                         },
                                         "custom information document": {
+                                            "survey fluid volume": 0.0,
+                                            "current fluid volume": 0.0,
                                             "intended transfer volume": 0.1,
                                             "source labware name": "384PP_AQ_BP",
                                             "destination labware name": "Eppendorf_PCR_384",
@@ -135,6 +141,8 @@
                                             "unit": "μL"
                                         },
                                         "custom information document": {
+                                            "survey fluid volume": 0.0,
+                                            "current fluid volume": 0.0,
                                             "intended transfer volume": 0.1,
                                             "source labware name": "384PP_AQ_BP",
                                             "destination labware name": "Eppendorf_PCR_384",

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/ExceptionsOnly.json
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/ExceptionsOnly.json
@@ -189,7 +189,7 @@
             "file name": "ExceptionsOnly.csv",
             "UNC path": "tests/parsers/beckman_echo_plate_reformat/testdata/ExceptionsOnly.csv",
             "ASM converter name": "allotropy_beckman_echo_plate_reformat",
-            "ASM converter version": "0.1.80",
+            "ASM converter version": "0.1.87",
             "software name": "Labcyte Echo Plate Reformat",
             "software version": "1.7.2"
         },

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/PartialTransfer.json
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/PartialTransfer.json
@@ -45,7 +45,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_0",
-                            "measurement time": "2024-12-09T13:34:27.411000+00:00"
+                            "measurement time": "2024-12-09T13:34:27.411000+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -87,7 +95,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_1",
-                            "measurement time": "2024-12-09T13:34:27.411000+00:00"
+                            "measurement time": "2024-12-09T13:34:27.411000+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/PartialTransfer.json
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/PartialTransfer.json
@@ -189,7 +189,7 @@
             "file name": "PartialTransfer.csv",
             "UNC path": "tests/parsers/beckman_echo_plate_reformat/testdata/PartialTransfer.csv",
             "ASM converter name": "allotropy_beckman_echo_plate_reformat",
-            "ASM converter version": "0.1.80",
+            "ASM converter version": "0.1.87",
             "software name": "Labcyte Echo Plate Reformat",
             "software version": "1.7.2"
         },

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/PartialTransfer.json
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/PartialTransfer.json
@@ -15,6 +15,8 @@
                                             "unit": "μL"
                                         },
                                         "custom information document": {
+                                            "survey fluid volume": 0.0,
+                                            "current fluid volume": 0.0,
                                             "intended transfer volume": 0.1,
                                             "source labware name": "384PP_AQ_BP",
                                             "destination labware name": "Eppendorf_PCR_384",
@@ -55,6 +57,8 @@
                                             "unit": "μL"
                                         },
                                         "custom information document": {
+                                            "survey fluid volume": 0.0,
+                                            "current fluid volume": 0.0,
                                             "intended transfer volume": 0.1,
                                             "source labware name": "384PP_AQ_BP",
                                             "destination labware name": "Eppendorf_PCR_384",
@@ -95,8 +99,8 @@
                                             "unit": "μL"
                                         },
                                         "custom information document": {
-                                            "survey fluid volume": 0.053678,
-                                            "current fluid volume": 0.053578,
+                                            "survey fluid volume": 53.678,
+                                            "current fluid volume": 53.578,
                                             "intended transfer volume": 0.1,
                                             "source labware name": "384PP_AQ_BP",
                                             "destination labware name": "Eppendorf_PCR_384",
@@ -137,8 +141,8 @@
                                             "unit": "μL"
                                         },
                                         "custom information document": {
-                                            "survey fluid volume": 0.053678,
-                                            "current fluid volume": 0.053478000000000005,
+                                            "survey fluid volume": 53.678,
+                                            "current fluid volume": 53.478,
                                             "intended transfer volume": 0.1,
                                             "source labware name": "384PP_AQ_BP",
                                             "destination labware name": "Eppendorf_PCR_384",

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/SurveyVolumeExamples.csv
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/SurveyVolumeExamples.csv
@@ -1,0 +1,159 @@
+Run ID,1741720420
+Run Date/Time,3/11/2025 15:14
+Application Name,Labcyte Echo Plate Reformat
+Application Version,1.7.2
+Protocol Name,SeV_r2_exc1.epr
+Order ID,1
+Reference ID,1
+User Name,LabAutomation
+
+[EXCEPTIONS]
+Date Time Point,Source Plate Name,Source Plate Barcode,Source Plate Type,Source Well,Destination Plate Name,Destination Plate Barcode,Destination Plate Type,Destination Well,Transfer Volume,Actual Volume,Sample ID,Sample Name,Survey Fluid Volume,Current Fluid Volume,Fluid Composition,Fluid Units,Fluid Type,Transfer Status
+15:54.8,Source[1],EchoSource001,384PP_AQ_BP,C21,Destination[1],EchoDestination001,Eppendorf_PCR_384,J15,1000,0,,,13.251,9.251,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:55.0,Source[1],EchoSource001,384PP_AQ_BP,B21,Destination[1],EchoDestination001,Eppendorf_PCR_384,K15,1000,0,,,13.182,9.182,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:55.1,Source[1],EchoSource001,384PP_AQ_BP,B23,Destination[1],EchoDestination001,Eppendorf_PCR_384,L15,1000,0,,,13.01,9.01,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:55.3,Source[1],EchoSource001,384PP_AQ_BP,D22,Destination[1],EchoDestination001,Eppendorf_PCR_384,L16,1000,0,,,13.872,8.872,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:55.5,Source[1],EchoSource001,384PP_AQ_BP,A21,Destination[1],EchoDestination001,Eppendorf_PCR_384,K16,1000,0,,,12.837,8.837,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:55.7,Source[1],EchoSource001,384PP_AQ_BP,C23,Destination[1],EchoDestination001,Eppendorf_PCR_384,J16,1000,0,,,11.75,8.75,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:56.0,Source[1],EchoSource001,384PP_AQ_BP,D24,Destination[1],EchoDestination001,Eppendorf_PCR_384,I16,1000,0,,,11.733,8.733,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:56.2,Source[1],EchoSource001,384PP_AQ_BP,D21,Destination[1],EchoDestination001,Eppendorf_PCR_384,H16,1000,0,,,14.683,8.683,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:56.4,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,G16,1000,0,,,17.677,8.677,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:56.6,Source[1],EchoSource001,384PP_AQ_BP,B24,Destination[1],EchoDestination001,Eppendorf_PCR_384,F16,1000,0,,,11.629,8.629,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:56.8,Source[1],EchoSource001,384PP_AQ_BP,C24,Destination[1],EchoDestination001,Eppendorf_PCR_384,E16,1000,0,,,13.579,8.579,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:57.0,Source[1],EchoSource001,384PP_AQ_BP,A22,Destination[1],EchoDestination001,Eppendorf_PCR_384,D16,1000,0,,,17.573,8.573,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:57.1,Source[1],EchoSource001,384PP_AQ_BP,D23,Destination[1],EchoDestination001,Eppendorf_PCR_384,D17,1000,0,,,13.562,8.562,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:57.4,Source[1],EchoSource001,384PP_AQ_BP,A23,Destination[1],EchoDestination001,Eppendorf_PCR_384,E17,1000,0,,,17.553,8.553,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:57.7,Source[1],EchoSource001,384PP_AQ_BP,C22,Destination[1],EchoDestination001,Eppendorf_PCR_384,F17,1000,0,,,14.304,8.304,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:57.8,Source[1],EchoSource001,384PP_AQ_BP,B22,Destination[1],EchoDestination001,Eppendorf_PCR_384,G17,1000,0,,,12.302,8.302,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:58.0,Source[1],EchoSource001,384PP_AQ_BP,C21,Destination[1],EchoDestination001,Eppendorf_PCR_384,H17,1000,0,,,13.251,9.251,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:58.2,Source[1],EchoSource001,384PP_AQ_BP,B21,Destination[1],EchoDestination001,Eppendorf_PCR_384,I17,1000,0,,,13.182,9.182,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:58.3,Source[1],EchoSource001,384PP_AQ_BP,B23,Destination[1],EchoDestination001,Eppendorf_PCR_384,J17,1000,0,,,13.01,9.01,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:58.5,Source[1],EchoSource001,384PP_AQ_BP,D22,Destination[1],EchoDestination001,Eppendorf_PCR_384,K17,1000,0,,,13.872,8.872,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:58.7,Source[1],EchoSource001,384PP_AQ_BP,A21,Destination[1],EchoDestination001,Eppendorf_PCR_384,L17,1000,0,,,12.837,8.837,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:59.0,Source[1],EchoSource001,384PP_AQ_BP,C23,Destination[1],EchoDestination001,Eppendorf_PCR_384,L18,1000,0,,,11.75,8.75,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:59.2,Source[1],EchoSource001,384PP_AQ_BP,D24,Destination[1],EchoDestination001,Eppendorf_PCR_384,K18,1000,0,,,11.733,8.733,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:59.4,Source[1],EchoSource001,384PP_AQ_BP,D21,Destination[1],EchoDestination001,Eppendorf_PCR_384,J18,1000,0,,,14.683,8.683,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:59.6,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,I18,1000,0,,,17.677,8.677,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+15:59.8,Source[1],EchoSource001,384PP_AQ_BP,B24,Destination[1],EchoDestination001,Eppendorf_PCR_384,H18,1000,0,,,11.629,8.629,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:00.0,Source[1],EchoSource001,384PP_AQ_BP,C24,Destination[1],EchoDestination001,Eppendorf_PCR_384,G18,1000,0,,,13.579,8.579,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:00.2,Source[1],EchoSource001,384PP_AQ_BP,A22,Destination[1],EchoDestination001,Eppendorf_PCR_384,F18,1000,0,,,17.573,8.573,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:00.4,Source[1],EchoSource001,384PP_AQ_BP,D23,Destination[1],EchoDestination001,Eppendorf_PCR_384,E18,1000,0,,,13.562,8.562,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:00.7,Source[1],EchoSource001,384PP_AQ_BP,A23,Destination[1],EchoDestination001,Eppendorf_PCR_384,D18,1000,0,,,17.553,8.553,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:00.9,Source[1],EchoSource001,384PP_AQ_BP,C22,Destination[1],EchoDestination001,Eppendorf_PCR_384,D19,1000,0,,,14.304,8.304,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:01.1,Source[1],EchoSource001,384PP_AQ_BP,B22,Destination[1],EchoDestination001,Eppendorf_PCR_384,E19,1000,0,,,12.302,8.302,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:01.2,Source[1],EchoSource001,384PP_AQ_BP,C21,Destination[1],EchoDestination001,Eppendorf_PCR_384,F19,1000,0,,,13.251,9.251,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:01.4,Source[1],EchoSource001,384PP_AQ_BP,B21,Destination[1],EchoDestination001,Eppendorf_PCR_384,G19,1000,0,,,13.182,9.182,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:01.6,Source[1],EchoSource001,384PP_AQ_BP,B23,Destination[1],EchoDestination001,Eppendorf_PCR_384,H19,1000,0,,,13.01,9.01,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:01.8,Source[1],EchoSource001,384PP_AQ_BP,D22,Destination[1],EchoDestination001,Eppendorf_PCR_384,I19,1000,0,,,13.872,8.872,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:01.9,Source[1],EchoSource001,384PP_AQ_BP,A21,Destination[1],EchoDestination001,Eppendorf_PCR_384,J19,1000,0,,,12.837,8.837,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:02.2,Source[1],EchoSource001,384PP_AQ_BP,C23,Destination[1],EchoDestination001,Eppendorf_PCR_384,K19,1000,0,,,11.75,8.75,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:02.4,Source[1],EchoSource001,384PP_AQ_BP,D24,Destination[1],EchoDestination001,Eppendorf_PCR_384,L19,1000,0,,,11.733,8.733,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:02.5,Source[1],EchoSource001,384PP_AQ_BP,D21,Destination[1],EchoDestination001,Eppendorf_PCR_384,L20,1000,0,,,14.683,8.683,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:02.7,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,K20,1000,0,,,17.677,8.677,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:03.0,Source[1],EchoSource001,384PP_AQ_BP,B24,Destination[1],EchoDestination001,Eppendorf_PCR_384,J20,1000,0,,,11.629,8.629,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:03.2,Source[1],EchoSource001,384PP_AQ_BP,C24,Destination[1],EchoDestination001,Eppendorf_PCR_384,I20,1000,0,,,13.579,8.579,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:03.3,Source[1],EchoSource001,384PP_AQ_BP,A22,Destination[1],EchoDestination001,Eppendorf_PCR_384,H20,1000,0,,,17.573,8.573,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:03.5,Source[1],EchoSource001,384PP_AQ_BP,D23,Destination[1],EchoDestination001,Eppendorf_PCR_384,G20,1000,0,,,13.562,8.562,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:03.8,Source[1],EchoSource001,384PP_AQ_BP,A23,Destination[1],EchoDestination001,Eppendorf_PCR_384,F20,1000,0,,,17.553,8.553,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:04.0,Source[1],EchoSource001,384PP_AQ_BP,C22,Destination[1],EchoDestination001,Eppendorf_PCR_384,E20,1000,0,,,14.304,8.304,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:04.3,Source[1],EchoSource001,384PP_AQ_BP,B22,Destination[1],EchoDestination001,Eppendorf_PCR_384,D20,1000,0,,,12.302,8.302,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:07.6,Source[1],EchoSource001,384PP_AQ_BP,C21,Destination[1],EchoDestination001,Eppendorf_PCR_384,D22,1000,0,,,13.251,9.251,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:07.8,Source[1],EchoSource001,384PP_AQ_BP,B21,Destination[1],EchoDestination001,Eppendorf_PCR_384,E22,1000,0,,,13.182,9.182,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:08.0,Source[1],EchoSource001,384PP_AQ_BP,B23,Destination[1],EchoDestination001,Eppendorf_PCR_384,F22,1000,0,,,13.01,9.01,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:08.2,Source[1],EchoSource001,384PP_AQ_BP,D22,Destination[1],EchoDestination001,Eppendorf_PCR_384,G22,1000,0,,,13.872,8.872,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:08.4,Source[1],EchoSource001,384PP_AQ_BP,A21,Destination[1],EchoDestination001,Eppendorf_PCR_384,H22,1000,0,,,12.837,8.837,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:08.6,Source[1],EchoSource001,384PP_AQ_BP,C23,Destination[1],EchoDestination001,Eppendorf_PCR_384,I22,1000,0,,,11.75,8.75,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:08.8,Source[1],EchoSource001,384PP_AQ_BP,D24,Destination[1],EchoDestination001,Eppendorf_PCR_384,J22,1000,0,,,11.733,8.733,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:09.0,Source[1],EchoSource001,384PP_AQ_BP,D21,Destination[1],EchoDestination001,Eppendorf_PCR_384,K22,1000,0,,,14.683,8.683,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+16:09.2,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,L22,1000,0,,,17.677,8.677,100,,AQ,MM0202001: Current fluid height below minimum transfer level
+
+[DETAILS]
+Date Time Point,Source Plate Name,Source Plate Barcode,Source Plate Type,Source Well,Destination Plate Name,Destination Plate Barcode,Destination Plate Type,Destination Well,Transfer Volume,Actual Volume,Sample ID,Sample Name,Survey Fluid Volume,Current Fluid Volume,Fluid Composition,Fluid Units,Fluid Type,Transfer Status
+14:58.0,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,D4,1000,1000,,,17.677,16.677,100,,AQ,
+14:58.6,Source[1],EchoSource001,384PP_AQ_BP,A22,Destination[1],EchoDestination001,Eppendorf_PCR_384,E4,1000,1000,,,17.573,16.573,100,,AQ,
+14:58.9,Source[1],EchoSource001,384PP_AQ_BP,A23,Destination[1],EchoDestination001,Eppendorf_PCR_384,F4,1000,1000,,,17.553,16.553,100,,AQ,
+14:59.2,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,G4,1000,1000,,,17.677,15.677,100,,AQ,
+14:59.5,Source[1],EchoSource001,384PP_AQ_BP,A22,Destination[1],EchoDestination001,Eppendorf_PCR_384,H4,1000,1000,,,17.573,15.573,100,,AQ,
+15:03.2,Source[1],EchoSource001,384PP_AQ_BP,A23,Destination[1],EchoDestination001,Eppendorf_PCR_384,D5,1000,1000,,,17.553,15.553,100,,AQ,
+15:03.6,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,E5,1000,1000,,,17.677,14.677,100,,AQ,
+15:03.9,Source[1],EchoSource001,384PP_AQ_BP,A22,Destination[1],EchoDestination001,Eppendorf_PCR_384,F5,1000,1000,,,17.573,14.573,100,,AQ,
+15:04.3,Source[1],EchoSource001,384PP_AQ_BP,A23,Destination[1],EchoDestination001,Eppendorf_PCR_384,G5,1000,1000,,,17.553,14.553,100,,AQ,
+15:04.5,Source[1],EchoSource001,384PP_AQ_BP,D21,Destination[1],EchoDestination001,Eppendorf_PCR_384,H5,1000,1000,,,14.683,13.683,100,,AQ,
+15:04.9,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,I5,1000,1000,,,17.677,13.677,100,,AQ,
+15:05.3,Source[1],EchoSource001,384PP_AQ_BP,A22,Destination[1],EchoDestination001,Eppendorf_PCR_384,J5,1000,1000,,,17.573,13.573,100,,AQ,
+15:05.7,Source[1],EchoSource001,384PP_AQ_BP,A23,Destination[1],EchoDestination001,Eppendorf_PCR_384,K5,1000,1000,,,17.553,13.553,100,,AQ,
+15:06.0,Source[1],EchoSource001,384PP_AQ_BP,C22,Destination[1],EchoDestination001,Eppendorf_PCR_384,L5,1000,1000,,,14.304,13.304,100,,AQ,
+15:09.5,Source[1],EchoSource001,384PP_AQ_BP,D22,Destination[1],EchoDestination001,Eppendorf_PCR_384,D6,1000,1000,,,13.872,12.872,100,,AQ,
+15:10.2,Source[1],EchoSource001,384PP_AQ_BP,D21,Destination[1],EchoDestination001,Eppendorf_PCR_384,E6,1000,1000,,,14.683,12.683,100,,AQ,
+15:10.4,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,F6,1000,1000,,,17.677,12.677,100,,AQ,
+15:10.9,Source[1],EchoSource001,384PP_AQ_BP,C24,Destination[1],EchoDestination001,Eppendorf_PCR_384,G6,1000,1000,,,13.579,12.579,100,,AQ,
+15:11.2,Source[1],EchoSource001,384PP_AQ_BP,A22,Destination[1],EchoDestination001,Eppendorf_PCR_384,H6,1000,1000,,,17.573,12.573,100,,AQ,
+15:11.6,Source[1],EchoSource001,384PP_AQ_BP,D23,Destination[1],EchoDestination001,Eppendorf_PCR_384,I6,1000,1000,,,13.562,12.562,100,,AQ,
+15:12.0,Source[1],EchoSource001,384PP_AQ_BP,A23,Destination[1],EchoDestination001,Eppendorf_PCR_384,J6,1000,1000,,,17.553,12.553,100,,AQ,
+15:12.4,Source[1],EchoSource001,384PP_AQ_BP,C22,Destination[1],EchoDestination001,Eppendorf_PCR_384,K6,1000,1000,,,14.304,12.304,100,,AQ,
+15:12.7,Source[1],EchoSource001,384PP_AQ_BP,C21,Destination[1],EchoDestination001,Eppendorf_PCR_384,L6,1000,1000,,,13.251,12.251,100,,AQ,
+15:16.2,Source[1],EchoSource001,384PP_AQ_BP,B21,Destination[1],EchoDestination001,Eppendorf_PCR_384,D8,1000,1000,,,13.182,12.182,100,,AQ,
+15:16.8,Source[1],EchoSource001,384PP_AQ_BP,B23,Destination[1],EchoDestination001,Eppendorf_PCR_384,E8,1000,1000,,,13.01,12.01,100,,AQ,
+15:17.1,Source[1],EchoSource001,384PP_AQ_BP,D22,Destination[1],EchoDestination001,Eppendorf_PCR_384,F8,1000,1000,,,13.872,11.872,100,,AQ,
+15:17.5,Source[1],EchoSource001,384PP_AQ_BP,A21,Destination[1],EchoDestination001,Eppendorf_PCR_384,G8,1000,1000,,,12.837,11.837,100,,AQ,
+15:17.9,Source[1],EchoSource001,384PP_AQ_BP,D21,Destination[1],EchoDestination001,Eppendorf_PCR_384,H8,1000,1000,,,14.683,11.683,100,,AQ,
+15:18.2,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,I8,1000,1000,,,17.677,11.677,100,,AQ,
+15:18.7,Source[1],EchoSource001,384PP_AQ_BP,C24,Destination[1],EchoDestination001,Eppendorf_PCR_384,J8,1000,1000,,,13.579,11.579,100,,AQ,
+15:19.0,Source[1],EchoSource001,384PP_AQ_BP,A22,Destination[1],EchoDestination001,Eppendorf_PCR_384,K8,1000,1000,,,17.573,11.573,100,,AQ,
+15:19.4,Source[1],EchoSource001,384PP_AQ_BP,D23,Destination[1],EchoDestination001,Eppendorf_PCR_384,L8,1000,1000,,,13.562,11.562,100,,AQ,
+15:23.0,Source[1],EchoSource001,384PP_AQ_BP,A23,Destination[1],EchoDestination001,Eppendorf_PCR_384,D9,1000,1000,,,17.553,11.553,100,,AQ,
+15:23.5,Source[1],EchoSource001,384PP_AQ_BP,C22,Destination[1],EchoDestination001,Eppendorf_PCR_384,E9,1000,1000,,,14.304,11.304,100,,AQ,
+15:23.8,Source[1],EchoSource001,384PP_AQ_BP,B22,Destination[1],EchoDestination001,Eppendorf_PCR_384,F9,1000,1000,,,12.302,11.302,100,,AQ,
+15:24.2,Source[1],EchoSource001,384PP_AQ_BP,C21,Destination[1],EchoDestination001,Eppendorf_PCR_384,G9,1000,1000,,,13.251,11.251,100,,AQ,
+15:24.5,Source[1],EchoSource001,384PP_AQ_BP,B21,Destination[1],EchoDestination001,Eppendorf_PCR_384,H9,1000,1000,,,13.182,11.182,100,,AQ,
+15:24.8,Source[1],EchoSource001,384PP_AQ_BP,B23,Destination[1],EchoDestination001,Eppendorf_PCR_384,I9,1000,1000,,,13.01,11.01,100,,AQ,
+15:25.1,Source[1],EchoSource001,384PP_AQ_BP,D22,Destination[1],EchoDestination001,Eppendorf_PCR_384,J9,1000,1000,,,13.872,10.872,100,,AQ,
+15:25.5,Source[1],EchoSource001,384PP_AQ_BP,A21,Destination[1],EchoDestination001,Eppendorf_PCR_384,K9,1000,1000,,,12.837,10.837,100,,AQ,
+15:25.9,Source[1],EchoSource001,384PP_AQ_BP,C23,Destination[1],EchoDestination001,Eppendorf_PCR_384,L9,1000,1000,,,11.75,10.75,100,,AQ,
+15:29.5,Source[1],EchoSource001,384PP_AQ_BP,D24,Destination[1],EchoDestination001,Eppendorf_PCR_384,D10,1000,1000,,,11.733,10.733,100,,AQ,
+15:30.2,Source[1],EchoSource001,384PP_AQ_BP,D21,Destination[1],EchoDestination001,Eppendorf_PCR_384,E10,1000,1000,,,14.683,10.683,100,,AQ,
+15:30.5,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,F10,1000,1000,,,17.677,10.677,100,,AQ,
+15:31.0,Source[1],EchoSource001,384PP_AQ_BP,B24,Destination[1],EchoDestination001,Eppendorf_PCR_384,G10,1000,1000,,,11.629,10.629,100,,AQ,
+15:31.3,Source[1],EchoSource001,384PP_AQ_BP,C24,Destination[1],EchoDestination001,Eppendorf_PCR_384,H10,1000,1000,,,13.579,10.579,100,,AQ,
+15:31.6,Source[1],EchoSource001,384PP_AQ_BP,A22,Destination[1],EchoDestination001,Eppendorf_PCR_384,I10,1000,1000,,,17.573,10.573,100,,AQ,
+15:32.0,Source[1],EchoSource001,384PP_AQ_BP,D23,Destination[1],EchoDestination001,Eppendorf_PCR_384,J10,1000,1000,,,13.562,10.562,100,,AQ,
+15:32.3,Source[1],EchoSource001,384PP_AQ_BP,A23,Destination[1],EchoDestination001,Eppendorf_PCR_384,K10,1000,1000,,,17.553,10.553,100,,AQ,
+15:32.7,Source[1],EchoSource001,384PP_AQ_BP,C22,Destination[1],EchoDestination001,Eppendorf_PCR_384,L10,1000,1000,,,14.304,10.304,100,,AQ,
+15:36.4,Source[1],EchoSource001,384PP_AQ_BP,B22,Destination[1],EchoDestination001,Eppendorf_PCR_384,D11,1000,1000,,,12.302,10.302,100,,AQ,
+15:36.9,Source[1],EchoSource001,384PP_AQ_BP,C21,Destination[1],EchoDestination001,Eppendorf_PCR_384,E11,1000,1000,,,13.251,10.251,100,,AQ,
+15:37.2,Source[1],EchoSource001,384PP_AQ_BP,B21,Destination[1],EchoDestination001,Eppendorf_PCR_384,F11,1000,1000,,,13.182,10.182,100,,AQ,
+15:37.5,Source[1],EchoSource001,384PP_AQ_BP,B23,Destination[1],EchoDestination001,Eppendorf_PCR_384,G11,1000,1000,,,13.01,10.01,100,,AQ,
+15:37.9,Source[1],EchoSource001,384PP_AQ_BP,D22,Destination[1],EchoDestination001,Eppendorf_PCR_384,H11,1000,1000,,,13.872,9.872,100,,AQ,
+15:38.2,Source[1],EchoSource001,384PP_AQ_BP,A21,Destination[1],EchoDestination001,Eppendorf_PCR_384,I11,1000,1000,,,12.837,9.837,100,,AQ,
+15:38.6,Source[1],EchoSource001,384PP_AQ_BP,C23,Destination[1],EchoDestination001,Eppendorf_PCR_384,J11,1000,1000,,,11.75,9.75,100,,AQ,
+15:39.0,Source[1],EchoSource001,384PP_AQ_BP,D24,Destination[1],EchoDestination001,Eppendorf_PCR_384,K11,1000,1000,,,11.733,9.733,100,,AQ,
+15:39.3,Source[1],EchoSource001,384PP_AQ_BP,D21,Destination[1],EchoDestination001,Eppendorf_PCR_384,L11,1000,1000,,,14.683,9.683,100,,AQ,
+15:42.9,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,D12,1000,1000,,,17.677,9.677,100,,AQ,
+15:43.3,Source[1],EchoSource001,384PP_AQ_BP,B24,Destination[1],EchoDestination001,Eppendorf_PCR_384,E12,1000,1000,,,11.629,9.629,100,,AQ,
+15:43.6,Source[1],EchoSource001,384PP_AQ_BP,C24,Destination[1],EchoDestination001,Eppendorf_PCR_384,F12,1000,1000,,,13.579,9.579,100,,AQ,
+15:43.9,Source[1],EchoSource001,384PP_AQ_BP,A22,Destination[1],EchoDestination001,Eppendorf_PCR_384,G12,1000,1000,,,17.573,9.573,100,,AQ,
+15:44.3,Source[1],EchoSource001,384PP_AQ_BP,D23,Destination[1],EchoDestination001,Eppendorf_PCR_384,H12,1000,1000,,,13.562,9.562,100,,AQ,
+15:44.7,Source[1],EchoSource001,384PP_AQ_BP,A23,Destination[1],EchoDestination001,Eppendorf_PCR_384,I12,1000,1000,,,17.553,9.553,100,,AQ,
+15:45.1,Source[1],EchoSource001,384PP_AQ_BP,C22,Destination[1],EchoDestination001,Eppendorf_PCR_384,J12,1000,1000,,,14.304,9.304,100,,AQ,
+15:45.4,Source[1],EchoSource001,384PP_AQ_BP,B22,Destination[1],EchoDestination001,Eppendorf_PCR_384,K12,1000,1000,,,12.302,9.302,100,,AQ,
+15:45.8,Source[1],EchoSource001,384PP_AQ_BP,C21,Destination[1],EchoDestination001,Eppendorf_PCR_384,L12,1000,1000,,,13.251,9.251,100,,AQ,
+15:46.0,Source[1],EchoSource001,384PP_AQ_BP,B21,Destination[1],EchoDestination001,Eppendorf_PCR_384,L13,1000,1000,,,13.182,9.182,100,,AQ,
+15:46.3,Source[1],EchoSource001,384PP_AQ_BP,B23,Destination[1],EchoDestination001,Eppendorf_PCR_384,K13,1000,1000,,,13.01,9.01,100,,AQ,
+15:46.7,Source[1],EchoSource001,384PP_AQ_BP,D22,Destination[1],EchoDestination001,Eppendorf_PCR_384,J13,1000,1000,,,13.872,8.872,100,,AQ,
+15:47.1,Source[1],EchoSource001,384PP_AQ_BP,A21,Destination[1],EchoDestination001,Eppendorf_PCR_384,I13,1000,1000,,,12.837,8.837,100,,AQ,
+15:47.4,Source[1],EchoSource001,384PP_AQ_BP,C23,Destination[1],EchoDestination001,Eppendorf_PCR_384,H13,1000,1000,,,11.75,8.75,100,,AQ,
+15:47.8,Source[1],EchoSource001,384PP_AQ_BP,D24,Destination[1],EchoDestination001,Eppendorf_PCR_384,G13,1000,1000,,,11.733,8.733,100,,AQ,
+15:48.2,Source[1],EchoSource001,384PP_AQ_BP,D21,Destination[1],EchoDestination001,Eppendorf_PCR_384,F13,1000,1000,,,14.683,8.683,100,,AQ,
+15:48.5,Source[1],EchoSource001,384PP_AQ_BP,A24,Destination[1],EchoDestination001,Eppendorf_PCR_384,E13,1000,1000,,,17.677,8.677,100,,AQ,
+15:48.9,Source[1],EchoSource001,384PP_AQ_BP,B24,Destination[1],EchoDestination001,Eppendorf_PCR_384,D13,1000,1000,,,11.629,8.629,100,,AQ,
+15:52.7,Source[1],EchoSource001,384PP_AQ_BP,C24,Destination[1],EchoDestination001,Eppendorf_PCR_384,D15,1000,1000,,,13.579,8.579,100,,AQ,
+15:53.0,Source[1],EchoSource001,384PP_AQ_BP,A22,Destination[1],EchoDestination001,Eppendorf_PCR_384,E15,1000,1000,,,17.573,8.573,100,,AQ,
+15:53.4,Source[1],EchoSource001,384PP_AQ_BP,D23,Destination[1],EchoDestination001,Eppendorf_PCR_384,F15,1000,1000,,,13.562,8.562,100,,AQ,
+15:53.7,Source[1],EchoSource001,384PP_AQ_BP,A23,Destination[1],EchoDestination001,Eppendorf_PCR_384,G15,1000,1000,,,17.553,8.553,100,,AQ,
+15:54.2,Source[1],EchoSource001,384PP_AQ_BP,C22,Destination[1],EchoDestination001,Eppendorf_PCR_384,H15,1000,1000,,,14.304,8.304,100,,AQ,
+15:54.5,Source[1],EchoSource001,384PP_AQ_BP,B22,Destination[1],EchoDestination001,Eppendorf_PCR_384,I15,1000,1000,,,12.302,8.302,100,,AQ,
+
+Instrument Name,E5XX-19119
+Instrument Model,Echo 525
+Instrument Serial Number,E5XX-19119
+Instrument Software Version,2.6.3

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/SurveyVolumeExamples.json
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/SurveyVolumeExamples.json
@@ -1,0 +1,5909 @@
+{
+    "$asm.manifest": "http://purl.allotrope.org/manifests/liquid-handler/BENCHLING/2024/11/liquid-handler.manifest",
+    "liquid handler aggregate document": {
+        "liquid handler document": [
+            {
+                "measurement aggregate document": {
+                    "measurement document": [
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.251,
+                                            "current fluid volume": 9.251,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C21",
+                                "destination well location identifier": "J15"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_0",
+                            "measurement time": "2025-05-06T15:54:48+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.182,
+                                            "current fluid volume": 9.182,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B21",
+                                "destination well location identifier": "K15"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_1",
+                            "measurement time": "2025-05-06T15:55:00+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.01,
+                                            "current fluid volume": 9.01,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B23",
+                                "destination well location identifier": "L15"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_2",
+                            "measurement time": "2025-05-06T15:55:06+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.872,
+                                            "current fluid volume": 8.872,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D22",
+                                "destination well location identifier": "L16"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_3",
+                            "measurement time": "2025-05-06T15:55:18+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.837,
+                                            "current fluid volume": 8.837,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A21",
+                                "destination well location identifier": "K16"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_4",
+                            "measurement time": "2025-05-06T15:55:30+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.75,
+                                            "current fluid volume": 8.75,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C23",
+                                "destination well location identifier": "J16"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_5",
+                            "measurement time": "2025-05-06T15:55:42+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.733,
+                                            "current fluid volume": 8.733,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D24",
+                                "destination well location identifier": "I16"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_6",
+                            "measurement time": "2025-05-06T15:56:00+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.683,
+                                            "current fluid volume": 8.683,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D21",
+                                "destination well location identifier": "H16"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_7",
+                            "measurement time": "2025-05-06T15:56:12+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 8.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "G16"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_8",
+                            "measurement time": "2025-05-06T15:56:24+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.629,
+                                            "current fluid volume": 8.629,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B24",
+                                "destination well location identifier": "F16"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_9",
+                            "measurement time": "2025-05-06T15:56:36+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.579,
+                                            "current fluid volume": 8.579,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C24",
+                                "destination well location identifier": "E16"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_10",
+                            "measurement time": "2025-05-06T15:56:48+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.573,
+                                            "current fluid volume": 8.573,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A22",
+                                "destination well location identifier": "D16"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_11",
+                            "measurement time": "2025-05-06T15:57:00+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.562,
+                                            "current fluid volume": 8.562,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D23",
+                                "destination well location identifier": "D17"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_12",
+                            "measurement time": "2025-05-06T15:57:06+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.553,
+                                            "current fluid volume": 8.553,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A23",
+                                "destination well location identifier": "E17"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_13",
+                            "measurement time": "2025-05-06T15:57:24+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.304,
+                                            "current fluid volume": 8.304,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C22",
+                                "destination well location identifier": "F17"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_14",
+                            "measurement time": "2025-05-06T15:57:42+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.302,
+                                            "current fluid volume": 8.302,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B22",
+                                "destination well location identifier": "G17"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_15",
+                            "measurement time": "2025-05-06T15:57:48+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.251,
+                                            "current fluid volume": 9.251,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C21",
+                                "destination well location identifier": "H17"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_16",
+                            "measurement time": "2025-05-06T15:58:00+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.182,
+                                            "current fluid volume": 9.182,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B21",
+                                "destination well location identifier": "I17"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_17",
+                            "measurement time": "2025-05-06T15:58:12+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.01,
+                                            "current fluid volume": 9.01,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B23",
+                                "destination well location identifier": "J17"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_18",
+                            "measurement time": "2025-05-06T15:58:18+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.872,
+                                            "current fluid volume": 8.872,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D22",
+                                "destination well location identifier": "K17"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_19",
+                            "measurement time": "2025-05-06T15:58:30+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.837,
+                                            "current fluid volume": 8.837,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A21",
+                                "destination well location identifier": "L17"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_20",
+                            "measurement time": "2025-05-06T15:58:42+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.75,
+                                            "current fluid volume": 8.75,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C23",
+                                "destination well location identifier": "L18"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_21",
+                            "measurement time": "2025-05-06T15:59:00+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.733,
+                                            "current fluid volume": 8.733,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D24",
+                                "destination well location identifier": "K18"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_22",
+                            "measurement time": "2025-05-06T15:59:12+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.683,
+                                            "current fluid volume": 8.683,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D21",
+                                "destination well location identifier": "J18"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_23",
+                            "measurement time": "2025-05-06T15:59:24+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 8.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "I18"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_24",
+                            "measurement time": "2025-05-06T15:59:36+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.629,
+                                            "current fluid volume": 8.629,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B24",
+                                "destination well location identifier": "H18"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_25",
+                            "measurement time": "2025-05-06T15:59:48+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.579,
+                                            "current fluid volume": 8.579,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C24",
+                                "destination well location identifier": "G18"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_26",
+                            "measurement time": "2025-05-06T16:00:00+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.573,
+                                            "current fluid volume": 8.573,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A22",
+                                "destination well location identifier": "F18"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_27",
+                            "measurement time": "2025-05-06T16:00:12+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.562,
+                                            "current fluid volume": 8.562,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D23",
+                                "destination well location identifier": "E18"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_28",
+                            "measurement time": "2025-05-06T16:00:24+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.553,
+                                            "current fluid volume": 8.553,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A23",
+                                "destination well location identifier": "D18"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_29",
+                            "measurement time": "2025-05-06T16:00:42+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.304,
+                                            "current fluid volume": 8.304,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C22",
+                                "destination well location identifier": "D19"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_30",
+                            "measurement time": "2025-05-06T16:00:54+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.302,
+                                            "current fluid volume": 8.302,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B22",
+                                "destination well location identifier": "E19"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_31",
+                            "measurement time": "2025-05-06T16:01:06+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.251,
+                                            "current fluid volume": 9.251,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C21",
+                                "destination well location identifier": "F19"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_32",
+                            "measurement time": "2025-05-06T16:01:12+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.182,
+                                            "current fluid volume": 9.182,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B21",
+                                "destination well location identifier": "G19"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_33",
+                            "measurement time": "2025-05-06T16:01:24+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.01,
+                                            "current fluid volume": 9.01,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B23",
+                                "destination well location identifier": "H19"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_34",
+                            "measurement time": "2025-05-06T16:01:36+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.872,
+                                            "current fluid volume": 8.872,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D22",
+                                "destination well location identifier": "I19"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_35",
+                            "measurement time": "2025-05-06T16:01:48+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.837,
+                                            "current fluid volume": 8.837,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A21",
+                                "destination well location identifier": "J19"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_36",
+                            "measurement time": "2025-05-06T16:01:54+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.75,
+                                            "current fluid volume": 8.75,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C23",
+                                "destination well location identifier": "K19"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_37",
+                            "measurement time": "2025-05-06T16:02:12+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.733,
+                                            "current fluid volume": 8.733,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D24",
+                                "destination well location identifier": "L19"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_38",
+                            "measurement time": "2025-05-06T16:02:24+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.683,
+                                            "current fluid volume": 8.683,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D21",
+                                "destination well location identifier": "L20"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_39",
+                            "measurement time": "2025-05-06T16:02:30+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 8.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "K20"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_40",
+                            "measurement time": "2025-05-06T16:02:42+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.629,
+                                            "current fluid volume": 8.629,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B24",
+                                "destination well location identifier": "J20"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_41",
+                            "measurement time": "2025-05-06T16:03:00+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.579,
+                                            "current fluid volume": 8.579,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C24",
+                                "destination well location identifier": "I20"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_42",
+                            "measurement time": "2025-05-06T16:03:12+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.573,
+                                            "current fluid volume": 8.573,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A22",
+                                "destination well location identifier": "H20"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_43",
+                            "measurement time": "2025-05-06T16:03:18+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.562,
+                                            "current fluid volume": 8.562,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D23",
+                                "destination well location identifier": "G20"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_44",
+                            "measurement time": "2025-05-06T16:03:30+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.553,
+                                            "current fluid volume": 8.553,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A23",
+                                "destination well location identifier": "F20"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_45",
+                            "measurement time": "2025-05-06T16:03:48+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.304,
+                                            "current fluid volume": 8.304,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C22",
+                                "destination well location identifier": "E20"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_46",
+                            "measurement time": "2025-05-06T16:04:00+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.302,
+                                            "current fluid volume": 8.302,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B22",
+                                "destination well location identifier": "D20"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_47",
+                            "measurement time": "2025-05-06T16:04:18+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.251,
+                                            "current fluid volume": 9.251,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C21",
+                                "destination well location identifier": "D22"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_48",
+                            "measurement time": "2025-05-06T16:07:36+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.182,
+                                            "current fluid volume": 9.182,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B21",
+                                "destination well location identifier": "E22"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_49",
+                            "measurement time": "2025-05-06T16:07:48+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.01,
+                                            "current fluid volume": 9.01,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B23",
+                                "destination well location identifier": "F22"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_50",
+                            "measurement time": "2025-05-06T16:08:00+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.872,
+                                            "current fluid volume": 8.872,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D22",
+                                "destination well location identifier": "G22"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_51",
+                            "measurement time": "2025-05-06T16:08:12+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.837,
+                                            "current fluid volume": 8.837,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A21",
+                                "destination well location identifier": "H22"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_52",
+                            "measurement time": "2025-05-06T16:08:24+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.75,
+                                            "current fluid volume": 8.75,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C23",
+                                "destination well location identifier": "I22"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_53",
+                            "measurement time": "2025-05-06T16:08:36+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.733,
+                                            "current fluid volume": 8.733,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D24",
+                                "destination well location identifier": "J22"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_54",
+                            "measurement time": "2025-05-06T16:08:48+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.683,
+                                            "current fluid volume": 8.683,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D21",
+                                "destination well location identifier": "K22"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_55",
+                            "measurement time": "2025-05-06T16:09:00+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 8.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "MM0202001: Current fluid height below minimum transfer level"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "L22"
+                            },
+                            "error aggregate document": {
+                                "error document": [
+                                    {
+                                        "error": "MM0202001: Current fluid height below minimum transfer level",
+                                        "error feature": "MM0202001"
+                                    }
+                                ]
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_56",
+                            "measurement time": "2025-05-06T16:09:12+00:00"
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 16.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "D4"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_57",
+                            "measurement time": "2025-05-06T14:58:00+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.573,
+                                            "current fluid volume": 16.573,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A22",
+                                "destination well location identifier": "E4"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_58",
+                            "measurement time": "2025-05-06T14:58:36+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.553,
+                                            "current fluid volume": 16.553,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A23",
+                                "destination well location identifier": "F4"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_59",
+                            "measurement time": "2025-05-06T14:58:54+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 15.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "G4"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_60",
+                            "measurement time": "2025-05-06T14:59:12+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.573,
+                                            "current fluid volume": 15.573,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A22",
+                                "destination well location identifier": "H4"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_61",
+                            "measurement time": "2025-05-06T14:59:30+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.553,
+                                            "current fluid volume": 15.553,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A23",
+                                "destination well location identifier": "D5"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_62",
+                            "measurement time": "2025-05-06T15:03:12+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 14.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "E5"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_63",
+                            "measurement time": "2025-05-06T15:03:36+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.573,
+                                            "current fluid volume": 14.573,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A22",
+                                "destination well location identifier": "F5"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_64",
+                            "measurement time": "2025-05-06T15:03:54+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.553,
+                                            "current fluid volume": 14.553,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A23",
+                                "destination well location identifier": "G5"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_65",
+                            "measurement time": "2025-05-06T15:04:18+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.683,
+                                            "current fluid volume": 13.683,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D21",
+                                "destination well location identifier": "H5"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_66",
+                            "measurement time": "2025-05-06T15:04:30+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 13.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "I5"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_67",
+                            "measurement time": "2025-05-06T15:04:54+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.573,
+                                            "current fluid volume": 13.573,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A22",
+                                "destination well location identifier": "J5"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_68",
+                            "measurement time": "2025-05-06T15:05:18+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.553,
+                                            "current fluid volume": 13.553,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A23",
+                                "destination well location identifier": "K5"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_69",
+                            "measurement time": "2025-05-06T15:05:42+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.304,
+                                            "current fluid volume": 13.304,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C22",
+                                "destination well location identifier": "L5"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_70",
+                            "measurement time": "2025-05-06T15:06:00+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.872,
+                                            "current fluid volume": 12.872,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D22",
+                                "destination well location identifier": "D6"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_71",
+                            "measurement time": "2025-05-06T15:09:30+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.683,
+                                            "current fluid volume": 12.683,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D21",
+                                "destination well location identifier": "E6"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_72",
+                            "measurement time": "2025-05-06T15:10:12+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 12.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "F6"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_73",
+                            "measurement time": "2025-05-06T15:10:24+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.579,
+                                            "current fluid volume": 12.579,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C24",
+                                "destination well location identifier": "G6"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_74",
+                            "measurement time": "2025-05-06T15:10:54+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.573,
+                                            "current fluid volume": 12.573,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A22",
+                                "destination well location identifier": "H6"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_75",
+                            "measurement time": "2025-05-06T15:11:12+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.562,
+                                            "current fluid volume": 12.562,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D23",
+                                "destination well location identifier": "I6"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_76",
+                            "measurement time": "2025-05-06T15:11:36+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.553,
+                                            "current fluid volume": 12.553,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A23",
+                                "destination well location identifier": "J6"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_77",
+                            "measurement time": "2025-05-06T15:12:00+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.304,
+                                            "current fluid volume": 12.304,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C22",
+                                "destination well location identifier": "K6"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_78",
+                            "measurement time": "2025-05-06T15:12:24+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.251,
+                                            "current fluid volume": 12.251,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C21",
+                                "destination well location identifier": "L6"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_79",
+                            "measurement time": "2025-05-06T15:12:42+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.182,
+                                            "current fluid volume": 12.182,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B21",
+                                "destination well location identifier": "D8"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_80",
+                            "measurement time": "2025-05-06T15:16:12+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.01,
+                                            "current fluid volume": 12.01,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B23",
+                                "destination well location identifier": "E8"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_81",
+                            "measurement time": "2025-05-06T15:16:48+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.872,
+                                            "current fluid volume": 11.872,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D22",
+                                "destination well location identifier": "F8"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_82",
+                            "measurement time": "2025-05-06T15:17:06+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.837,
+                                            "current fluid volume": 11.837,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A21",
+                                "destination well location identifier": "G8"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_83",
+                            "measurement time": "2025-05-06T15:17:30+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.683,
+                                            "current fluid volume": 11.683,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D21",
+                                "destination well location identifier": "H8"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_84",
+                            "measurement time": "2025-05-06T15:17:54+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 11.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "I8"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_85",
+                            "measurement time": "2025-05-06T15:18:12+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.579,
+                                            "current fluid volume": 11.579,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C24",
+                                "destination well location identifier": "J8"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_86",
+                            "measurement time": "2025-05-06T15:18:42+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.573,
+                                            "current fluid volume": 11.573,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A22",
+                                "destination well location identifier": "K8"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_87",
+                            "measurement time": "2025-05-06T15:19:00+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.562,
+                                            "current fluid volume": 11.562,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D23",
+                                "destination well location identifier": "L8"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_88",
+                            "measurement time": "2025-05-06T15:19:24+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.553,
+                                            "current fluid volume": 11.553,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A23",
+                                "destination well location identifier": "D9"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_89",
+                            "measurement time": "2025-05-06T15:23:00+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.304,
+                                            "current fluid volume": 11.304,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C22",
+                                "destination well location identifier": "E9"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_90",
+                            "measurement time": "2025-05-06T15:23:30+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.302,
+                                            "current fluid volume": 11.302,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B22",
+                                "destination well location identifier": "F9"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_91",
+                            "measurement time": "2025-05-06T15:23:48+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.251,
+                                            "current fluid volume": 11.251,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C21",
+                                "destination well location identifier": "G9"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_92",
+                            "measurement time": "2025-05-06T15:24:12+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.182,
+                                            "current fluid volume": 11.182,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B21",
+                                "destination well location identifier": "H9"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_93",
+                            "measurement time": "2025-05-06T15:24:30+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.01,
+                                            "current fluid volume": 11.01,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B23",
+                                "destination well location identifier": "I9"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_94",
+                            "measurement time": "2025-05-06T15:24:48+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.872,
+                                            "current fluid volume": 10.872,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D22",
+                                "destination well location identifier": "J9"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_95",
+                            "measurement time": "2025-05-06T15:25:06+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.837,
+                                            "current fluid volume": 10.837,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A21",
+                                "destination well location identifier": "K9"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_96",
+                            "measurement time": "2025-05-06T15:25:30+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.75,
+                                            "current fluid volume": 10.75,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C23",
+                                "destination well location identifier": "L9"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_97",
+                            "measurement time": "2025-05-06T15:25:54+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.733,
+                                            "current fluid volume": 10.733,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D24",
+                                "destination well location identifier": "D10"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_98",
+                            "measurement time": "2025-05-06T15:29:30+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.683,
+                                            "current fluid volume": 10.683,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D21",
+                                "destination well location identifier": "E10"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_99",
+                            "measurement time": "2025-05-06T15:30:12+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 10.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "F10"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_100",
+                            "measurement time": "2025-05-06T15:30:30+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.629,
+                                            "current fluid volume": 10.629,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B24",
+                                "destination well location identifier": "G10"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_101",
+                            "measurement time": "2025-05-06T15:31:00+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.579,
+                                            "current fluid volume": 10.579,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C24",
+                                "destination well location identifier": "H10"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_102",
+                            "measurement time": "2025-05-06T15:31:18+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.573,
+                                            "current fluid volume": 10.573,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A22",
+                                "destination well location identifier": "I10"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_103",
+                            "measurement time": "2025-05-06T15:31:36+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.562,
+                                            "current fluid volume": 10.562,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D23",
+                                "destination well location identifier": "J10"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_104",
+                            "measurement time": "2025-05-06T15:32:00+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.553,
+                                            "current fluid volume": 10.553,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A23",
+                                "destination well location identifier": "K10"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_105",
+                            "measurement time": "2025-05-06T15:32:18+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.304,
+                                            "current fluid volume": 10.304,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C22",
+                                "destination well location identifier": "L10"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_106",
+                            "measurement time": "2025-05-06T15:32:42+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.302,
+                                            "current fluid volume": 10.302,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B22",
+                                "destination well location identifier": "D11"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_107",
+                            "measurement time": "2025-05-06T15:36:24+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.251,
+                                            "current fluid volume": 10.251,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C21",
+                                "destination well location identifier": "E11"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_108",
+                            "measurement time": "2025-05-06T15:36:54+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.182,
+                                            "current fluid volume": 10.182,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B21",
+                                "destination well location identifier": "F11"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_109",
+                            "measurement time": "2025-05-06T15:37:12+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.01,
+                                            "current fluid volume": 10.01,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B23",
+                                "destination well location identifier": "G11"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_110",
+                            "measurement time": "2025-05-06T15:37:30+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.872,
+                                            "current fluid volume": 9.872,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D22",
+                                "destination well location identifier": "H11"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_111",
+                            "measurement time": "2025-05-06T15:37:54+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.837,
+                                            "current fluid volume": 9.837,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A21",
+                                "destination well location identifier": "I11"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_112",
+                            "measurement time": "2025-05-06T15:38:12+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.75,
+                                            "current fluid volume": 9.75,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C23",
+                                "destination well location identifier": "J11"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_113",
+                            "measurement time": "2025-05-06T15:38:36+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.733,
+                                            "current fluid volume": 9.733,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D24",
+                                "destination well location identifier": "K11"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_114",
+                            "measurement time": "2025-05-06T15:39:00+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.683,
+                                            "current fluid volume": 9.683,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D21",
+                                "destination well location identifier": "L11"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_115",
+                            "measurement time": "2025-05-06T15:39:18+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 9.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "D12"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_116",
+                            "measurement time": "2025-05-06T15:42:54+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.629,
+                                            "current fluid volume": 9.629,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B24",
+                                "destination well location identifier": "E12"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_117",
+                            "measurement time": "2025-05-06T15:43:18+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.579,
+                                            "current fluid volume": 9.579,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C24",
+                                "destination well location identifier": "F12"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_118",
+                            "measurement time": "2025-05-06T15:43:36+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.573,
+                                            "current fluid volume": 9.573,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A22",
+                                "destination well location identifier": "G12"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_119",
+                            "measurement time": "2025-05-06T15:43:54+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.562,
+                                            "current fluid volume": 9.562,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D23",
+                                "destination well location identifier": "H12"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_120",
+                            "measurement time": "2025-05-06T15:44:18+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.553,
+                                            "current fluid volume": 9.553,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A23",
+                                "destination well location identifier": "I12"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_121",
+                            "measurement time": "2025-05-06T15:44:42+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.304,
+                                            "current fluid volume": 9.304,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C22",
+                                "destination well location identifier": "J12"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_122",
+                            "measurement time": "2025-05-06T15:45:06+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.302,
+                                            "current fluid volume": 9.302,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B22",
+                                "destination well location identifier": "K12"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_123",
+                            "measurement time": "2025-05-06T15:45:24+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.251,
+                                            "current fluid volume": 9.251,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C21",
+                                "destination well location identifier": "L12"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_124",
+                            "measurement time": "2025-05-06T15:45:48+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.182,
+                                            "current fluid volume": 9.182,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B21",
+                                "destination well location identifier": "L13"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_125",
+                            "measurement time": "2025-05-06T15:46:00+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.01,
+                                            "current fluid volume": 9.01,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B23",
+                                "destination well location identifier": "K13"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_126",
+                            "measurement time": "2025-05-06T15:46:18+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.872,
+                                            "current fluid volume": 8.872,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D22",
+                                "destination well location identifier": "J13"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_127",
+                            "measurement time": "2025-05-06T15:46:42+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.837,
+                                            "current fluid volume": 8.837,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A21",
+                                "destination well location identifier": "I13"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_128",
+                            "measurement time": "2025-05-06T15:47:06+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.75,
+                                            "current fluid volume": 8.75,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C23",
+                                "destination well location identifier": "H13"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_129",
+                            "measurement time": "2025-05-06T15:47:24+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.733,
+                                            "current fluid volume": 8.733,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D24",
+                                "destination well location identifier": "G13"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_130",
+                            "measurement time": "2025-05-06T15:47:48+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.683,
+                                            "current fluid volume": 8.683,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D21",
+                                "destination well location identifier": "F13"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_131",
+                            "measurement time": "2025-05-06T15:48:12+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.677,
+                                            "current fluid volume": 8.677,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A24",
+                                "destination well location identifier": "E13"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_132",
+                            "measurement time": "2025-05-06T15:48:30+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 11.629,
+                                            "current fluid volume": 8.629,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B24",
+                                "destination well location identifier": "D13"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_133",
+                            "measurement time": "2025-05-06T15:48:54+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.579,
+                                            "current fluid volume": 8.579,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C24",
+                                "destination well location identifier": "D15"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_134",
+                            "measurement time": "2025-05-06T15:52:42+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.573,
+                                            "current fluid volume": 8.573,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A22",
+                                "destination well location identifier": "E15"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_135",
+                            "measurement time": "2025-05-06T15:53:00+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 13.562,
+                                            "current fluid volume": 8.562,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "D23",
+                                "destination well location identifier": "F15"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_136",
+                            "measurement time": "2025-05-06T15:53:24+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 17.553,
+                                            "current fluid volume": 8.553,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "A23",
+                                "destination well location identifier": "G15"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_137",
+                            "measurement time": "2025-05-06T15:53:42+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 14.304,
+                                            "current fluid volume": 8.304,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "C22",
+                                "destination well location identifier": "H15"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_138",
+                            "measurement time": "2025-05-06T15:54:12+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        },
+                        {
+                            "device control aggregate document": {
+                                "device control document": [
+                                    {
+                                        "device type": "liquid handler",
+                                        "injection volume setting": {
+                                            "value": 1.0,
+                                            "unit": "μL"
+                                        },
+                                        "custom information document": {
+                                            "survey fluid volume": 12.302,
+                                            "current fluid volume": 8.302,
+                                            "intended transfer volume": 1.0,
+                                            "source labware name": "384PP_AQ_BP",
+                                            "destination labware name": "Eppendorf_PCR_384",
+                                            "fluid composition": "100",
+                                            "fluid type": "AQ",
+                                            "transfer status": "N/A"
+                                        }
+                                    }
+                                ]
+                            },
+                            "sample document": {
+                                "sample identifier": "N/A",
+                                "source location identifier": "Source[1]",
+                                "destination location identifier": "Destination[1]",
+                                "source well plate identifier": "EchoSource001",
+                                "destination well plate identifier": "EchoDestination001",
+                                "source well location identifier": "B22",
+                                "destination well location identifier": "I15"
+                            },
+                            "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_139",
+                            "measurement time": "2025-05-06T15:54:30+00:00",
+                            "aspiration volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 1.0,
+                                "unit": "μL"
+                            }
+                        }
+                    ],
+                    "analytical method identifier": "SeV_r2_exc1.epr"
+                },
+                "analyst": "LabAutomation"
+            }
+        ],
+        "data system document": {
+            "ASM file identifier": "SurveyVolumeExamples.json",
+            "data system instance identifier": "N/A",
+            "file name": "SurveyVolumeExamples.csv",
+            "UNC path": "tests/parsers/beckman_echo_plate_reformat/testdata/SurveyVolumeExamples.csv",
+            "ASM converter name": "allotropy_beckman_echo_plate_reformat",
+            "ASM converter version": "0.1.80",
+            "software name": "Labcyte Echo Plate Reformat",
+            "software version": "2.6.3"
+        },
+        "device system document": {
+            "equipment serial number": "E5XX-19119",
+            "product manufacturer": "Beckman Coulter"
+        }
+    }
+}

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/SurveyVolumeExamples.json
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/SurveyVolumeExamples.json
@@ -45,7 +45,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_0",
-                            "measurement time": "2025-05-07T15:54:48+00:00"
+                            "measurement time": "2025-05-09T15:54:48+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -87,7 +95,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_1",
-                            "measurement time": "2025-05-07T15:55:00+00:00"
+                            "measurement time": "2025-05-09T15:55:00+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -129,7 +145,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_2",
-                            "measurement time": "2025-05-07T15:55:06+00:00"
+                            "measurement time": "2025-05-09T15:55:06+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -171,7 +195,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_3",
-                            "measurement time": "2025-05-07T15:55:18+00:00"
+                            "measurement time": "2025-05-09T15:55:18+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -213,7 +245,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_4",
-                            "measurement time": "2025-05-07T15:55:30+00:00"
+                            "measurement time": "2025-05-09T15:55:30+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -255,7 +295,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_5",
-                            "measurement time": "2025-05-07T15:55:42+00:00"
+                            "measurement time": "2025-05-09T15:55:42+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -297,7 +345,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_6",
-                            "measurement time": "2025-05-07T15:56:00+00:00"
+                            "measurement time": "2025-05-09T15:56:00+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -339,7 +395,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_7",
-                            "measurement time": "2025-05-07T15:56:12+00:00"
+                            "measurement time": "2025-05-09T15:56:12+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -381,7 +445,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_8",
-                            "measurement time": "2025-05-07T15:56:24+00:00"
+                            "measurement time": "2025-05-09T15:56:24+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -423,7 +495,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_9",
-                            "measurement time": "2025-05-07T15:56:36+00:00"
+                            "measurement time": "2025-05-09T15:56:36+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -465,7 +545,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_10",
-                            "measurement time": "2025-05-07T15:56:48+00:00"
+                            "measurement time": "2025-05-09T15:56:48+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -507,7 +595,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_11",
-                            "measurement time": "2025-05-07T15:57:00+00:00"
+                            "measurement time": "2025-05-09T15:57:00+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -549,7 +645,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_12",
-                            "measurement time": "2025-05-07T15:57:06+00:00"
+                            "measurement time": "2025-05-09T15:57:06+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -591,7 +695,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_13",
-                            "measurement time": "2025-05-07T15:57:24+00:00"
+                            "measurement time": "2025-05-09T15:57:24+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -633,7 +745,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_14",
-                            "measurement time": "2025-05-07T15:57:42+00:00"
+                            "measurement time": "2025-05-09T15:57:42+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -675,7 +795,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_15",
-                            "measurement time": "2025-05-07T15:57:48+00:00"
+                            "measurement time": "2025-05-09T15:57:48+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -717,7 +845,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_16",
-                            "measurement time": "2025-05-07T15:58:00+00:00"
+                            "measurement time": "2025-05-09T15:58:00+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -759,7 +895,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_17",
-                            "measurement time": "2025-05-07T15:58:12+00:00"
+                            "measurement time": "2025-05-09T15:58:12+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -801,7 +945,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_18",
-                            "measurement time": "2025-05-07T15:58:18+00:00"
+                            "measurement time": "2025-05-09T15:58:18+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -843,7 +995,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_19",
-                            "measurement time": "2025-05-07T15:58:30+00:00"
+                            "measurement time": "2025-05-09T15:58:30+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -885,7 +1045,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_20",
-                            "measurement time": "2025-05-07T15:58:42+00:00"
+                            "measurement time": "2025-05-09T15:58:42+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -927,7 +1095,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_21",
-                            "measurement time": "2025-05-07T15:59:00+00:00"
+                            "measurement time": "2025-05-09T15:59:00+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -969,7 +1145,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_22",
-                            "measurement time": "2025-05-07T15:59:12+00:00"
+                            "measurement time": "2025-05-09T15:59:12+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1011,7 +1195,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_23",
-                            "measurement time": "2025-05-07T15:59:24+00:00"
+                            "measurement time": "2025-05-09T15:59:24+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1053,7 +1245,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_24",
-                            "measurement time": "2025-05-07T15:59:36+00:00"
+                            "measurement time": "2025-05-09T15:59:36+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1095,7 +1295,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_25",
-                            "measurement time": "2025-05-07T15:59:48+00:00"
+                            "measurement time": "2025-05-09T15:59:48+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1137,7 +1345,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_26",
-                            "measurement time": "2025-05-07T16:00:00+00:00"
+                            "measurement time": "2025-05-09T16:00:00+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1179,7 +1395,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_27",
-                            "measurement time": "2025-05-07T16:00:12+00:00"
+                            "measurement time": "2025-05-09T16:00:12+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1221,7 +1445,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_28",
-                            "measurement time": "2025-05-07T16:00:24+00:00"
+                            "measurement time": "2025-05-09T16:00:24+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1263,7 +1495,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_29",
-                            "measurement time": "2025-05-07T16:00:42+00:00"
+                            "measurement time": "2025-05-09T16:00:42+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1305,7 +1545,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_30",
-                            "measurement time": "2025-05-07T16:00:54+00:00"
+                            "measurement time": "2025-05-09T16:00:54+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1347,7 +1595,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_31",
-                            "measurement time": "2025-05-07T16:01:06+00:00"
+                            "measurement time": "2025-05-09T16:01:06+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1389,7 +1645,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_32",
-                            "measurement time": "2025-05-07T16:01:12+00:00"
+                            "measurement time": "2025-05-09T16:01:12+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1431,7 +1695,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_33",
-                            "measurement time": "2025-05-07T16:01:24+00:00"
+                            "measurement time": "2025-05-09T16:01:24+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1473,7 +1745,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_34",
-                            "measurement time": "2025-05-07T16:01:36+00:00"
+                            "measurement time": "2025-05-09T16:01:36+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1515,7 +1795,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_35",
-                            "measurement time": "2025-05-07T16:01:48+00:00"
+                            "measurement time": "2025-05-09T16:01:48+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1557,7 +1845,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_36",
-                            "measurement time": "2025-05-07T16:01:54+00:00"
+                            "measurement time": "2025-05-09T16:01:54+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1599,7 +1895,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_37",
-                            "measurement time": "2025-05-07T16:02:12+00:00"
+                            "measurement time": "2025-05-09T16:02:12+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1641,7 +1945,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_38",
-                            "measurement time": "2025-05-07T16:02:24+00:00"
+                            "measurement time": "2025-05-09T16:02:24+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1683,7 +1995,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_39",
-                            "measurement time": "2025-05-07T16:02:30+00:00"
+                            "measurement time": "2025-05-09T16:02:30+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1725,7 +2045,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_40",
-                            "measurement time": "2025-05-07T16:02:42+00:00"
+                            "measurement time": "2025-05-09T16:02:42+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1767,7 +2095,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_41",
-                            "measurement time": "2025-05-07T16:03:00+00:00"
+                            "measurement time": "2025-05-09T16:03:00+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1809,7 +2145,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_42",
-                            "measurement time": "2025-05-07T16:03:12+00:00"
+                            "measurement time": "2025-05-09T16:03:12+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1851,7 +2195,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_43",
-                            "measurement time": "2025-05-07T16:03:18+00:00"
+                            "measurement time": "2025-05-09T16:03:18+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1893,7 +2245,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_44",
-                            "measurement time": "2025-05-07T16:03:30+00:00"
+                            "measurement time": "2025-05-09T16:03:30+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1935,7 +2295,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_45",
-                            "measurement time": "2025-05-07T16:03:48+00:00"
+                            "measurement time": "2025-05-09T16:03:48+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -1977,7 +2345,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_46",
-                            "measurement time": "2025-05-07T16:04:00+00:00"
+                            "measurement time": "2025-05-09T16:04:00+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -2019,7 +2395,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_47",
-                            "measurement time": "2025-05-07T16:04:18+00:00"
+                            "measurement time": "2025-05-09T16:04:18+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -2061,7 +2445,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_48",
-                            "measurement time": "2025-05-07T16:07:36+00:00"
+                            "measurement time": "2025-05-09T16:07:36+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -2103,7 +2495,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_49",
-                            "measurement time": "2025-05-07T16:07:48+00:00"
+                            "measurement time": "2025-05-09T16:07:48+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -2145,7 +2545,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_50",
-                            "measurement time": "2025-05-07T16:08:00+00:00"
+                            "measurement time": "2025-05-09T16:08:00+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -2187,7 +2595,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_51",
-                            "measurement time": "2025-05-07T16:08:12+00:00"
+                            "measurement time": "2025-05-09T16:08:12+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -2229,7 +2645,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_52",
-                            "measurement time": "2025-05-07T16:08:24+00:00"
+                            "measurement time": "2025-05-09T16:08:24+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -2271,7 +2695,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_53",
-                            "measurement time": "2025-05-07T16:08:36+00:00"
+                            "measurement time": "2025-05-09T16:08:36+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -2313,7 +2745,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_54",
-                            "measurement time": "2025-05-07T16:08:48+00:00"
+                            "measurement time": "2025-05-09T16:08:48+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -2355,7 +2795,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_55",
-                            "measurement time": "2025-05-07T16:09:00+00:00"
+                            "measurement time": "2025-05-09T16:09:00+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -2397,7 +2845,15 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_56",
-                            "measurement time": "2025-05-07T16:09:12+00:00"
+                            "measurement time": "2025-05-09T16:09:12+00:00",
+                            "aspiration volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            },
+                            "transfer volume": {
+                                "value": 0.0,
+                                "unit": "μL"
+                            }
                         },
                         {
                             "device control aggregate document": {
@@ -2431,7 +2887,7 @@
                                 "destination well location identifier": "D4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_57",
-                            "measurement time": "2025-05-07T14:58:00+00:00",
+                            "measurement time": "2025-05-09T14:58:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2473,7 +2929,7 @@
                                 "destination well location identifier": "E4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_58",
-                            "measurement time": "2025-05-07T14:58:36+00:00",
+                            "measurement time": "2025-05-09T14:58:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2515,7 +2971,7 @@
                                 "destination well location identifier": "F4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_59",
-                            "measurement time": "2025-05-07T14:58:54+00:00",
+                            "measurement time": "2025-05-09T14:58:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2557,7 +3013,7 @@
                                 "destination well location identifier": "G4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_60",
-                            "measurement time": "2025-05-07T14:59:12+00:00",
+                            "measurement time": "2025-05-09T14:59:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2599,7 +3055,7 @@
                                 "destination well location identifier": "H4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_61",
-                            "measurement time": "2025-05-07T14:59:30+00:00",
+                            "measurement time": "2025-05-09T14:59:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2641,7 +3097,7 @@
                                 "destination well location identifier": "D5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_62",
-                            "measurement time": "2025-05-07T15:03:12+00:00",
+                            "measurement time": "2025-05-09T15:03:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2683,7 +3139,7 @@
                                 "destination well location identifier": "E5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_63",
-                            "measurement time": "2025-05-07T15:03:36+00:00",
+                            "measurement time": "2025-05-09T15:03:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2725,7 +3181,7 @@
                                 "destination well location identifier": "F5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_64",
-                            "measurement time": "2025-05-07T15:03:54+00:00",
+                            "measurement time": "2025-05-09T15:03:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2767,7 +3223,7 @@
                                 "destination well location identifier": "G5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_65",
-                            "measurement time": "2025-05-07T15:04:18+00:00",
+                            "measurement time": "2025-05-09T15:04:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2809,7 +3265,7 @@
                                 "destination well location identifier": "H5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_66",
-                            "measurement time": "2025-05-07T15:04:30+00:00",
+                            "measurement time": "2025-05-09T15:04:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2851,7 +3307,7 @@
                                 "destination well location identifier": "I5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_67",
-                            "measurement time": "2025-05-07T15:04:54+00:00",
+                            "measurement time": "2025-05-09T15:04:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2893,7 +3349,7 @@
                                 "destination well location identifier": "J5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_68",
-                            "measurement time": "2025-05-07T15:05:18+00:00",
+                            "measurement time": "2025-05-09T15:05:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2935,7 +3391,7 @@
                                 "destination well location identifier": "K5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_69",
-                            "measurement time": "2025-05-07T15:05:42+00:00",
+                            "measurement time": "2025-05-09T15:05:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2977,7 +3433,7 @@
                                 "destination well location identifier": "L5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_70",
-                            "measurement time": "2025-05-07T15:06:00+00:00",
+                            "measurement time": "2025-05-09T15:06:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3019,7 +3475,7 @@
                                 "destination well location identifier": "D6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_71",
-                            "measurement time": "2025-05-07T15:09:30+00:00",
+                            "measurement time": "2025-05-09T15:09:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3061,7 +3517,7 @@
                                 "destination well location identifier": "E6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_72",
-                            "measurement time": "2025-05-07T15:10:12+00:00",
+                            "measurement time": "2025-05-09T15:10:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3103,7 +3559,7 @@
                                 "destination well location identifier": "F6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_73",
-                            "measurement time": "2025-05-07T15:10:24+00:00",
+                            "measurement time": "2025-05-09T15:10:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3145,7 +3601,7 @@
                                 "destination well location identifier": "G6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_74",
-                            "measurement time": "2025-05-07T15:10:54+00:00",
+                            "measurement time": "2025-05-09T15:10:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3187,7 +3643,7 @@
                                 "destination well location identifier": "H6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_75",
-                            "measurement time": "2025-05-07T15:11:12+00:00",
+                            "measurement time": "2025-05-09T15:11:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3229,7 +3685,7 @@
                                 "destination well location identifier": "I6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_76",
-                            "measurement time": "2025-05-07T15:11:36+00:00",
+                            "measurement time": "2025-05-09T15:11:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3271,7 +3727,7 @@
                                 "destination well location identifier": "J6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_77",
-                            "measurement time": "2025-05-07T15:12:00+00:00",
+                            "measurement time": "2025-05-09T15:12:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3313,7 +3769,7 @@
                                 "destination well location identifier": "K6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_78",
-                            "measurement time": "2025-05-07T15:12:24+00:00",
+                            "measurement time": "2025-05-09T15:12:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3355,7 +3811,7 @@
                                 "destination well location identifier": "L6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_79",
-                            "measurement time": "2025-05-07T15:12:42+00:00",
+                            "measurement time": "2025-05-09T15:12:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3397,7 +3853,7 @@
                                 "destination well location identifier": "D8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_80",
-                            "measurement time": "2025-05-07T15:16:12+00:00",
+                            "measurement time": "2025-05-09T15:16:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3439,7 +3895,7 @@
                                 "destination well location identifier": "E8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_81",
-                            "measurement time": "2025-05-07T15:16:48+00:00",
+                            "measurement time": "2025-05-09T15:16:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3481,7 +3937,7 @@
                                 "destination well location identifier": "F8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_82",
-                            "measurement time": "2025-05-07T15:17:06+00:00",
+                            "measurement time": "2025-05-09T15:17:06+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3523,7 +3979,7 @@
                                 "destination well location identifier": "G8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_83",
-                            "measurement time": "2025-05-07T15:17:30+00:00",
+                            "measurement time": "2025-05-09T15:17:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3565,7 +4021,7 @@
                                 "destination well location identifier": "H8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_84",
-                            "measurement time": "2025-05-07T15:17:54+00:00",
+                            "measurement time": "2025-05-09T15:17:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3607,7 +4063,7 @@
                                 "destination well location identifier": "I8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_85",
-                            "measurement time": "2025-05-07T15:18:12+00:00",
+                            "measurement time": "2025-05-09T15:18:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3649,7 +4105,7 @@
                                 "destination well location identifier": "J8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_86",
-                            "measurement time": "2025-05-07T15:18:42+00:00",
+                            "measurement time": "2025-05-09T15:18:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3691,7 +4147,7 @@
                                 "destination well location identifier": "K8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_87",
-                            "measurement time": "2025-05-07T15:19:00+00:00",
+                            "measurement time": "2025-05-09T15:19:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3733,7 +4189,7 @@
                                 "destination well location identifier": "L8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_88",
-                            "measurement time": "2025-05-07T15:19:24+00:00",
+                            "measurement time": "2025-05-09T15:19:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3775,7 +4231,7 @@
                                 "destination well location identifier": "D9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_89",
-                            "measurement time": "2025-05-07T15:23:00+00:00",
+                            "measurement time": "2025-05-09T15:23:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3817,7 +4273,7 @@
                                 "destination well location identifier": "E9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_90",
-                            "measurement time": "2025-05-07T15:23:30+00:00",
+                            "measurement time": "2025-05-09T15:23:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3859,7 +4315,7 @@
                                 "destination well location identifier": "F9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_91",
-                            "measurement time": "2025-05-07T15:23:48+00:00",
+                            "measurement time": "2025-05-09T15:23:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3901,7 +4357,7 @@
                                 "destination well location identifier": "G9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_92",
-                            "measurement time": "2025-05-07T15:24:12+00:00",
+                            "measurement time": "2025-05-09T15:24:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3943,7 +4399,7 @@
                                 "destination well location identifier": "H9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_93",
-                            "measurement time": "2025-05-07T15:24:30+00:00",
+                            "measurement time": "2025-05-09T15:24:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3985,7 +4441,7 @@
                                 "destination well location identifier": "I9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_94",
-                            "measurement time": "2025-05-07T15:24:48+00:00",
+                            "measurement time": "2025-05-09T15:24:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4027,7 +4483,7 @@
                                 "destination well location identifier": "J9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_95",
-                            "measurement time": "2025-05-07T15:25:06+00:00",
+                            "measurement time": "2025-05-09T15:25:06+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4069,7 +4525,7 @@
                                 "destination well location identifier": "K9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_96",
-                            "measurement time": "2025-05-07T15:25:30+00:00",
+                            "measurement time": "2025-05-09T15:25:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4111,7 +4567,7 @@
                                 "destination well location identifier": "L9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_97",
-                            "measurement time": "2025-05-07T15:25:54+00:00",
+                            "measurement time": "2025-05-09T15:25:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4153,7 +4609,7 @@
                                 "destination well location identifier": "D10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_98",
-                            "measurement time": "2025-05-07T15:29:30+00:00",
+                            "measurement time": "2025-05-09T15:29:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4195,7 +4651,7 @@
                                 "destination well location identifier": "E10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_99",
-                            "measurement time": "2025-05-07T15:30:12+00:00",
+                            "measurement time": "2025-05-09T15:30:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4237,7 +4693,7 @@
                                 "destination well location identifier": "F10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_100",
-                            "measurement time": "2025-05-07T15:30:30+00:00",
+                            "measurement time": "2025-05-09T15:30:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4279,7 +4735,7 @@
                                 "destination well location identifier": "G10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_101",
-                            "measurement time": "2025-05-07T15:31:00+00:00",
+                            "measurement time": "2025-05-09T15:31:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4321,7 +4777,7 @@
                                 "destination well location identifier": "H10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_102",
-                            "measurement time": "2025-05-07T15:31:18+00:00",
+                            "measurement time": "2025-05-09T15:31:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4363,7 +4819,7 @@
                                 "destination well location identifier": "I10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_103",
-                            "measurement time": "2025-05-07T15:31:36+00:00",
+                            "measurement time": "2025-05-09T15:31:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4405,7 +4861,7 @@
                                 "destination well location identifier": "J10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_104",
-                            "measurement time": "2025-05-07T15:32:00+00:00",
+                            "measurement time": "2025-05-09T15:32:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4447,7 +4903,7 @@
                                 "destination well location identifier": "K10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_105",
-                            "measurement time": "2025-05-07T15:32:18+00:00",
+                            "measurement time": "2025-05-09T15:32:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4489,7 +4945,7 @@
                                 "destination well location identifier": "L10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_106",
-                            "measurement time": "2025-05-07T15:32:42+00:00",
+                            "measurement time": "2025-05-09T15:32:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4531,7 +4987,7 @@
                                 "destination well location identifier": "D11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_107",
-                            "measurement time": "2025-05-07T15:36:24+00:00",
+                            "measurement time": "2025-05-09T15:36:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4573,7 +5029,7 @@
                                 "destination well location identifier": "E11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_108",
-                            "measurement time": "2025-05-07T15:36:54+00:00",
+                            "measurement time": "2025-05-09T15:36:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4615,7 +5071,7 @@
                                 "destination well location identifier": "F11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_109",
-                            "measurement time": "2025-05-07T15:37:12+00:00",
+                            "measurement time": "2025-05-09T15:37:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4657,7 +5113,7 @@
                                 "destination well location identifier": "G11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_110",
-                            "measurement time": "2025-05-07T15:37:30+00:00",
+                            "measurement time": "2025-05-09T15:37:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4699,7 +5155,7 @@
                                 "destination well location identifier": "H11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_111",
-                            "measurement time": "2025-05-07T15:37:54+00:00",
+                            "measurement time": "2025-05-09T15:37:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4741,7 +5197,7 @@
                                 "destination well location identifier": "I11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_112",
-                            "measurement time": "2025-05-07T15:38:12+00:00",
+                            "measurement time": "2025-05-09T15:38:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4783,7 +5239,7 @@
                                 "destination well location identifier": "J11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_113",
-                            "measurement time": "2025-05-07T15:38:36+00:00",
+                            "measurement time": "2025-05-09T15:38:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4825,7 +5281,7 @@
                                 "destination well location identifier": "K11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_114",
-                            "measurement time": "2025-05-07T15:39:00+00:00",
+                            "measurement time": "2025-05-09T15:39:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4867,7 +5323,7 @@
                                 "destination well location identifier": "L11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_115",
-                            "measurement time": "2025-05-07T15:39:18+00:00",
+                            "measurement time": "2025-05-09T15:39:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4909,7 +5365,7 @@
                                 "destination well location identifier": "D12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_116",
-                            "measurement time": "2025-05-07T15:42:54+00:00",
+                            "measurement time": "2025-05-09T15:42:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4951,7 +5407,7 @@
                                 "destination well location identifier": "E12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_117",
-                            "measurement time": "2025-05-07T15:43:18+00:00",
+                            "measurement time": "2025-05-09T15:43:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4993,7 +5449,7 @@
                                 "destination well location identifier": "F12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_118",
-                            "measurement time": "2025-05-07T15:43:36+00:00",
+                            "measurement time": "2025-05-09T15:43:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5035,7 +5491,7 @@
                                 "destination well location identifier": "G12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_119",
-                            "measurement time": "2025-05-07T15:43:54+00:00",
+                            "measurement time": "2025-05-09T15:43:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5077,7 +5533,7 @@
                                 "destination well location identifier": "H12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_120",
-                            "measurement time": "2025-05-07T15:44:18+00:00",
+                            "measurement time": "2025-05-09T15:44:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5119,7 +5575,7 @@
                                 "destination well location identifier": "I12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_121",
-                            "measurement time": "2025-05-07T15:44:42+00:00",
+                            "measurement time": "2025-05-09T15:44:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5161,7 +5617,7 @@
                                 "destination well location identifier": "J12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_122",
-                            "measurement time": "2025-05-07T15:45:06+00:00",
+                            "measurement time": "2025-05-09T15:45:06+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5203,7 +5659,7 @@
                                 "destination well location identifier": "K12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_123",
-                            "measurement time": "2025-05-07T15:45:24+00:00",
+                            "measurement time": "2025-05-09T15:45:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5245,7 +5701,7 @@
                                 "destination well location identifier": "L12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_124",
-                            "measurement time": "2025-05-07T15:45:48+00:00",
+                            "measurement time": "2025-05-09T15:45:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5287,7 +5743,7 @@
                                 "destination well location identifier": "L13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_125",
-                            "measurement time": "2025-05-07T15:46:00+00:00",
+                            "measurement time": "2025-05-09T15:46:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5329,7 +5785,7 @@
                                 "destination well location identifier": "K13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_126",
-                            "measurement time": "2025-05-07T15:46:18+00:00",
+                            "measurement time": "2025-05-09T15:46:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5371,7 +5827,7 @@
                                 "destination well location identifier": "J13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_127",
-                            "measurement time": "2025-05-07T15:46:42+00:00",
+                            "measurement time": "2025-05-09T15:46:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5413,7 +5869,7 @@
                                 "destination well location identifier": "I13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_128",
-                            "measurement time": "2025-05-07T15:47:06+00:00",
+                            "measurement time": "2025-05-09T15:47:06+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5455,7 +5911,7 @@
                                 "destination well location identifier": "H13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_129",
-                            "measurement time": "2025-05-07T15:47:24+00:00",
+                            "measurement time": "2025-05-09T15:47:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5497,7 +5953,7 @@
                                 "destination well location identifier": "G13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_130",
-                            "measurement time": "2025-05-07T15:47:48+00:00",
+                            "measurement time": "2025-05-09T15:47:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5539,7 +5995,7 @@
                                 "destination well location identifier": "F13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_131",
-                            "measurement time": "2025-05-07T15:48:12+00:00",
+                            "measurement time": "2025-05-09T15:48:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5581,7 +6037,7 @@
                                 "destination well location identifier": "E13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_132",
-                            "measurement time": "2025-05-07T15:48:30+00:00",
+                            "measurement time": "2025-05-09T15:48:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5623,7 +6079,7 @@
                                 "destination well location identifier": "D13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_133",
-                            "measurement time": "2025-05-07T15:48:54+00:00",
+                            "measurement time": "2025-05-09T15:48:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5665,7 +6121,7 @@
                                 "destination well location identifier": "D15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_134",
-                            "measurement time": "2025-05-07T15:52:42+00:00",
+                            "measurement time": "2025-05-09T15:52:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5707,7 +6163,7 @@
                                 "destination well location identifier": "E15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_135",
-                            "measurement time": "2025-05-07T15:53:00+00:00",
+                            "measurement time": "2025-05-09T15:53:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5749,7 +6205,7 @@
                                 "destination well location identifier": "F15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_136",
-                            "measurement time": "2025-05-07T15:53:24+00:00",
+                            "measurement time": "2025-05-09T15:53:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5791,7 +6247,7 @@
                                 "destination well location identifier": "G15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_137",
-                            "measurement time": "2025-05-07T15:53:42+00:00",
+                            "measurement time": "2025-05-09T15:53:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5833,7 +6289,7 @@
                                 "destination well location identifier": "H15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_138",
-                            "measurement time": "2025-05-07T15:54:12+00:00",
+                            "measurement time": "2025-05-09T15:54:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5875,7 +6331,7 @@
                                 "destination well location identifier": "I15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_139",
-                            "measurement time": "2025-05-07T15:54:30+00:00",
+                            "measurement time": "2025-05-09T15:54:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5914,8 +6370,8 @@
             }
         },
         "custom information document": {
-            "Reference ID": 1.0,
-            "Order ID": 1.0
+            "Order ID": 1.0,
+            "Reference ID": 1.0
         }
     }
 }

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/SurveyVolumeExamples.json
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/SurveyVolumeExamples.json
@@ -45,7 +45,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_0",
-                            "measurement time": "2025-05-06T15:54:48+00:00"
+                            "measurement time": "2025-05-07T15:54:48+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -87,7 +87,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_1",
-                            "measurement time": "2025-05-06T15:55:00+00:00"
+                            "measurement time": "2025-05-07T15:55:00+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -129,7 +129,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_2",
-                            "measurement time": "2025-05-06T15:55:06+00:00"
+                            "measurement time": "2025-05-07T15:55:06+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -171,7 +171,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_3",
-                            "measurement time": "2025-05-06T15:55:18+00:00"
+                            "measurement time": "2025-05-07T15:55:18+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -213,7 +213,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_4",
-                            "measurement time": "2025-05-06T15:55:30+00:00"
+                            "measurement time": "2025-05-07T15:55:30+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -255,7 +255,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_5",
-                            "measurement time": "2025-05-06T15:55:42+00:00"
+                            "measurement time": "2025-05-07T15:55:42+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -297,7 +297,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_6",
-                            "measurement time": "2025-05-06T15:56:00+00:00"
+                            "measurement time": "2025-05-07T15:56:00+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -339,7 +339,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_7",
-                            "measurement time": "2025-05-06T15:56:12+00:00"
+                            "measurement time": "2025-05-07T15:56:12+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -381,7 +381,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_8",
-                            "measurement time": "2025-05-06T15:56:24+00:00"
+                            "measurement time": "2025-05-07T15:56:24+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -423,7 +423,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_9",
-                            "measurement time": "2025-05-06T15:56:36+00:00"
+                            "measurement time": "2025-05-07T15:56:36+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -465,7 +465,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_10",
-                            "measurement time": "2025-05-06T15:56:48+00:00"
+                            "measurement time": "2025-05-07T15:56:48+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -507,7 +507,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_11",
-                            "measurement time": "2025-05-06T15:57:00+00:00"
+                            "measurement time": "2025-05-07T15:57:00+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -549,7 +549,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_12",
-                            "measurement time": "2025-05-06T15:57:06+00:00"
+                            "measurement time": "2025-05-07T15:57:06+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -591,7 +591,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_13",
-                            "measurement time": "2025-05-06T15:57:24+00:00"
+                            "measurement time": "2025-05-07T15:57:24+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -633,7 +633,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_14",
-                            "measurement time": "2025-05-06T15:57:42+00:00"
+                            "measurement time": "2025-05-07T15:57:42+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -675,7 +675,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_15",
-                            "measurement time": "2025-05-06T15:57:48+00:00"
+                            "measurement time": "2025-05-07T15:57:48+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -717,7 +717,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_16",
-                            "measurement time": "2025-05-06T15:58:00+00:00"
+                            "measurement time": "2025-05-07T15:58:00+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -759,7 +759,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_17",
-                            "measurement time": "2025-05-06T15:58:12+00:00"
+                            "measurement time": "2025-05-07T15:58:12+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -801,7 +801,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_18",
-                            "measurement time": "2025-05-06T15:58:18+00:00"
+                            "measurement time": "2025-05-07T15:58:18+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -843,7 +843,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_19",
-                            "measurement time": "2025-05-06T15:58:30+00:00"
+                            "measurement time": "2025-05-07T15:58:30+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -885,7 +885,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_20",
-                            "measurement time": "2025-05-06T15:58:42+00:00"
+                            "measurement time": "2025-05-07T15:58:42+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -927,7 +927,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_21",
-                            "measurement time": "2025-05-06T15:59:00+00:00"
+                            "measurement time": "2025-05-07T15:59:00+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -969,7 +969,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_22",
-                            "measurement time": "2025-05-06T15:59:12+00:00"
+                            "measurement time": "2025-05-07T15:59:12+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1011,7 +1011,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_23",
-                            "measurement time": "2025-05-06T15:59:24+00:00"
+                            "measurement time": "2025-05-07T15:59:24+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1053,7 +1053,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_24",
-                            "measurement time": "2025-05-06T15:59:36+00:00"
+                            "measurement time": "2025-05-07T15:59:36+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1095,7 +1095,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_25",
-                            "measurement time": "2025-05-06T15:59:48+00:00"
+                            "measurement time": "2025-05-07T15:59:48+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1137,7 +1137,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_26",
-                            "measurement time": "2025-05-06T16:00:00+00:00"
+                            "measurement time": "2025-05-07T16:00:00+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1179,7 +1179,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_27",
-                            "measurement time": "2025-05-06T16:00:12+00:00"
+                            "measurement time": "2025-05-07T16:00:12+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1221,7 +1221,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_28",
-                            "measurement time": "2025-05-06T16:00:24+00:00"
+                            "measurement time": "2025-05-07T16:00:24+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1263,7 +1263,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_29",
-                            "measurement time": "2025-05-06T16:00:42+00:00"
+                            "measurement time": "2025-05-07T16:00:42+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1305,7 +1305,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_30",
-                            "measurement time": "2025-05-06T16:00:54+00:00"
+                            "measurement time": "2025-05-07T16:00:54+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1347,7 +1347,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_31",
-                            "measurement time": "2025-05-06T16:01:06+00:00"
+                            "measurement time": "2025-05-07T16:01:06+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1389,7 +1389,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_32",
-                            "measurement time": "2025-05-06T16:01:12+00:00"
+                            "measurement time": "2025-05-07T16:01:12+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1431,7 +1431,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_33",
-                            "measurement time": "2025-05-06T16:01:24+00:00"
+                            "measurement time": "2025-05-07T16:01:24+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1473,7 +1473,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_34",
-                            "measurement time": "2025-05-06T16:01:36+00:00"
+                            "measurement time": "2025-05-07T16:01:36+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1515,7 +1515,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_35",
-                            "measurement time": "2025-05-06T16:01:48+00:00"
+                            "measurement time": "2025-05-07T16:01:48+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1557,7 +1557,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_36",
-                            "measurement time": "2025-05-06T16:01:54+00:00"
+                            "measurement time": "2025-05-07T16:01:54+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1599,7 +1599,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_37",
-                            "measurement time": "2025-05-06T16:02:12+00:00"
+                            "measurement time": "2025-05-07T16:02:12+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1641,7 +1641,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_38",
-                            "measurement time": "2025-05-06T16:02:24+00:00"
+                            "measurement time": "2025-05-07T16:02:24+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1683,7 +1683,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_39",
-                            "measurement time": "2025-05-06T16:02:30+00:00"
+                            "measurement time": "2025-05-07T16:02:30+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1725,7 +1725,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_40",
-                            "measurement time": "2025-05-06T16:02:42+00:00"
+                            "measurement time": "2025-05-07T16:02:42+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1767,7 +1767,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_41",
-                            "measurement time": "2025-05-06T16:03:00+00:00"
+                            "measurement time": "2025-05-07T16:03:00+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1809,7 +1809,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_42",
-                            "measurement time": "2025-05-06T16:03:12+00:00"
+                            "measurement time": "2025-05-07T16:03:12+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1851,7 +1851,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_43",
-                            "measurement time": "2025-05-06T16:03:18+00:00"
+                            "measurement time": "2025-05-07T16:03:18+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1893,7 +1893,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_44",
-                            "measurement time": "2025-05-06T16:03:30+00:00"
+                            "measurement time": "2025-05-07T16:03:30+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1935,7 +1935,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_45",
-                            "measurement time": "2025-05-06T16:03:48+00:00"
+                            "measurement time": "2025-05-07T16:03:48+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -1977,7 +1977,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_46",
-                            "measurement time": "2025-05-06T16:04:00+00:00"
+                            "measurement time": "2025-05-07T16:04:00+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -2019,7 +2019,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_47",
-                            "measurement time": "2025-05-06T16:04:18+00:00"
+                            "measurement time": "2025-05-07T16:04:18+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -2061,7 +2061,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_48",
-                            "measurement time": "2025-05-06T16:07:36+00:00"
+                            "measurement time": "2025-05-07T16:07:36+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -2103,7 +2103,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_49",
-                            "measurement time": "2025-05-06T16:07:48+00:00"
+                            "measurement time": "2025-05-07T16:07:48+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -2145,7 +2145,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_50",
-                            "measurement time": "2025-05-06T16:08:00+00:00"
+                            "measurement time": "2025-05-07T16:08:00+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -2187,7 +2187,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_51",
-                            "measurement time": "2025-05-06T16:08:12+00:00"
+                            "measurement time": "2025-05-07T16:08:12+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -2229,7 +2229,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_52",
-                            "measurement time": "2025-05-06T16:08:24+00:00"
+                            "measurement time": "2025-05-07T16:08:24+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -2271,7 +2271,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_53",
-                            "measurement time": "2025-05-06T16:08:36+00:00"
+                            "measurement time": "2025-05-07T16:08:36+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -2313,7 +2313,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_54",
-                            "measurement time": "2025-05-06T16:08:48+00:00"
+                            "measurement time": "2025-05-07T16:08:48+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -2355,7 +2355,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_55",
-                            "measurement time": "2025-05-06T16:09:00+00:00"
+                            "measurement time": "2025-05-07T16:09:00+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -2397,7 +2397,7 @@
                                 ]
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_56",
-                            "measurement time": "2025-05-06T16:09:12+00:00"
+                            "measurement time": "2025-05-07T16:09:12+00:00"
                         },
                         {
                             "device control aggregate document": {
@@ -2431,7 +2431,7 @@
                                 "destination well location identifier": "D4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_57",
-                            "measurement time": "2025-05-06T14:58:00+00:00",
+                            "measurement time": "2025-05-07T14:58:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2473,7 +2473,7 @@
                                 "destination well location identifier": "E4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_58",
-                            "measurement time": "2025-05-06T14:58:36+00:00",
+                            "measurement time": "2025-05-07T14:58:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2515,7 +2515,7 @@
                                 "destination well location identifier": "F4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_59",
-                            "measurement time": "2025-05-06T14:58:54+00:00",
+                            "measurement time": "2025-05-07T14:58:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2557,7 +2557,7 @@
                                 "destination well location identifier": "G4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_60",
-                            "measurement time": "2025-05-06T14:59:12+00:00",
+                            "measurement time": "2025-05-07T14:59:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2599,7 +2599,7 @@
                                 "destination well location identifier": "H4"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_61",
-                            "measurement time": "2025-05-06T14:59:30+00:00",
+                            "measurement time": "2025-05-07T14:59:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2641,7 +2641,7 @@
                                 "destination well location identifier": "D5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_62",
-                            "measurement time": "2025-05-06T15:03:12+00:00",
+                            "measurement time": "2025-05-07T15:03:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2683,7 +2683,7 @@
                                 "destination well location identifier": "E5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_63",
-                            "measurement time": "2025-05-06T15:03:36+00:00",
+                            "measurement time": "2025-05-07T15:03:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2725,7 +2725,7 @@
                                 "destination well location identifier": "F5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_64",
-                            "measurement time": "2025-05-06T15:03:54+00:00",
+                            "measurement time": "2025-05-07T15:03:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2767,7 +2767,7 @@
                                 "destination well location identifier": "G5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_65",
-                            "measurement time": "2025-05-06T15:04:18+00:00",
+                            "measurement time": "2025-05-07T15:04:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2809,7 +2809,7 @@
                                 "destination well location identifier": "H5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_66",
-                            "measurement time": "2025-05-06T15:04:30+00:00",
+                            "measurement time": "2025-05-07T15:04:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2851,7 +2851,7 @@
                                 "destination well location identifier": "I5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_67",
-                            "measurement time": "2025-05-06T15:04:54+00:00",
+                            "measurement time": "2025-05-07T15:04:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2893,7 +2893,7 @@
                                 "destination well location identifier": "J5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_68",
-                            "measurement time": "2025-05-06T15:05:18+00:00",
+                            "measurement time": "2025-05-07T15:05:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2935,7 +2935,7 @@
                                 "destination well location identifier": "K5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_69",
-                            "measurement time": "2025-05-06T15:05:42+00:00",
+                            "measurement time": "2025-05-07T15:05:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -2977,7 +2977,7 @@
                                 "destination well location identifier": "L5"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_70",
-                            "measurement time": "2025-05-06T15:06:00+00:00",
+                            "measurement time": "2025-05-07T15:06:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3019,7 +3019,7 @@
                                 "destination well location identifier": "D6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_71",
-                            "measurement time": "2025-05-06T15:09:30+00:00",
+                            "measurement time": "2025-05-07T15:09:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3061,7 +3061,7 @@
                                 "destination well location identifier": "E6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_72",
-                            "measurement time": "2025-05-06T15:10:12+00:00",
+                            "measurement time": "2025-05-07T15:10:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3103,7 +3103,7 @@
                                 "destination well location identifier": "F6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_73",
-                            "measurement time": "2025-05-06T15:10:24+00:00",
+                            "measurement time": "2025-05-07T15:10:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3145,7 +3145,7 @@
                                 "destination well location identifier": "G6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_74",
-                            "measurement time": "2025-05-06T15:10:54+00:00",
+                            "measurement time": "2025-05-07T15:10:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3187,7 +3187,7 @@
                                 "destination well location identifier": "H6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_75",
-                            "measurement time": "2025-05-06T15:11:12+00:00",
+                            "measurement time": "2025-05-07T15:11:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3229,7 +3229,7 @@
                                 "destination well location identifier": "I6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_76",
-                            "measurement time": "2025-05-06T15:11:36+00:00",
+                            "measurement time": "2025-05-07T15:11:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3271,7 +3271,7 @@
                                 "destination well location identifier": "J6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_77",
-                            "measurement time": "2025-05-06T15:12:00+00:00",
+                            "measurement time": "2025-05-07T15:12:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3313,7 +3313,7 @@
                                 "destination well location identifier": "K6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_78",
-                            "measurement time": "2025-05-06T15:12:24+00:00",
+                            "measurement time": "2025-05-07T15:12:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3355,7 +3355,7 @@
                                 "destination well location identifier": "L6"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_79",
-                            "measurement time": "2025-05-06T15:12:42+00:00",
+                            "measurement time": "2025-05-07T15:12:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3397,7 +3397,7 @@
                                 "destination well location identifier": "D8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_80",
-                            "measurement time": "2025-05-06T15:16:12+00:00",
+                            "measurement time": "2025-05-07T15:16:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3439,7 +3439,7 @@
                                 "destination well location identifier": "E8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_81",
-                            "measurement time": "2025-05-06T15:16:48+00:00",
+                            "measurement time": "2025-05-07T15:16:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3481,7 +3481,7 @@
                                 "destination well location identifier": "F8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_82",
-                            "measurement time": "2025-05-06T15:17:06+00:00",
+                            "measurement time": "2025-05-07T15:17:06+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3523,7 +3523,7 @@
                                 "destination well location identifier": "G8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_83",
-                            "measurement time": "2025-05-06T15:17:30+00:00",
+                            "measurement time": "2025-05-07T15:17:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3565,7 +3565,7 @@
                                 "destination well location identifier": "H8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_84",
-                            "measurement time": "2025-05-06T15:17:54+00:00",
+                            "measurement time": "2025-05-07T15:17:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3607,7 +3607,7 @@
                                 "destination well location identifier": "I8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_85",
-                            "measurement time": "2025-05-06T15:18:12+00:00",
+                            "measurement time": "2025-05-07T15:18:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3649,7 +3649,7 @@
                                 "destination well location identifier": "J8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_86",
-                            "measurement time": "2025-05-06T15:18:42+00:00",
+                            "measurement time": "2025-05-07T15:18:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3691,7 +3691,7 @@
                                 "destination well location identifier": "K8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_87",
-                            "measurement time": "2025-05-06T15:19:00+00:00",
+                            "measurement time": "2025-05-07T15:19:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3733,7 +3733,7 @@
                                 "destination well location identifier": "L8"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_88",
-                            "measurement time": "2025-05-06T15:19:24+00:00",
+                            "measurement time": "2025-05-07T15:19:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3775,7 +3775,7 @@
                                 "destination well location identifier": "D9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_89",
-                            "measurement time": "2025-05-06T15:23:00+00:00",
+                            "measurement time": "2025-05-07T15:23:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3817,7 +3817,7 @@
                                 "destination well location identifier": "E9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_90",
-                            "measurement time": "2025-05-06T15:23:30+00:00",
+                            "measurement time": "2025-05-07T15:23:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3859,7 +3859,7 @@
                                 "destination well location identifier": "F9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_91",
-                            "measurement time": "2025-05-06T15:23:48+00:00",
+                            "measurement time": "2025-05-07T15:23:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3901,7 +3901,7 @@
                                 "destination well location identifier": "G9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_92",
-                            "measurement time": "2025-05-06T15:24:12+00:00",
+                            "measurement time": "2025-05-07T15:24:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3943,7 +3943,7 @@
                                 "destination well location identifier": "H9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_93",
-                            "measurement time": "2025-05-06T15:24:30+00:00",
+                            "measurement time": "2025-05-07T15:24:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -3985,7 +3985,7 @@
                                 "destination well location identifier": "I9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_94",
-                            "measurement time": "2025-05-06T15:24:48+00:00",
+                            "measurement time": "2025-05-07T15:24:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4027,7 +4027,7 @@
                                 "destination well location identifier": "J9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_95",
-                            "measurement time": "2025-05-06T15:25:06+00:00",
+                            "measurement time": "2025-05-07T15:25:06+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4069,7 +4069,7 @@
                                 "destination well location identifier": "K9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_96",
-                            "measurement time": "2025-05-06T15:25:30+00:00",
+                            "measurement time": "2025-05-07T15:25:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4111,7 +4111,7 @@
                                 "destination well location identifier": "L9"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_97",
-                            "measurement time": "2025-05-06T15:25:54+00:00",
+                            "measurement time": "2025-05-07T15:25:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4153,7 +4153,7 @@
                                 "destination well location identifier": "D10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_98",
-                            "measurement time": "2025-05-06T15:29:30+00:00",
+                            "measurement time": "2025-05-07T15:29:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4195,7 +4195,7 @@
                                 "destination well location identifier": "E10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_99",
-                            "measurement time": "2025-05-06T15:30:12+00:00",
+                            "measurement time": "2025-05-07T15:30:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4237,7 +4237,7 @@
                                 "destination well location identifier": "F10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_100",
-                            "measurement time": "2025-05-06T15:30:30+00:00",
+                            "measurement time": "2025-05-07T15:30:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4279,7 +4279,7 @@
                                 "destination well location identifier": "G10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_101",
-                            "measurement time": "2025-05-06T15:31:00+00:00",
+                            "measurement time": "2025-05-07T15:31:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4321,7 +4321,7 @@
                                 "destination well location identifier": "H10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_102",
-                            "measurement time": "2025-05-06T15:31:18+00:00",
+                            "measurement time": "2025-05-07T15:31:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4363,7 +4363,7 @@
                                 "destination well location identifier": "I10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_103",
-                            "measurement time": "2025-05-06T15:31:36+00:00",
+                            "measurement time": "2025-05-07T15:31:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4405,7 +4405,7 @@
                                 "destination well location identifier": "J10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_104",
-                            "measurement time": "2025-05-06T15:32:00+00:00",
+                            "measurement time": "2025-05-07T15:32:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4447,7 +4447,7 @@
                                 "destination well location identifier": "K10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_105",
-                            "measurement time": "2025-05-06T15:32:18+00:00",
+                            "measurement time": "2025-05-07T15:32:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4489,7 +4489,7 @@
                                 "destination well location identifier": "L10"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_106",
-                            "measurement time": "2025-05-06T15:32:42+00:00",
+                            "measurement time": "2025-05-07T15:32:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4531,7 +4531,7 @@
                                 "destination well location identifier": "D11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_107",
-                            "measurement time": "2025-05-06T15:36:24+00:00",
+                            "measurement time": "2025-05-07T15:36:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4573,7 +4573,7 @@
                                 "destination well location identifier": "E11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_108",
-                            "measurement time": "2025-05-06T15:36:54+00:00",
+                            "measurement time": "2025-05-07T15:36:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4615,7 +4615,7 @@
                                 "destination well location identifier": "F11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_109",
-                            "measurement time": "2025-05-06T15:37:12+00:00",
+                            "measurement time": "2025-05-07T15:37:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4657,7 +4657,7 @@
                                 "destination well location identifier": "G11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_110",
-                            "measurement time": "2025-05-06T15:37:30+00:00",
+                            "measurement time": "2025-05-07T15:37:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4699,7 +4699,7 @@
                                 "destination well location identifier": "H11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_111",
-                            "measurement time": "2025-05-06T15:37:54+00:00",
+                            "measurement time": "2025-05-07T15:37:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4741,7 +4741,7 @@
                                 "destination well location identifier": "I11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_112",
-                            "measurement time": "2025-05-06T15:38:12+00:00",
+                            "measurement time": "2025-05-07T15:38:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4783,7 +4783,7 @@
                                 "destination well location identifier": "J11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_113",
-                            "measurement time": "2025-05-06T15:38:36+00:00",
+                            "measurement time": "2025-05-07T15:38:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4825,7 +4825,7 @@
                                 "destination well location identifier": "K11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_114",
-                            "measurement time": "2025-05-06T15:39:00+00:00",
+                            "measurement time": "2025-05-07T15:39:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4867,7 +4867,7 @@
                                 "destination well location identifier": "L11"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_115",
-                            "measurement time": "2025-05-06T15:39:18+00:00",
+                            "measurement time": "2025-05-07T15:39:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4909,7 +4909,7 @@
                                 "destination well location identifier": "D12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_116",
-                            "measurement time": "2025-05-06T15:42:54+00:00",
+                            "measurement time": "2025-05-07T15:42:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4951,7 +4951,7 @@
                                 "destination well location identifier": "E12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_117",
-                            "measurement time": "2025-05-06T15:43:18+00:00",
+                            "measurement time": "2025-05-07T15:43:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -4993,7 +4993,7 @@
                                 "destination well location identifier": "F12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_118",
-                            "measurement time": "2025-05-06T15:43:36+00:00",
+                            "measurement time": "2025-05-07T15:43:36+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5035,7 +5035,7 @@
                                 "destination well location identifier": "G12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_119",
-                            "measurement time": "2025-05-06T15:43:54+00:00",
+                            "measurement time": "2025-05-07T15:43:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5077,7 +5077,7 @@
                                 "destination well location identifier": "H12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_120",
-                            "measurement time": "2025-05-06T15:44:18+00:00",
+                            "measurement time": "2025-05-07T15:44:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5119,7 +5119,7 @@
                                 "destination well location identifier": "I12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_121",
-                            "measurement time": "2025-05-06T15:44:42+00:00",
+                            "measurement time": "2025-05-07T15:44:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5161,7 +5161,7 @@
                                 "destination well location identifier": "J12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_122",
-                            "measurement time": "2025-05-06T15:45:06+00:00",
+                            "measurement time": "2025-05-07T15:45:06+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5203,7 +5203,7 @@
                                 "destination well location identifier": "K12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_123",
-                            "measurement time": "2025-05-06T15:45:24+00:00",
+                            "measurement time": "2025-05-07T15:45:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5245,7 +5245,7 @@
                                 "destination well location identifier": "L12"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_124",
-                            "measurement time": "2025-05-06T15:45:48+00:00",
+                            "measurement time": "2025-05-07T15:45:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5287,7 +5287,7 @@
                                 "destination well location identifier": "L13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_125",
-                            "measurement time": "2025-05-06T15:46:00+00:00",
+                            "measurement time": "2025-05-07T15:46:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5329,7 +5329,7 @@
                                 "destination well location identifier": "K13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_126",
-                            "measurement time": "2025-05-06T15:46:18+00:00",
+                            "measurement time": "2025-05-07T15:46:18+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5371,7 +5371,7 @@
                                 "destination well location identifier": "J13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_127",
-                            "measurement time": "2025-05-06T15:46:42+00:00",
+                            "measurement time": "2025-05-07T15:46:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5413,7 +5413,7 @@
                                 "destination well location identifier": "I13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_128",
-                            "measurement time": "2025-05-06T15:47:06+00:00",
+                            "measurement time": "2025-05-07T15:47:06+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5455,7 +5455,7 @@
                                 "destination well location identifier": "H13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_129",
-                            "measurement time": "2025-05-06T15:47:24+00:00",
+                            "measurement time": "2025-05-07T15:47:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5497,7 +5497,7 @@
                                 "destination well location identifier": "G13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_130",
-                            "measurement time": "2025-05-06T15:47:48+00:00",
+                            "measurement time": "2025-05-07T15:47:48+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5539,7 +5539,7 @@
                                 "destination well location identifier": "F13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_131",
-                            "measurement time": "2025-05-06T15:48:12+00:00",
+                            "measurement time": "2025-05-07T15:48:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5581,7 +5581,7 @@
                                 "destination well location identifier": "E13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_132",
-                            "measurement time": "2025-05-06T15:48:30+00:00",
+                            "measurement time": "2025-05-07T15:48:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5623,7 +5623,7 @@
                                 "destination well location identifier": "D13"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_133",
-                            "measurement time": "2025-05-06T15:48:54+00:00",
+                            "measurement time": "2025-05-07T15:48:54+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5665,7 +5665,7 @@
                                 "destination well location identifier": "D15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_134",
-                            "measurement time": "2025-05-06T15:52:42+00:00",
+                            "measurement time": "2025-05-07T15:52:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5707,7 +5707,7 @@
                                 "destination well location identifier": "E15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_135",
-                            "measurement time": "2025-05-06T15:53:00+00:00",
+                            "measurement time": "2025-05-07T15:53:00+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5749,7 +5749,7 @@
                                 "destination well location identifier": "F15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_136",
-                            "measurement time": "2025-05-06T15:53:24+00:00",
+                            "measurement time": "2025-05-07T15:53:24+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5791,7 +5791,7 @@
                                 "destination well location identifier": "G15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_137",
-                            "measurement time": "2025-05-06T15:53:42+00:00",
+                            "measurement time": "2025-05-07T15:53:42+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5833,7 +5833,7 @@
                                 "destination well location identifier": "H15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_138",
-                            "measurement time": "2025-05-06T15:54:12+00:00",
+                            "measurement time": "2025-05-07T15:54:12+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5875,7 +5875,7 @@
                                 "destination well location identifier": "I15"
                             },
                             "measurement identifier": "BECKMAN_ECHO_PLATE_REFORMAT_TEST_ID_139",
-                            "measurement time": "2025-05-06T15:54:30+00:00",
+                            "measurement time": "2025-05-07T15:54:30+00:00",
                             "aspiration volume": {
                                 "value": 1.0,
                                 "unit": "μL"
@@ -5886,7 +5886,11 @@
                             }
                         }
                     ],
-                    "analytical method identifier": "SeV_r2_exc1.epr"
+                    "analytical method identifier": "SeV_r2_exc1.epr",
+                    "experimental data identifier": "1741720420",
+                    "custom information document": {
+                        "Run Date/Time": "3/11/2025 15:14"
+                    }
                 },
                 "analyst": "LabAutomation"
             }
@@ -5897,13 +5901,21 @@
             "file name": "SurveyVolumeExamples.csv",
             "UNC path": "tests/parsers/beckman_echo_plate_reformat/testdata/SurveyVolumeExamples.csv",
             "ASM converter name": "allotropy_beckman_echo_plate_reformat",
-            "ASM converter version": "0.1.80",
+            "ASM converter version": "0.1.87",
             "software name": "Labcyte Echo Plate Reformat",
-            "software version": "2.6.3"
+            "software version": "1.7.2"
         },
         "device system document": {
             "equipment serial number": "E5XX-19119",
-            "product manufacturer": "Beckman Coulter"
+            "model number": "Echo 525",
+            "product manufacturer": "Beckman Coulter",
+            "custom information document": {
+                "Instrument Software Version": "2.6.3"
+            }
+        },
+        "custom information document": {
+            "Reference ID": 1.0,
+            "Order ID": 1.0
         }
     }
 }

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/TransferOnly.json
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/TransferOnly.json
@@ -15,8 +15,8 @@
                                             "unit": "μL"
                                         },
                                         "custom information document": {
-                                            "survey fluid volume": 0.052337,
-                                            "current fluid volume": 0.052237000000000006,
+                                            "survey fluid volume": 52.337,
+                                            "current fluid volume": 52.237,
                                             "intended transfer volume": 0.1,
                                             "source labware name": "384PP_AQ_BP",
                                             "destination labware name": "Eppendorf_PCR_384",
@@ -57,8 +57,8 @@
                                             "unit": "μL"
                                         },
                                         "custom information document": {
-                                            "survey fluid volume": 0.052337,
-                                            "current fluid volume": 0.052137,
+                                            "survey fluid volume": 52.337,
+                                            "current fluid volume": 52.137,
                                             "intended transfer volume": 0.1,
                                             "source labware name": "384PP_AQ_BP",
                                             "destination labware name": "Eppendorf_PCR_384",
@@ -99,8 +99,8 @@
                                             "unit": "μL"
                                         },
                                         "custom information document": {
-                                            "survey fluid volume": 0.052626,
-                                            "current fluid volume": 0.052526,
+                                            "survey fluid volume": 52.626,
+                                            "current fluid volume": 52.526,
                                             "intended transfer volume": 0.1,
                                             "source labware name": "384PP_AQ_BP",
                                             "destination labware name": "Eppendorf_PCR_384",
@@ -141,8 +141,8 @@
                                             "unit": "μL"
                                         },
                                         "custom information document": {
-                                            "survey fluid volume": 0.052626,
-                                            "current fluid volume": 0.052426,
+                                            "survey fluid volume": 52.626,
+                                            "current fluid volume": 52.426,
                                             "intended transfer volume": 0.1,
                                             "source labware name": "384PP_AQ_BP",
                                             "destination labware name": "Eppendorf_PCR_384",

--- a/tests/parsers/beckman_echo_plate_reformat/testdata/TransferOnly.json
+++ b/tests/parsers/beckman_echo_plate_reformat/testdata/TransferOnly.json
@@ -189,7 +189,7 @@
             "file name": "TransferOnly.csv",
             "UNC path": "tests/parsers/beckman_echo_plate_reformat/testdata/TransferOnly.csv",
             "ASM converter name": "allotropy_beckman_echo_plate_reformat",
-            "ASM converter version": "0.1.80",
+            "ASM converter version": "0.1.87",
             "software name": "Labcyte Echo Plate Reformat",
             "software version": "1.7.2"
         },


### PR DESCRIPTION
Survey volume results (for 'Survey Fluid Volume' and 'Current Fluid Volume' fields in the Echo output CSV) are already in microliters, and we were spuriously converting this number "from nl to ul" resulting in incorrect volumes in the output data.  
Also added another test case that has exceptions with valid survey results.  